### PR TITLE
Use GitHub OIDC Call to get AWS Creds before STS Call

### DIFF
--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -99,6 +99,14 @@ jobs:
 
       - name: Configure AWS Credentials
         run: |
+          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+
+          echo "AWS_ROLE_ARN=$AWS_ROLE_ARN" >> $GITHUB_ENV
+          echo "AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE" >> $GITHUB_ENV
+
+          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+
           AWS_CREDENTIALS=$(aws sts get-session-token)
           echo "AWS_ACCESS_KEY_ID=$(echo $AWS_CREDENTIALS | jq '.Credentials.AccessKeyId')" >> $GITHUB_ENV;
           echo "AWS_SECRET_ACCESS_KEY=$(echo $AWS_CREDENTIALS | jq '.Credentials.SecretAccessKey')" >> $GITHUB_ENV;


### PR DESCRIPTION
# Description

Follow up to #88, before we make a call to `aws sts get-session-token`, we need to have _some_ AWS credentials. We don't want the credentials to be long-lived, so we try to use the `AWS_WEB_IDENTITY_TOKEN_FILE` env variable resolution method to provide credentials. GitHub will populate this file with temporary credentials (that last 5 minutes) that will give us enough time to call `sts` for additional temporary credentials which last longer (24 hours).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
