### PR TITLE
Small edits to Soak Tests

### DIFF
--- a/.github/scripts/performance-tests/produce_metric_widget_images.py
+++ b/.github/scripts/performance-tests/produce_metric_widget_images.py
@@ -366,17 +366,22 @@ if __name__ == "__main__":
             f"Will create a snapshot at URL: https://github.com/{args.github_repository}/blob/gh-pages/{snapshot_location}",
         )
 
-    # Delete oldest snapshots
+    # Delete oldest run folders in most recent commit and oldest commit folders
 
-    snapshot_dirs_length = len(os.listdir(SOAK_TESTS_SNAPSHOTS_COMMITS_DIR))
+    for snapshots_dir in [
+        SOAK_TESTS_SNAPSHOTS_COMMITS_DIR,
+        f"{SOAK_TESTS_SNAPSHOTS_COMMITS_DIR}/{ args.target_sha }/runs",
+    ]:
+        snapshot_dirs_length = len(os.listdir(snapshots_dir))
 
-    if snapshot_dirs_length > args.max_benchmarks_to_keep:
-        oldest_snapshot_dirs = nsmallest(
-            snapshot_dirs_length - args.max_benchmarks_to_keep,
-            Path(SOAK_TESTS_SNAPSHOTS_COMMITS_DIR).iterdir(),
-            key=os.path.getmtime,
-        )
-        for old_snapshots_dir in oldest_snapshot_dirs:
-            shutil.rmtree(old_snapshots_dir, ignore_errors=True)
+        if snapshot_dirs_length > args.max_benchmarks_to_keep:
+            oldest_snapshot_dirs = nsmallest(
+                snapshot_dirs_length - args.max_benchmarks_to_keep,
+                Path(snapshots_dir).iterdir(),
+                key=os.path.getmtime,
+            )
+            for old_snapshots_dir in oldest_snapshot_dirs:
+
+                shutil.rmtree(old_snapshots_dir, ignore_errors=True)
 
     logger.info("Done creating metric widget images.")

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -23,8 +23,8 @@ env:
   AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
   DEFAULT_TEST_DURATION_MINUTES: 300
   HOSTMETRICS_INTERVAL_SECS: 600
-  CPU_LOAD_THRESHOLD: 71
-  TOTAL_MEMORY_THRESHOLD: 2147483648
+  CPU_LOAD_THRESHOLD: 40
+  TOTAL_MEMORY_THRESHOLD: 4294967296 # 4 GiB
   MAX_BENCHMARKS_TO_KEEP: 100
   # TODO: We might be able to adapt the "Soak Tests" to be "Overhead Tests".
   # This means monitoring the Sample App's performance using high levels of TPS
@@ -238,7 +238,7 @@ jobs:
         with:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
       - name: Publish Issue if failed AFTER Performance Tests
-        uses: NathanielRN/create-an-issue@v2.5.1-alpha2
+        uses: JasonEtco/create-an-issue@v2
         if: ${{ github.event_name == 'schedule' &&
           steps.check-failure-after-performance-tests.outcome == 'failure' }}
         env:


### PR DESCRIPTION
# Description

Follow up to #84, we make some small edits to the Soak Tests:
1. Delete oldest snapshots in the `commits/<current_commit_id>/runs/` folder as well as the `commits/` folder.
2. Set the CPU threshold and Memory Threshold based on [this comment which found these values to work for all apps](https://github.com/NathanielRN/aws-otel-java-instrumentation/pull/1#issuecomment-925169660)
3. With https://github.com/JasonEtco/create-an-issue/pull/114 merged, we can use the upstream JasonEtco/create-an-issue action again! (This will be broken until the next minor release)
4. ~Fix authentication by using `aws sts get-session-token` instead of GitHub OIDC. This is because we found that the OIDC token expires after 5 minutes, and Soak Tests might not refresh until 10 or 40 minutes later. That's why for Soak Tests specifically we need this different way of using "temporary credentials".~ Moved to #88

~It would be interesting to check in the future if using `aws sts get-session-token` allow us to remove the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
