### PR TITLE
Update to xray sampler 1.5-SNAPSHOT

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -69,7 +69,7 @@ val DEPENDENCIES = listOf(
   "commons-logging:commons-logging:1.2",
   "com.sparkjava:spark-core:2.9.3",
   "com.squareup.okhttp3:okhttp:4.9.1",
-  "io.opentelemetry.contrib:opentelemetry-aws-xray:1.4.0",
+  "io.opentelemetry.contrib:opentelemetry-aws-xray:1.5.0-SNAPSHOT",
   "io.opentelemetry.javaagent:opentelemetry-javaagent:${if (!TEST_SNAPSHOTS) "1.5.2" else "$otelSnapshotVersion-SNAPSHOT"}",
   "net.bytebuddy:byte-buddy:1.11.13"
 )

--- a/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
+++ b/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
@@ -227,7 +227,7 @@ class SpringBootSmokeTest {
     var exported = getExported();
     // 5 spans per request (1 CLIENT, 2 SERVER, 2 INTERNAL) if sampled. The default sampler is
     // around 5%, we do a very rough check that there are no more than 10% sampled.
-    assertThat(exported).hasSizeLessThanOrEqualTo(numRequests * 5 / 10);
+    assertThat(exported).isNotEmpty().hasSizeLessThanOrEqualTo(numRequests * 5 / 10);
   }
 
   private List<Span> getExported() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Because of a dependency conflict between 1.4 and the 1.5 sdk-autoconfigure module (latter is still alpha API), this needs to be aligned for now. Didn't catch in unit tests due to a bad assertion.

Will release java-contrib 1.5 soon but we can release from SNAPSHOT in the meantime since it's not exposed through any POM

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
