### PR TITLE
Use Long Lasting AWS Creds for Soak Tests only

### DIFF
--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -36,7 +36,6 @@ jobs:
     name: Soak Performance Test - (${{ matrix.app-platform }}, ${{ matrix.instrumentation-type }})
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
       issues: write
     strategy:
@@ -98,19 +97,13 @@ jobs:
     # MARK: - Run Performance Tests
 
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-
-          echo "AWS_ROLE_ARN=$AWS_ROLE_ARN" >> $GITHUB_ENV
-          echo "AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE" >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-
-          AWS_CREDENTIALS=$(aws sts get-session-token)
-          echo "AWS_ACCESS_KEY_ID=$(echo $AWS_CREDENTIALS | jq '.Credentials.AccessKeyId')" >> $GITHUB_ENV;
-          echo "AWS_SECRET_ACCESS_KEY=$(echo $AWS_CREDENTIALS | jq '.Credentials.SecretAccessKey')" >> $GITHUB_ENV;
-          echo "AWS_SESSION_TOKEN=$(echo $AWS_CREDENTIALS | jq '.Credentials.SessionToken')" >> $GITHUB_ENV;
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 21600 # 6 Hours
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       # NOTE: We only login to prevent getting throttled for too many docker
       # pulls. We do not publish anything to ECR.
       - name: Login to ECR


### PR DESCRIPTION
# Description

In #88 and #89, we learned that there was _no way_ to get short-lived credentials for the Soak Tests.

If we use GitHub OIDC alone, the tokens expire after 5 minutes and credentials are unrecoverable if not refreshed within that time. Soak Tests run for 5 hours and at a collection interval of 10 minutes so they don't refresh in time.

If we use `aws sts get-session-token` we still need long lasting credentials. As mentioned in [the aws CLI docs](https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html):

> The GetSessionToken operation must be called by using the long-term Amazon Web Services security credentials of the Amazon Web Services account root user or an IAM user.

Trying to use GitHub Sessional Credentials to get additional sessional STS credentials results in [the following error](https://github.com/aws-observability/aws-otel-java-instrumentation/runs/3735504769?check_suite_focus=true):

```
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1429    0  1429    0     0  18088      0 --:--:-- --:--:-- --:--:-- 18088

An error occurred (AccessDenied) when calling the GetSessionToken operation: Cannot call GetSessionToken with session credentials
Error: Process completed with exit code 254.
```

So for Soak Tests, we need to use long lasting credentials.

# Alternative Solutions to this PR

It is possible that because this is such a new feature, GitHub might update their token expiration to last longer in the future in which case we can go back to that authentication.

We might consider making a separate role for Soak Tests with more strict permissions, but this still requires long last credentials.

Finally, we might considering **forcing the Soak Tests to refresh every 5 minutes** before the token expires. Then we could use GitHub OIDC, but it would require changing the Soak Test code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
