### PR TITLE
Edits for compatability with aws-otel-collector v13

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -13,6 +13,9 @@ exporters:
     region: us-west-2
 
 service:
+  telemetry:
+    logs:
+      level: debug
   pipelines:
     traces:
       receivers:

--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   otel:
     image: amazon/aws-otel-collector:latest
-    command: --config /config/collector-config.yml --log-level debug
+    command: --config /config/collector-config.yml
     environment:
       - AWS_ROLE_ARN
       - AWS_WEB_IDENTITY_TOKEN_FILE


### PR DESCRIPTION
# Description

With the release of `public.ecr.aws/aws-observability/aws-otel-collector:latest` `v13`, we need to update our workflows to be compatible with it.

Specifically we remove the `--log-level` flag to fix the `main-build.yml` build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
