### PR TITLE
Add an AWS composite propagator that can be used in AWS-service compa…

### DIFF
--- a/awspropagator/build.gradle.kts
+++ b/awspropagator/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+plugins {
+  `java-library`
+}
+
+base {
+  archivesBaseName = "aws-opentelemetry-propagator"
+}
+
+dependencies {
+  api("io.opentelemetry:opentelemetry-context")
+  implementation("io.opentelemetry:opentelemetry-extension-aws")
+  implementation("io.opentelemetry:opentelemetry-extension-trace-propagators")
+}

--- a/awspropagator/src/main/java/software/amazon/opentelemetry/awspropagator/AwsCompositePropagator.java
+++ b/awspropagator/src/main/java/software/amazon/opentelemetry/awspropagator/AwsCompositePropagator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.awspropagator;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.extension.aws.AwsXrayPropagator;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link TextMapPropagator} for use by AWS services or compatible ones such as localstack. As AWS
+ * is generic cloud infrastructure, rather than enforcing a specific injection format such as
+ * W3CTraceContext, it is intended to inject the same format as was extracted to allow compatibility
+ * with client applications that may not understand newer formats like W3C.
+ *
+ * <p>To allow rolling this propagator out to independent services, it also supports a mode that
+ * always injects in AWS format. This is intended for a transition period where most services will
+ * only understand that format.
+ */
+public final class AwsCompositePropagator implements TextMapPropagator {
+
+  // The currently supported propagators. This may grow or be made configurable in the future.
+  private static final List<TextMapPropagator> PROPAGATORS =
+      Arrays.asList(
+          W3CBaggagePropagator.getInstance(),
+          AwsXrayPropagator.getInstance(),
+          W3CTraceContextPropagator.getInstance(),
+          B3Propagator.injectingMultiHeaders());
+
+  /**
+   * Returns a {@link AwsCompositePropagator} which injects in the same format it extracted a trace
+   * context with. For example, if an incoming request contained a trace context in B3 format, an
+   * outgoing request will have B3 format injected.
+   */
+  public static AwsCompositePropagator injectingExtractedFormat() {
+    return new AwsCompositePropagator(true);
+  }
+
+  /**
+   * Returns a {@link AwsCompositePropagator} which injects in the AWS format (X-Amzn-Trace-Id). For
+   * example, if an incoming request contained a trace context in B3 format, an outgoing request
+   * will have AWS format injected.
+   */
+  public static AwsCompositePropagator injectingAwsFormat() {
+    return new AwsCompositePropagator(false);
+  }
+
+  private static final ContextKey<TextMapPropagator> EXTRACTED_PROPAGATOR =
+      ContextKey.named("extracted-propagator");
+
+  private final List<String> fields;
+  private final boolean injectExtractedFormat;
+
+  private AwsCompositePropagator(boolean injectExtractedFormat) {
+    this.injectExtractedFormat = injectExtractedFormat;
+
+    fields = PROPAGATORS.stream().flatMap(p -> p.fields().stream()).collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return fields;
+  }
+
+  @Override
+  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+    if (injectExtractedFormat) {
+      TextMapPropagator extractedPropagator = context.get(EXTRACTED_PROPAGATOR);
+      if (extractedPropagator != null) {
+        extractedPropagator.inject(context, carrier, setter);
+        Baggage baggage = Baggage.fromContextOrNull(context);
+        if (baggage != null && extractedPropagator != AwsXrayPropagator.getInstance()) {
+          // We extracted a span from a format not supporting baggage within the trace context
+          // itself, for example b3. if we have baggage we just propagate using w3c
+          // baggage.
+          W3CBaggagePropagator.getInstance().inject(context, carrier, setter);
+        }
+        return;
+      }
+    }
+    // Unless injecting in the same format as extracted, always inject X-Amzn-Trace-Id, the only
+    // format recognized by all AWS services as of now.
+    AwsXrayPropagator.getInstance().inject(context, carrier, setter);
+  }
+
+  @Override
+  public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+    for (TextMapPropagator propagator : PROPAGATORS) {
+      context = propagator.extract(context, carrier, getter);
+      if (Span.fromContextOrNull(context) != null) {
+        if (injectExtractedFormat) {
+          context = context.with(EXTRACTED_PROPAGATOR, propagator);
+        }
+        return context;
+      }
+    }
+
+    return context;
+  }
+}

