### PR TITLE
Append aws suffix in agent manifest

### DIFF
--- a/otelagent/build.gradle.kts
+++ b/otelagent/build.gradle.kts
@@ -70,7 +70,15 @@ tasks {
       attributes.put("Premain-Class", "software.amazon.opentelemetry.javaagent.bootstrap.AwsAgentBootstrap")
       attributes.put("Can-Redefine-Classes", "true")
       attributes.put("Can-Retransform-Classes", "true")
-      attributes.put("Implementation-Version", project.version)
+
+      val versionString = project.version.toString()
+      val implementationVersion: String
+      if (versionString.endsWith("-SNAPSHOT")) {
+        implementationVersion = "${versionString.dropLast("-SNAPSHOT".length)}-aws-SNAPSHOT"
+      } else {
+        implementationVersion = "$versionString-aws"
+      }
+      attributes.put("Implementation-Version", implementationVersion)
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We currently append `-aws` to the version itself, but it makes it hard to release anything other than the agent from this repo (e.g. awsagentprovider as a separate jar, awspropagator). Release note titles also look a bit strange with the `-aws` suffix there.

This embeds `-aws` into the agent manifest directly instead, so we can still see the distro in `telemetry.auto.version`. Instead of having a patch version following the suffix (e.g. `-aws.1`), we can just make sure major / minor version stay in sync with upstream and not worry too much about the patch version since we'd only want to diverge in emergency cases either way.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
