### PR TITLE
Update to upstream agent 0.10.1

### DIFF
--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -24,6 +24,7 @@ base {
 
 dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-spi")
   compileOnly("org.slf4j:slf4j-api")
 
   implementation("io.opentelemetry:opentelemetry-sdk-extension-aws-v1-support")
@@ -48,15 +49,7 @@ tasks {
     relocate("io.opentelemetry.instrumentation.api", "io.opentelemetry.javaagent.shaded.instrumentation.api")
 
     // relocate OpenTelemetry API usage
-    relocate("io.opentelemetry.OpenTelemetry", "io.opentelemetry.javaagent.shaded.io.opentelemetry.OpenTelemetry")
-    relocate("io.opentelemetry.common", "io.opentelemetry.javaagent.shaded.io.opentelemetry.common")
-    relocate("io.opentelemetry.baggage", "io.opentelemetry.javaagent.shaded.io.opentelemetry.baggage")
+    relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
     relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
-    relocate("io.opentelemetry.internal", "io.opentelemetry.javaagent.shaded.io.opentelemetry.internal")
-    relocate("io.opentelemetry.metrics", "io.opentelemetry.javaagent.shaded.io.opentelemetry.metrics")
-    relocate("io.opentelemetry.trace", "io.opentelemetry.javaagent.shaded.io.opentelemetry.trace")
-
-    // relocate OpenTelemetry API dependency usage
-    relocate("io.grpc", "io.opentelemetry.javaagent.shaded.io.grpc")
   }
 }

--- a/awsagentprovider/src/main/java/com/softwareaws/xray/opentelemetry/providers/AwsAgentProperties.java
+++ b/awsagentprovider/src/main/java/com/softwareaws/xray/opentelemetry/providers/AwsAgentProperties.java
@@ -13,18 +13,15 @@
  * permissions and limitations under the License.
  */
 
-package com.softwareaws.xray.opentelemetry.agentbootstrap;
+package com.softwareaws.xray.opentelemetry.providers;
 
-import io.opentelemetry.javaagent.OpenTelemetryAgent;
-import java.lang.instrument.Instrumentation;
+import io.opentelemetry.javaagent.spi.config.PropertySource;
+import java.util.Collections;
+import java.util.Map;
 
