### PR TITLE
Use STS get-session-token for short lived AWS authentication with OIDC

### DIFF
--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -4,9 +4,10 @@ services:
     image: otel/opentelemetry-collector-contrib:latest
     command: --config /otel-collector/collector-config.yml
     environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_DEFAULT_REGION
-      - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
       - TARGET_SHA
       - GITHUB_RUN_ID
       - HOSTMETRICS_INTERVAL_SECS
@@ -17,7 +18,6 @@ services:
       - APP_PROCESS_EXECUTABLE_NAME
     volumes:
       - ./otel-collector:/otel-collector
-      - /tmp/awscreds:/tmp/awscreds
       - type: bind
         source: /proc
         target: /proc
@@ -30,9 +30,10 @@ services:
     environment:
       - INSTANCE_ID
       - LISTEN_ADDRESS=0.0.0.0:${LISTEN_ADDRESS_PORT}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_DEFAULT_REGION
-      - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
       - SAMPLE_APP_LOG_LEVEL=ERROR
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
       # Java specific values
@@ -41,8 +42,6 @@ services:
       # Produces several "java.lang.IllegalArgumentException: Counters can only increase"
       # error messages. Removing for now to not have log messages skew results.
       # - OTEL_METRICS_EXPORTER=otlp
-    volumes:
-      - /tmp/awscreds:/tmp/awscreds
     ports:
       - '${LISTEN_ADDRESS_PORT}:${LISTEN_ADDRESS_PORT}'
 
@@ -60,9 +59,10 @@ services:
     build:
       context: ./alarms-poller
     environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_DEFAULT_REGION
-      - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
       - HOSTMETRICS_INTERVAL_SECS
       - NUM_OF_CPUS
       - TARGET_SHA
@@ -74,6 +74,5 @@ services:
       - MATRIX_COMMIT_COMBO
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp/awscreds:/tmp/awscreds
     depends_on:
       - load-generator

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -20,7 +20,6 @@ env:
   # NOTE: The configuration of `APP_PROCESS_EXECUTABLE_NAME` is repo dependent
   APP_PROCESS_EXECUTABLE_NAME: java
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
   DEFAULT_TEST_DURATION_MINUTES: 300
   HOSTMETRICS_INTERVAL_SECS: 600
   CPU_LOAD_THRESHOLD: 71
@@ -100,9 +99,10 @@ jobs:
 
       - name: Configure AWS Credentials
         run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+          AWS_CREDENTIALS=$(aws sts get-session-token)
+          echo "AWS_ACCESS_KEY_ID=$(echo $AWS_CREDENTIALS | jq '.Credentials.AccessKeyId')" >> $GITHUB_ENV;
+          echo "AWS_SECRET_ACCESS_KEY=$(echo $AWS_CREDENTIALS | jq '.Credentials.SecretAccessKey')" >> $GITHUB_ENV;
+          echo "AWS_SESSION_TOKEN=$(echo $AWS_CREDENTIALS | jq '.Credentials.SessionToken')" >> $GITHUB_ENV;
       # NOTE: We only login to prevent getting throttled for too many docker
       # pulls. We do not publish anything to ECR.
       - name: Login to ECR
@@ -128,6 +128,9 @@ jobs:
           LISTEN_ADDRESS_PORT: ${{ env.LISTEN_ADDRESS_PORT }}
           LOG_GROUP_NAME: otel-sdk-performance-tests
           # Also uses:
+          # AWS_ACCESS_KEY_ID
+          # AWS_SECRET_ACCESS_KEY
+          # AWS_SESSION_TOKEN
           # TARGET_SHA
           # LOGS_NAMESPACE
           # LOG_STREAM_NAME


### PR DESCRIPTION
# Description

Fix authentication by using `aws sts get-session-token` instead of GitHub's `$ACTIONS_ID_TOKEN_REQUEST_URL` and `$ACTIONS_ID_TOKEN_REQUEST_TOKEN`. This is because we found that the GitHub OIDC token expires after 5 minutes, and Soak Tests might not refresh until 10 or 40 minutes later. That's why for Soak Tests specifically we need this different way of getting "short-lived credentials".

It would be interesting to check in the future if using `aws sts get-session-token` allow us to remove the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
