### PR TITLE
Fix gh-pages link for auto Soak Test links

### DIFF
--- a/.github/auto-issue-templates/failure-after-soak_tests.md
+++ b/.github/auto-issue-templates/failure-after-soak_tests.md
@@ -9,7 +9,7 @@ After the Soak Tests completed, a performance degradation was revealed for commi
 
 # Useful Links
 
-Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/{{ sha }}). These are the snapshots for the violating commit:
+Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/commits/{{ sha }}). These are the snapshots for the violating commit:
 
 ![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-cpu-load.png?raw=true)
 ![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-total-memory.png?raw=true)

--- a/.github/auto-issue-templates/failure-during-soak_tests.md
+++ b/.github/auto-issue-templates/failure-during-soak_tests.md
@@ -9,7 +9,7 @@ During Soak Tests execution, a performance degradation was revealed for commit {
 
 # Useful Links
 
-Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/{{ sha }}). These are the snapshots for the violating commit:
+Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/commits/{{ sha }}). These are the snapshots for the violating commit:
 
 ![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-cpu-load.png?raw=true)
 ![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-total-memory.png?raw=true)


### PR DESCRIPTION
# Description

We separated the Soak Tests by commit SHA and while we updated the image links we did not update the `gh-pages` branch link.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