--- a/awspropagator/src/test/java/software/amazon/opentelemetry/awspropagator/AwsCompositePropagatorTest.java
+++ b/awspropagator/src/test/java/software/amazon/opentelemetry/awspropagator/AwsCompositePropagatorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.awspropagator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.extension.aws.AwsXrayPropagator;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class AwsCompositePropagatorTest {
+
+  private static final Span SPAN1 =
+      Span.wrap(
+          SpanContext.createFromRemoteParent(
+              "ff000000000000000000000000000041",
+              "ff00000000000041",
+              TraceFlags.getDefault(),
+              TraceState.getDefault()));
+  private static final Span SPAN2 =
+      Span.wrap(
+          SpanContext.createFromRemoteParent(
+              "ff000000000000000000000000000042",
+              "ff00000000000042",
+              TraceFlags.getDefault(),
+              TraceState.getDefault()));
+
+  private static final TextMapGetter<Map<String, String>> MAP_GETTER =
+      new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @ParameterizedTest
+  @ArgumentsSource(SupportedPropagators.class)
+  void extractsAndInjectAws(TextMapPropagator propagator) {
+    Map<String, String> map = new HashMap<>();
+    propagator.inject(Context.root().with(SPAN1), map, Map::put);
+    TextMapPropagator awsPropagator = AwsCompositePropagator.injectingAwsFormat();
+    Context context = awsPropagator.extract(Context.root(), map, MAP_GETTER);
+    assertThat(Span.fromContext(context).getSpanContext()).isEqualTo(SPAN1.getSpanContext());
+
+    Map<String, String> map2 = new HashMap<>();
+    awsPropagator.inject(context, map2, Map::put);
+
+    Map<String, String> map3 = new HashMap<>();
+    AwsXrayPropagator.getInstance().inject(context, map3, Map::put);
+    assertThat(map2).containsExactlyInAnyOrderEntriesOf(map3);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SupportedPropagators.class)
+  void extractsAndInjectExtracted(TextMapPropagator propagator) {
+    Map<String, String> map = new HashMap<>();
+    propagator.inject(Context.root().with(SPAN1), map, Map::put);
+    TextMapPropagator awsPropagator = AwsCompositePropagator.injectingExtractedFormat();
+    Context context = awsPropagator.extract(Context.root(), map, MAP_GETTER);
+    assertThat(Span.fromContext(context).getSpanContext()).isEqualTo(SPAN1.getSpanContext());
+
+    Map<String, String> map2 = new HashMap<>();
+    awsPropagator.inject(context, map2, Map::put);
+
+    Map<String, String> map3 = new HashMap<>();
+    propagator.inject(context, map3, Map::put);
+    assertThat(map2).containsExactlyInAnyOrderEntriesOf(map3);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SupportedPropagators.class)
+  void baggageExtractedFormat(TextMapPropagator propagator) {
+    Map<String, String> map = new HashMap<>();
+    propagator.inject(Context.root().with(SPAN1), map, Map::put);
+    Baggage baggage = Baggage.builder().put("cat", "meow").build();
+    W3CBaggagePropagator.getInstance().inject(Context.root().with(baggage), map, Map::put);
+    TextMapPropagator awsPropagator = AwsCompositePropagator.injectingExtractedFormat();
+    Context context = awsPropagator.extract(Context.root(), map, MAP_GETTER);
+    assertThat(Span.fromContext(context).getSpanContext()).isEqualTo(SPAN1.getSpanContext());
+    assertThat(Baggage.fromContext(context)).isEqualTo(baggage);
+
+    Map<String, String> map2 = new HashMap<>();
+    awsPropagator.inject(context, map2, Map::put);
+
+    Map<String, String> map3 = new HashMap<>();
+    propagator.inject(context, map3, Map::put);
+
+    if (propagator != AwsXrayPropagator.getInstance()) {
+      W3CBaggagePropagator.getInstance().inject(context, map3, Map::put);
+    }
+
+    assertThat(map2).containsExactlyInAnyOrderEntriesOf(map3);
+  }
+
+  @Test
+  void awsPrioritized() {
+    Map<String, String> map = new HashMap<>();
+    AwsXrayPropagator.getInstance().inject(Context.root().with(SPAN1), map, Map::put);
+    W3CTraceContextPropagator.getInstance().inject(Context.root().with(SPAN2), map, Map::put);
+    assertThat(
+            Span.fromContext(
+                    AwsCompositePropagator.injectingExtractedFormat()
+                        .extract(Context.root(), map, MAP_GETTER))
+                .getSpanContext())
+        .isEqualTo(SPAN1.getSpanContext());
+  }
+
+  private static class SupportedPropagators implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+              AwsXrayPropagator.getInstance(),
+              W3CTraceContextPropagator.getInstance(),
+              B3Propagator.injectingMultiHeaders())
+          .map(Arguments::of);
+    }
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,7 @@ allprojects {
 
       testImplementation("org.assertj:assertj-core")
       testImplementation("org.junit.jupiter:junit-jupiter-api")
+      testImplementation("org.junit.jupiter:junit-jupiter-params")
       testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
 }
 
 include(":awsagentprovider")
+include(":awspropagator")
 include(":dependencyManagement")
 include(":instrumentation:logback-1.0")
 include(":instrumentation:log4j-2.13.2")


### PR DESCRIPTION
…tible projects.

*Issue #, if available:*

*Description of changes:*

A composite propagator that allows extracting from several different formats to support compatibility with a variety of client applications, even ones with legacy app instrumentation. It can be configured to either inject with the extracted format, or with the most AWS-compatible format currently, the AWS XRay propagator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
