### PR TITLE
Remove `-test-` component for Sample App Images

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
           LISTEN_ADDRESS: 0.0.0.0:8080
-          APP_IMAGE: public.ecr.aws/aws-otel-test/aws-otel-java-test-springboot:${{ github.sha }}
+          APP_IMAGE: public.ecr.aws/aws-otel-test/aws-otel-java-springboot:${{ github.sha }}
           VALIDATOR_COMMAND: -c springboot-otel-trace-metric-validation.yml --endpoint http://app:8080 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}
 
   test_Spark_App_With_Java_Agent:
@@ -114,7 +114,7 @@ jobs:
         env:
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
           LISTEN_ADDRESS: 0.0.0.0:4567
-          APP_IMAGE: public.ecr.aws/aws-otel-test/aws-otel-java-test-spark:${{ github.sha }}
+          APP_IMAGE: public.ecr.aws/aws-otel-test/aws-otel-java-spark:${{ github.sha }}
           VALIDATOR_COMMAND: -c spark-otel-trace-metric-validation.yml --endpoint http://app:4567 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}
 
   test_Spark_AWS_SDK_V1_App_With_Java_Agent:

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -24,7 +24,7 @@ application {
 
 jib {
   to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-test-spark:${System.getenv("COMMIT_HASH")}"
+    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:${System.getenv("COMMIT_HASH")}"
   }
   from {
     image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
 jib {
   to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-test-springboot:${System.getenv("COMMIT_HASH")}"
+    image = "public.ecr.aws/aws-otel-test/aws-otel-java-springboot:${System.getenv("COMMIT_HASH")}"
   }
   from {
     image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"


### PR DESCRIPTION
*Description of changes:*

Both of `springboot` and the `spark` app have containers with a `-test-` component in that last part of their image name.

https://github.com/aws-observability/aws-otel-java-instrumentation/blob/30f9f95629a71397b1ab90643f5b9d8bd133c241/sample-apps/springboot/build.gradle.kts#L18

https://github.com/aws-observability/aws-otel-java-instrumentation/blob/30f9f95629a71397b1ab90643f5b9d8bd133c241/sample-apps/spark/build.gradle.kts#L26

This PR adds it to the `spark-awssdkv1` app so that everything is consistent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
