### PR TITLE
Update to OTel 0.14

### DIFF
--- a/awsagentprovider/src/main/java/io/opentelemetry/sdk/trace/RandomIdGenerator.java
+++ b/awsagentprovider/src/main/java/io/opentelemetry/sdk/trace/RandomIdGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.opentelemetry.sdk.trace;
+
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.sdk.extension.aws.trace.AwsXrayIdGenerator;
+import java.util.concurrent.ThreadLocalRandom;
+
+// TODO(anuraaga): Remove this hack when upgrading to OTel 0.15.0. There is an issue in 0.14.0 that
+// prevents
+// using SPI to override the ID generator.
+enum RandomIdGenerator implements IdGenerator {
+  INSTANCE;
+
+  private static final long INVALID_ID = 0;
+
+  @Override
+  public String generateSpanId() {
+    // Inline implementation since AwsXrayIdGenerator would delegate back to RandomIdGenerator
+    // causing an infinite loop.
+    long id;
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    do {
+      id = random.nextLong();
+    } while (id == INVALID_ID);
+    return SpanId.fromLong(id);
+  }
+
+  @Override
+  public String generateTraceId() {
+    return AwsXrayIdGenerator.getInstance().generateTraceId();
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerProviderFactory.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerProviderFactory.java
@@ -15,13 +15,12 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.extension.aws.trace.AwsXrayIdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.spi.OpenTelemetryFactory;
+import io.opentelemetry.spi.trace.TracerProviderFactory;
 
-public class AwsOpenTelemetryFactory implements OpenTelemetryFactory {
+public class AwsTracerProviderFactory implements TracerProviderFactory {
 
   private static final SdkTracerProvider TRACER_PROVIDER;
 
@@ -33,11 +32,12 @@ public class AwsOpenTelemetryFactory implements OpenTelemetryFactory {
       }
     }
 
-    TRACER_PROVIDER = SdkTracerProvider.builder().setIdGenerator(new AwsXrayIdGenerator()).build();
+    TRACER_PROVIDER =
+        SdkTracerProvider.builder().setIdGenerator(AwsXrayIdGenerator.getInstance()).build();
   }
 
   @Override
-  public OpenTelemetry create() {
-    return OpenTelemetrySdk.builder().setTracerProvider(TRACER_PROVIDER).build();
+  public TracerProvider create() {
+    return TRACER_PROVIDER;
   }
 }

--- a/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.shaded.io.opentelemetry.spi.trace.TracerProviderFactory
+++ b/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.shaded.io.opentelemetry.spi.trace.TracerProviderFactory
@@ -13,4 +13,4 @@
 # permissions and limitations under the License.
 #
 
-software.amazon.opentelemetry.javaagent.providers.AwsOpenTelemetryFactory
+software.amazon.opentelemetry.javaagent.providers.AwsTracerProviderFactory

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerProviderFactoryTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerProviderFactoryTest.java
@@ -18,19 +18,19 @@ package software.amazon.opentelemetry.javaagent.providers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.Ints;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.TracerProvider;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.RepeatedTest;
 
-class AwsOpenTelemetryFactoryTest {
+class AwsTracerProviderFactoryTest {
 
-  private static final OpenTelemetry openTelemetry = new AwsOpenTelemetryFactory().create();
+  private static final TracerProvider tracerProvider = new AwsTracerProviderFactory().create();
 
   // The probability of this passing once without correct IDs is low, 20 times is inconceivable.
   @RepeatedTest(20)
   void providerGeneratesXrayIds() {
     int startTimeSecs = (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
-    var span = openTelemetry.getTracer("test").spanBuilder("test").startSpan();
+    var span = tracerProvider.get("test").spanBuilder("test").startSpan();
     byte[] traceId = span.getSpanContext().getTraceIdBytes();
     int epoch = Ints.fromBytes(traceId[0], traceId[1], traceId[2], traceId[3]);
     assertThat(epoch).isGreaterThanOrEqualTo(startTimeSecs);

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -26,7 +26,7 @@ val DEPENDENCY_BOMS = listOf(
   "com.google.protobuf:protobuf-bom:3.14.0",
   "com.linecorp.armeria:armeria-bom:1.3.0",
   "io.grpc:grpc-bom:1.34.0",
-  "io.opentelemetry:opentelemetry-bom:0.13.1",
+  "io.opentelemetry:opentelemetry-bom:0.14.1",
   "org.apache.logging.log4j:log4j-bom:2.14.0",
   "org.junit:junit-bom:5.7.0",
   "org.springframework.boot:spring-boot-dependencies:2.4.0",
@@ -42,7 +42,7 @@ val DEPENDENCY_SETS = listOf(
   ),
   DependencySet(
     "io.opentelemetry.javaagent",
-    "0.13.0",
+    "0.14.0",
     listOf(
       "opentelemetry-javaagent",
       "opentelemetry-javaagent-spi"

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -41,6 +41,13 @@ val DEPENDENCY_SETS = listOf(
     listOf("guava", "guava-testlib")
   ),
   DependencySet(
+    "io.opentelemetry",
+    "0.14.1-alpha",
+    listOf(
+      "opentelemetry-api-metrics"
+    )
+  ),
+  DependencySet(
     "io.opentelemetry.javaagent",
     "0.14.0",
     listOf(

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation("com.sparkjava:spark-core")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("io.opentelemetry:opentelemetry-api")
+  implementation("io.opentelemetry:opentelemetry-api-metrics")
   implementation("software.amazon.awssdk:s3")
 }
 

--- a/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -1,6 +1,5 @@
 package com.amazon.sampleapp;
 
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;

--- a/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -2,6 +2,7 @@ package com.amazon.sampleapp;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongValueRecorder;
 import io.opentelemetry.api.metrics.Meter;
@@ -18,7 +19,7 @@ public class MetricEmitter {
   LongValueRecorder apiLatencyRecorder;
 
   public MetricEmitter() {
-    Meter meter = OpenTelemetry.getGlobalMeter("aws-otel", "1.0");
+    Meter meter = GlobalMetricsProvider.getMeter("aws-otel", "1.0");
 
     // give a instanceId appending to the metricname so that we can check the metric for each round
     // of integ-test

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp")
   implementation("software.amazon.awssdk:s3")
   implementation("io.opentelemetry:opentelemetry-api")
+  implementation("io.opentelemetry:opentelemetry-api-metrics")
 }
 
 jib {

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -1,6 +1,5 @@
 package com.amazon.sampleapp;
 
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -2,6 +2,7 @@ package com.amazon.sampleapp;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongValueRecorder;
 import io.opentelemetry.api.metrics.Meter;
@@ -18,7 +19,7 @@ public class MetricEmitter {
   LongValueRecorder apiLatencyRecorder;
 
   public MetricEmitter() {
-    Meter meter = OpenTelemetry.getGlobalMeter("aws-otel", "1.0");
+    Meter meter = GlobalMetricsProvider.getMeter("aws-otel", "1.0");
 
     // give a instanceId appending to the metricname so that we can check the metric for each round
     // of integ-test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Had to work around issue that prevents SPI configuration to work until 0.15.0. Fix is in upstream in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2077 but that has breaking changes to configuration options which we can't push out in a patch. This workaround is tame enough.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