-public class AwsAgentBootstrap {
-
-  public static void premain(final String agentArgs, final Instrumentation inst) {
-    agentmain(agentArgs, inst);
-  }
-
-  public static void agentmain(final String agentArgs, final Instrumentation inst) {
-    OpenTelemetryAgent.agentmain(agentArgs, inst);
+public class AwsAgentProperties implements PropertySource {
+  @Override
+  public Map<String, String> getProperties() {
+    return Collections.singletonMap("otel.propagators", "xray,tracecontext,b3");
   }
 }

--- a/awsagentprovider/src/main/java/com/softwareaws/xray/opentelemetry/providers/AwsTracerProviderFactory.java
+++ b/awsagentprovider/src/main/java/com/softwareaws/xray/opentelemetry/providers/AwsTracerProviderFactory.java
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package com.softwareaws.xray.opentelemetry.exporters;
+package com.softwareaws.xray.opentelemetry.providers;
 
-import io.opentelemetry.sdk.extensions.trace.aws.AwsXRayIdsGenerator;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.api.trace.spi.TracerProviderFactory;
+import io.opentelemetry.sdk.extension.trace.aws.AwsXrayIdGenerator;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
-import io.opentelemetry.trace.TracerProvider;
-import io.opentelemetry.trace.spi.TracerProviderFactory;
 
 public class AwsTracerProviderFactory implements TracerProviderFactory {
 
@@ -32,8 +32,7 @@ public class AwsTracerProviderFactory implements TracerProviderFactory {
       }
     }
 
-    TRACER_PROVIDER =
-        TracerSdkProvider.builder().setIdsGenerator(new AwsXRayIdsGenerator()).build();
+    TRACER_PROVIDER = TracerSdkProvider.builder().setIdsGenerator(new AwsXrayIdGenerator()).build();
   }
 
   @Override

--- a/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.spi.TracerProviderFactory
+++ b/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.spi.TracerProviderFactory
@@ -13,4 +13,4 @@
 # permissions and limitations under the License.
 #
 
-com.softwareaws.xray.opentelemetry.exporters.AwsTracerProviderFactory
+com.softwareaws.xray.opentelemetry.providers.AwsTracerProviderFactory

--- a/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.spi.config.PropertySource
+++ b/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.spi.config.PropertySource
@@ -1,0 +1,1 @@
+com.softwareaws.xray.opentelemetry.providers.AwsAgentProperties

--- a/awsagentprovider/src/test/java/com/softwareaws/xray/opentelemetry/providers/AwsTracerProviderFactoryTest.java
+++ b/awsagentprovider/src/test/java/com/softwareaws/xray/opentelemetry/providers/AwsTracerProviderFactoryTest.java
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package com.softwareaws.xray.opentelemetry.exporters;
+package com.softwareaws.xray.opentelemetry.providers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.Ints;
-import io.opentelemetry.trace.TracerProvider;
+import io.opentelemetry.api.trace.TracerProvider;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.RepeatedTest;
 
@@ -31,7 +31,7 @@ class AwsTracerProviderFactoryTest {
   void providerGeneratesXrayIds() {
     int startTimeSecs = (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
     var span = TRACER_PROVIDER.get("test").spanBuilder("test").startSpan();
-    byte[] traceId = span.getContext().getTraceIdBytes();
+    byte[] traceId = span.getSpanContext().getTraceIdBytes();
     int epoch = Ints.fromBytes(traceId[0], traceId[1], traceId[2], traceId[3]);
     assertThat(epoch).isGreaterThanOrEqualTo(startTimeSecs);
   }

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -27,6 +27,7 @@ val DEPENDENCY_BOMS = listOf(
   "com.google.protobuf:protobuf-bom:3.13.0",
   "com.linecorp.armeria:armeria-bom:1.0.0",
   "io.grpc:grpc-bom:1.30.2",
+  "io.opentelemetry:opentelemetry-bom:0.10.0",
   "io.zipkin.brave:brave-bom:5.12.3",
   "io.zipkin.reporter2:zipkin-reporter-bom:2.15.0",
   "org.apache.logging.log4j:log4j-bom:2.13.3",
@@ -43,40 +44,10 @@ val DEPENDENCY_SETS = listOf(
   ),
   DependencySet(
     "io.opentelemetry.javaagent",
-    "0.9.0",
+    "0.10.1",
     listOf(
-      "opentelemetry-javaagent"
-    )
-  ),
-  DependencySet(
-    "io.opentelemetry",
-    "0.9.1",
-    listOf(
-      "opentelemetry-api",
-      "opentelemetry-exporters-logging",
-      "opentelemetry-exporters-otlp"
-    )
-  ),
-  DependencySet(
-    "io.opentelemetry",
-    "0.9.1",
-    listOf(
-      "opentelemetry-context-prop",
-      "opentelemetry-extension-trace-propagators",
-      "opentelemetry-proto",
-      "opentelemetry-sdk",
-      "opentelemetry-sdk-extension-aws-v1-support"
-    )
-  ),
-  DependencySet(
-    "io.opentelemetry",
-    "0.9.1",
-    listOf(
-      "opentelemetry-sdk-baggage",
-      "opentelemetry-sdk-common",
-      "opentelemetry-sdk-correlation-context",
-      "opentelemetry-sdk-metrics",
-      "opentelemetry-sdk-tracing"
+      "opentelemetry-javaagent",
+      "opentelemetry-javaagent-spi"
     )
   ),
   DependencySet(

--- a/smoke-tests/runner/build.gradle.kts
+++ b/smoke-tests/runner/build.gradle.kts
@@ -39,8 +39,6 @@ tasks {
   named<Test>("test") {
     dependsOn(otelAgentJarTask)
 
-    enabled = System.getenv("CI") != null
-
     jvmArgs(
       "-Dio.awsobservability.instrumentation.smoketests.runner.agentPath=${otelAgentJarTask.get().archiveFile.get()
         .getAsFile().absolutePath}"

--- a/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
+++ b/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
@@ -143,7 +143,7 @@ class SpringBootSmokeTest {
     assertThat(response.status().isSuccess()).isTrue();
     assertThat(response.headers())
         .extracting(e -> e.getKey().toString())
-        .contains("received-x-amzn-trace-id", "received-x-b3-traceid", "received-traceparent");
+        .contains("received-x-amzn-trace-id", "received-b3", "received-traceparent");
 
     var exported = getExported();
     assertThat(exported)


### PR DESCRIPTION
*Description of changes:*

Updates agent dependency to 0.10.1 and uses `PropertySource` SPI instead of system property to interact properly with config property resolution order.

Default behavior of OTel changed from populating x-b3 to b3(single) when injecting (still extracts both)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
