### PR TITLE
Detect docker-compose start up failures and fail early

### DIFF
--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -154,7 +154,7 @@ jobs:
           echo "RUN_TESTS_EXIT_CODE=$RUN_TESTS_EXIT_CODE" | tee --append $GITHUB_ENV;
           exit $RUN_TESTS_EXIT_CODE;
       - name: Fail early if Soak Tests failed to start
-        if: ${{ env.RUN_TESTS_EXIT_CODE == 1 }}
+        if: ${{ env.RUN_TESTS_EXIT_CODE == '' || env.RUN_TESTS_EXIT_CODE == 1 }}
         run: exit 1;
 
     # MARK: - Report on Performance Test Results


### PR DESCRIPTION
*Description of changes:*

In the [most recent Soak Test workflow run](https://github.com/aws-observability/aws-otel-java-instrumentation/runs/3872109510?check_suite_focus=true) there was a failure related to `docker-compose` not even being able to start the `load-generator` service. Because we did not set the `RUN_TESTS_EXIT_CODE` environment variable, we assumed the tests ran successfully and continued the execution of the Soak Tests. Instead of that, we should notice that the variable was not even set and fail the Soak Tests early.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
