### PR TITLE
Remove anomaly CPU benchmark because it will trigger scheduled performance violations

### DIFF
--- a/soak-tests/per-commit-overall-results/data.js
+++ b/soak-tests/per-commit-overall-results/data.js
@@ -47,38 +47,6 @@ window.BENCHMARK_DATA = {
             "username": "web-flow",
             "email": "noreply@github.com"
           },
-          "id": "525ef8f8ea2f3922515ba6b38a232e5e4dc4b4a2",
-          "message": "Increase points to alarm for memory usage poll (#94)",
-          "timestamp": "2021-10-11T02:50:29Z",
-          "url": "https://github.com/aws-observability/aws-otel-java-instrumentation/commit/525ef8f8ea2f3922515ba6b38a232e5e4dc4b4a2"
-        },
-        "date": 1633982766257,
-        "tool": "custombenchmark",
-        "benches": [
-          {
-            "name": "Soak Test Average CPU Load",
-            "value": 6.415344827586207,
-            "unit": "Percent"
-          },
-          {
-            "name": "Soak Test Average Virtual Memory Used",
-            "value": 3445.71484375,
-            "unit": "Megabytes"
-          }
-        ]
-      },
-      {
-        "commit": {
-          "author": {
-            "name": "(Eliseo) Nathaniel Ruiz Nowell",
-            "username": "NathanielRN",
-            "email": "enowell@amazon.com"
-          },
-          "committer": {
-            "name": "GitHub",
-            "username": "web-flow",
-            "email": "noreply@github.com"
-          },
           "id": "1e5ce35bb81462d44f539d98bb481659f8e13392",
           "message": "Detect docker-compose start up failures and fail early (#95)",
           "timestamp": "2021-10-14T05:02:30Z",


### PR DESCRIPTION
*Description of changes:*

Over the weekend, the Soak Tests were failing and saying that the average performance was getting much worse. This was because there was a commit that occurred over a week ago where the CPU Load was only 6% so subsequent CPU loads of ~24% violated our performance increase threshold.

Because we run on a schedule, the Soak Tests are running on the _same_ commit over and over again... So **every** scheduled run will have the same 6% -> 24% CPU load performance hit violation.... Basically it's saying "we will continue to fail until you fix the performance violation on this commit".

That's why as a temporary solution, we remove this problematic CPU Load datapoint to stop the false failures. In the future, the Soak Tests should probably continue to fail like they are now **when we trust the results to be accurate using stable runners**.

We can also simply _update_ the issue instead of creating a new each time!

Fixes #98
Fixes #99

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.