### PR TITLE
Assert xray sampler exported spans is not empty.

### DIFF
--- a/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
+++ b/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
@@ -227,7 +227,7 @@ class SpringBootSmokeTest {
     var exported = getExported();
     // 5 spans per request (1 CLIENT, 2 SERVER, 2 INTERNAL) if sampled. The default sampler is
     // around 5%, we do a very rough check that there are no more than 10% sampled.
-    assertThat(exported).hasSizeLessThanOrEqualTo(numRequests * 5 / 10);
+    assertThat(exported).isNotEmpty().hasSizeLessThanOrEqualTo(numRequests * 5 / 10);
   }
 
   private List<Span> getExported() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since the sampling is random we can't have too strict of an assertion, but we do need to assert it's not empty in the case it's completely broken.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
