### PR TITLE
Use aws-credentials action to configure creds bc it uses OIDC by default

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -4,8 +4,10 @@ services:
     image: amazon/aws-otel-collector:latest
     command: --config /config/collector-config.yml
     environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
     volumes:
       - .:/config
       - /tmp/awscreds:/tmp/awscreds
@@ -17,8 +19,10 @@ services:
     environment:
       - INSTANCE_ID
       - LISTEN_ADDRESS
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
       - AWS_REGION=us-west-2
@@ -37,8 +41,10 @@ services:
       - otel
       - app
     environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
       - AWS_REGION=us-west-2
     volumes:
       - /tmp/awscreds:/tmp/awscreds

--- a/.github/workflows/docker-build-corretto-slim.yml
+++ b/.github/workflows/docker-build-corretto-slim.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -23,11 +22,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/docker-build-smoke-tests-fake-backend.yml
+++ b/.github/workflows/docker-build-smoke-tests-fake-backend.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -28,11 +27,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -25,11 +24,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 
@@ -69,11 +67,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 
@@ -100,11 +97,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 
@@ -131,11 +127,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -25,11 +24,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -67,11 +66,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -25,11 +24,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR1
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -99,8 +99,6 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 21600 # 6 Hours
           aws-region: ${{ env.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

GitHub just announced [their OIDC feature as GA](https://github.blog/changelog/2021-10-27-github-actions-secure-cloud-deployments-with-openid-connect/), but what’s even cooler is that they seem to have worked with the “configure-aws-credentials GH Action” team to integrate it seamlessly into the action :]

From the [aws-actions/configure-aws-credentials updated README](https://github.com/aws-actions/configure-aws-credentials#assuming-a-role) from 15 days ago:

> We recommend using GitHub’s OIDC provider to get short-lived credentials needed for your actions. Specifying role-to-assume without providing an aws-access-key-id  or a web-identity-token-file will signal to the action that you wish to use the OIDC provider. The default session duration is 1 hour when using the OIDC provider to directly assume an IAM Role. The default session duration is 6 hours when using an IAM User to assume an IAM Role (by providing an aws-access-key-id, aws-secret-access-key, and a role-to-assume) . If you would like to adjust this you can pass a duration to role-duration-seconds, but the duration cannot exceed the maximum that was defined when the IAM Role was created. The default session name is GitHubActions, and you can modify it by specifying the desired name in role-session-name.

This should mean we can use the action to do OIDC authentication, and that the Soak Tests can also use it because the 1 hour default expiry will be enough for it to refresh those credentials 🙂 Previously this was not possible because the OIDC token had a default expiry of 5 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
