### PR TITLE
Use SNAPSHOT versioning for dev builds to more easily override JAVA_T…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@
  */
 
 import com.github.jk1.license.render.InventoryMarkdownReportRenderer
+import nebula.plugin.release.git.opinion.Strategies
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
@@ -21,6 +22,10 @@ plugins {
   id("nebula.release") version "15.1.0"
   id("com.diffplug.spotless") version "5.1.2"
   id("com.github.jk1.dependency-license-report") version "1.14"
+}
+
+release {
+  defaultVersionStrategy = Strategies.getSNAPSHOT()
 }
 
 val releaseTask = tasks.named("release")

--- a/scripts/docker/corretto-slim/Dockerfile
+++ b/scripts/docker/corretto-slim/Dockerfile
@@ -1,5 +1,24 @@
-FROM amazoncorretto/amazoncorretto:11-alpine-jre
+FROM amazoncorretto:11-alpine-jdk
+
+# Copied from https://github.com/corretto/corretto-docker/blob/master/11/jre/alpine/Dockerfile
+RUN jlink --endian little --release-info $JAVA_HOME/release \
+            --add-modules "java.base,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,\
+java.rmi,java.security.sasl,java.xml,jdk.internal.vm.ci,jdk.jfr,jdk.management,jdk.management.jfr,jdk.management.agent,jdk.net,jdk.sctp,jdk.unsupported,\
+jdk.naming.rmi,java.compiler,jdk.aot,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,java.se,java.net.http,java.scripting,java.security.jgss,\
+java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,\
+jdk.dynalink,jdk.httpserver,jdk.jsobject,jdk.localedata,jdk.naming.dns,jdk.scripting.nashorn,jdk.security.auth,jdk.security.jgss,jdk.xml.dom,jdk.zipfs,\
+jdk.pack,jdk.scripting.nashorn.shell,jdk.jcmd,jdk.jfr" \
+            --no-man-pages --no-header-files --strip-debug --output /temp/java-11-amazon-corretto
+
+FROM alpine:3.12
+
+COPY --from=0 /temp/java-11-amazon-corretto /usr/lib/jvm/java-11-amazon-corretto
+COPY --from=0 /licenses /licenses
 
 RUN apk update && apk add libc6-compat ca-certificates && rm -rf /var/cache/apk/*
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
+ENV PATH=$PATH:/usr/lib/jvm/java-11-amazon-corretto/bin
 
 ENTRYPOINT ["java", "-jar"]


### PR DESCRIPTION
…OOL_OPTIONS.

*Issue #, if available:* 

*Description of changes:*

It's hard to override JAVA_TOOL_OPTIONS when not being able to reason about the version number.

Also restores corretto-slim build, 11-alpine-jre was mysteriously unpublished from Docker Hub :O


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
