### PR TITLE
Add `SAMPLE_APP_LOG_LEVEL` env var to control sample app logging

### DIFF
--- a/sample-apps/spark-awssdkv1/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark-awssdkv1/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -41,8 +41,6 @@ public class MetricEmitter {
     // give a instanceId appending to the metricname so that we can check the metric for each round
     // of integ-test
 
-    System.out.println("OTLP port is: " + System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"));
-
     String latencyMetricName = API_LATENCY_METRIC;
     String apiBytesSentMetricName = API_COUNTER_METRIC;
     String totalApiBytesSentMetricName = API_SUM_METRIC;
@@ -88,13 +86,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit total http request size "
-                      + totalBytesSent
-                      + " byte, "
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   totalBytesSent,
                   Attributes.of(
@@ -108,13 +99,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit last api latency "
-                      + apiLastLatency
-                      + ","
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   apiLastLatency,
                   Attributes.of(
@@ -127,13 +111,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit actual queue size "
-                      + actualQueueSize
-                      + ","
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   actualQueueSize,
                   Attributes.of(
@@ -149,8 +126,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitReturnTimeMetric(Long returnTime, String apiName, String statusCode) {
-    System.out.println(
-        "emit metric with return time " + returnTime + "," + apiName + "," + statusCode);
     apiLatencyRecorder.record(
         returnTime, Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
   }
@@ -163,7 +138,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitBytesSentMetric(int bytes, String apiName, String statusCode) {
-    System.out.println("emit metric with http request size " + bytes + " byte, " + apiName);
     apiBytesSentCounter.add(
         bytes, Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
   }
@@ -176,8 +150,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitQueueSizeChangeMetric(int queueSizeChange, String apiName, String statusCode) {
-    System.out.println(
-        "emit metric with queue size change " + queueSizeChange + "," + apiName + "," + statusCode);
     queueSizeCounter.add(
         queueSizeChange,
         Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
@@ -194,13 +166,6 @@ public class MetricEmitter {
     totalBytesSent += bytes;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update total http request size "
-            + totalBytesSent
-            + " byte, "
-            + apiName
-            + ","
-            + statusCode);
   }
 
   /**
@@ -214,8 +179,6 @@ public class MetricEmitter {
     apiLastLatency = returnTime;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update last latency value " + totalBytesSent + ", " + apiName + "," + statusCode);
   }
   /**
    * update actual queue size, it will be collected by UpDownSumObserver
@@ -228,7 +191,5 @@ public class MetricEmitter {
     actualQueueSize += queueSizeChange;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update actual queue size " + actualQueueSize + ", " + apiName + "," + statusCode);
   }
 }

--- a/sample-apps/spark/src/main/java/com/amazon/sampleapp/App.java
+++ b/sample-apps/spark/src/main/java/com/amazon/sampleapp/App.java
@@ -16,6 +16,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class App {
   private static final Logger logger = LogManager.getLogger();
+  private static final boolean shouldSampleAppLog =
+      System.getenv().getOrDefault("SAMPLE_APP_LOG_LEVEL", "INFO").equals("INFO");
 
   static final String REQUEST_START_TIME = "requestStartTime";
   static int mimicQueueSize;
@@ -55,7 +57,9 @@ public class App {
     get(
         "/outgoing-http-call",
         (req, res) -> {
-          logger.info("Executing outgoing-http-call");
+          if (shouldSampleAppLog) {
+            logger.info("Executing outgoing-http-call");
+          }
 
           try (Response response =
               httpClient
@@ -72,7 +76,9 @@ public class App {
     get(
         "/aws-sdk-call",
         (req, res) -> {
-          logger.info("Executing aws-sdk-all");
+          if (shouldSampleAppLog) {
+            logger.info("Executing aws-sdk-all");
+          }
 
           s3.listBuckets();
 

--- a/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -41,8 +41,6 @@ public class MetricEmitter {
     // give a instanceId appending to the metricname so that we can check the metric for each round
     // of integ-test
 
-    System.out.println("OTLP port is: " + System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"));
-
     String latencyMetricName = API_LATENCY_METRIC;
     String apiBytesSentMetricName = API_COUNTER_METRIC;
     String totalApiBytesSentMetricName = API_SUM_METRIC;
@@ -88,13 +86,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit total http request size "
-                      + totalBytesSent
-                      + " byte, "
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   totalBytesSent,
                   Attributes.of(
@@ -108,13 +99,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit last api latency "
-                      + apiLastLatency
-                      + ","
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   apiLastLatency,
                   Attributes.of(
@@ -127,13 +111,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit actual queue size "
-                      + actualQueueSize
-                      + ","
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   actualQueueSize,
                   Attributes.of(
@@ -149,8 +126,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitReturnTimeMetric(Long returnTime, String apiName, String statusCode) {
-    System.out.println(
-        "emit metric with return time " + returnTime + "," + apiName + "," + statusCode);
     apiLatencyRecorder.record(
         returnTime, Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
   }
@@ -163,7 +138,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitBytesSentMetric(int bytes, String apiName, String statusCode) {
-    System.out.println("emit metric with http request size " + bytes + " byte, " + apiName);
     apiBytesSentCounter.add(
         bytes, Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
   }
@@ -176,8 +150,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitQueueSizeChangeMetric(int queueSizeChange, String apiName, String statusCode) {
-    System.out.println(
-        "emit metric with queue size change " + queueSizeChange + "," + apiName + "," + statusCode);
     queueSizeCounter.add(
         queueSizeChange,
         Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
@@ -194,13 +166,6 @@ public class MetricEmitter {
     totalBytesSent += bytes;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update total http request size "
-            + totalBytesSent
-            + " byte, "
-            + apiName
-            + ","
-            + statusCode);
   }
 
   /**
@@ -214,8 +179,6 @@ public class MetricEmitter {
     apiLastLatency = returnTime;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update last latency value " + totalBytesSent + ", " + apiName + "," + statusCode);
   }
   /**
    * update actual queue size, it will be collected by UpDownSumObserver
@@ -228,7 +191,5 @@ public class MetricEmitter {
     actualQueueSize += queueSizeChange;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update actual queue size " + actualQueueSize + ", " + apiName + "," + statusCode);
   }
 }

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/DemoController.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/DemoController.java
@@ -17,6 +17,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Controller
 public class DemoController {
   private static final Logger logger = LoggerFactory.getLogger(DemoController.class);
+  private static final boolean shouldSampleAppLog =
+      System.getenv().getOrDefault("SAMPLE_APP_LOG_LEVEL", "INFO").equals("INFO");
 
   private final Call.Factory httpClient;
   private final S3Client s3;
@@ -38,7 +40,9 @@ public class DemoController {
   @GetMapping("/outgoing-http-call")
   @ResponseBody
   public String httpCall() {
-    logger.info("Executing outgoing-http-call");
+    if (shouldSampleAppLog) {
+      logger.info("Executing outgoing-http-call");
+    }
 
     try (Response response =
         httpClient.newCall(new Request.Builder().url("https://aws.amazon.com").build()).execute()) {
@@ -53,7 +57,9 @@ public class DemoController {
   @GetMapping("/aws-sdk-call")
   @ResponseBody
   public String awssdkCall() {
-    logger.info("Executing aws-sdk-all");
+    if (shouldSampleAppLog) {
+      logger.info("Executing aws-sdk-all");
+    }
 
     s3.listBuckets();
 

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -41,8 +41,6 @@ public class MetricEmitter {
     // give a instanceId appending to the metricname so that we can check the metric for each round
     // of integ-test
 
-    System.out.println("OTLP port is: " + System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"));
-
     String latencyMetricName = API_LATENCY_METRIC;
     String apiBytesSentMetricName = API_COUNTER_METRIC;
     String totalApiBytesSentMetricName = API_SUM_METRIC;
@@ -88,13 +86,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit total http request size "
-                      + totalBytesSent
-                      + " byte, "
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   totalBytesSent,
                   Attributes.of(
@@ -108,13 +99,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit last api latency "
-                      + apiLastLatency
-                      + ","
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   apiLastLatency,
                   Attributes.of(
@@ -127,13 +111,6 @@ public class MetricEmitter {
         .ofLongs()
         .buildWithCallback(
             measurement -> {
-              System.out.println(
-                  "emit actual queue size "
-                      + actualQueueSize
-                      + ","
-                      + apiNameValue
-                      + ","
-                      + statusCodeValue);
               measurement.observe(
                   actualQueueSize,
                   Attributes.of(
@@ -149,8 +126,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitReturnTimeMetric(Long returnTime, String apiName, String statusCode) {
-    System.out.println(
-        "emit metric with return time " + returnTime + "," + apiName + "," + statusCode);
     apiLatencyRecorder.record(
         returnTime, Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
   }
@@ -163,7 +138,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitBytesSentMetric(int bytes, String apiName, String statusCode) {
-    System.out.println("emit metric with http request size " + bytes + " byte, " + apiName);
     apiBytesSentCounter.add(
         bytes, Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
   }
@@ -176,8 +150,6 @@ public class MetricEmitter {
    * @param statusCode
    */
   public void emitQueueSizeChangeMetric(int queueSizeChange, String apiName, String statusCode) {
-    System.out.println(
-        "emit metric with queue size change " + queueSizeChange + "," + apiName + "," + statusCode);
     queueSizeCounter.add(
         queueSizeChange,
         Attributes.of(DIMENSION_API_NAME, apiName, DIMENSION_STATUS_CODE, statusCode));
@@ -194,13 +166,6 @@ public class MetricEmitter {
     totalBytesSent += bytes;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update total http request size "
-            + totalBytesSent
-            + " byte, "
-            + apiName
-            + ","
-            + statusCode);
   }
 
   /**
@@ -214,8 +179,6 @@ public class MetricEmitter {
     apiLastLatency = returnTime;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update last latency value " + totalBytesSent + ", " + apiName + "," + statusCode);
   }
   /**
    * update actual queue size, it will be collected by UpDownSumObserver
@@ -228,7 +191,5 @@ public class MetricEmitter {
     actualQueueSize += queueSizeChange;
     apiNameValue = apiName;
     statusCodeValue = statusCode;
-    System.out.println(
-        "update actual queue size " + actualQueueSize + ", " + apiName + "," + statusCode);
   }
 }


### PR DESCRIPTION
# Description

For the incoming Soak Tests, we would like to add an environment to control when the Sample Apps produces log outputs. We use branching to control the log messages that indicate an API endpoint was hit, and we remove the `System.out.println` log messages from the `MetricEmitter.java` file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
