### PR TITLE
Add publish-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 
   id("com.diffplug.spotless")
   id("com.github.jk1.dependency-license-report")
+  id("io.github.gradle-nexus.publish-plugin")
   id("nebula.release")
 }
 
@@ -29,8 +30,20 @@ release {
   defaultVersionStrategy = Strategies.getSNAPSHOT()
 }
 
+nexusPublishing {
+  repositories {
+    sonatype {
+      nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2"))
+      snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+      username.set(System.getenv("PUBLISH_USERNAME"))
+      password.set(System.getenv("PUBLISH_PASSWORD"))
+    }
+  }
+}
+
 val releaseTask = tasks.named("release")
 val postReleaseTask = tasks.named("release")
+val closeAndReleaseTask = tasks.named("closeAndReleaseSonatypeStagingRepository")
 
 allprojects {
 
@@ -126,10 +139,12 @@ allprojects {
   plugins.withId("maven-publish") {
     plugins.apply("signing")
 
-    val publishTask = tasks.named("publish")
+    afterEvaluate {
+      val publishTask = tasks.named("publishToSonatype")
 
-    postReleaseTask.configure {
-      dependsOn(publishTask)
+      postReleaseTask.configure {
+        dependsOn(publishTask)
+      }
     }
 
     configure<PublishingExtension> {
@@ -184,22 +199,6 @@ allprojects {
               developerConnection.set("scm:git:git@github.com:aws-observability/aws-otel-java-instrumentation.git")
               url.set("https://github.com/aws-observability/aws-otel-java-instrumentation.git")
             }
-          }
-        }
-      }
-
-      val isSnapshot = version.toString().endsWith("SNAPSHOT")
-
-      repositories {
-        maven {
-          name = "Sonatype"
-          url = uri(
-            if (isSnapshot) "https://aws.oss.sonatype.org/content/repositories/snapshots/"
-            else "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2"
-          )
-          credentials {
-            username = System.getenv("PUBLISH_USERNAME")
-            password = System.getenv("PUBLISH_PASSWORD")
           }
         }
       }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ nexusPublishing {
 
 val releaseTask = tasks.named("release")
 val postReleaseTask = tasks.named("release")
-val closeAndReleaseTask = tasks.named("closeAndReleaseSonatypeStagingRepository")
 
 allprojects {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ pluginManagement {
     id("com.github.jk1.dependency-license-report") version "1.16"
     id("com.github.johnrengelman.shadow") version "6.1.0"
     id("com.google.cloud.tools.jib") version "2.7.0"
+    id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
     id("nebula.release") version "15.3.0"
     id("org.springframework.boot") version "2.4.0"
   }


### PR DESCRIPTION
*Description of changes:*
This is the successor to the gradle-nexus-staging-plugin we previously tried but couldn't due to conflicts with jib. It's modern code and doesn't conflict so we should finally be able to automate the nexus close.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
