### PR TITLE
GH Action OIDC AWS Creds for GH workflows

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -4,8 +4,9 @@ services:
     image: amazon/aws-otel-collector:latest
     command: --config /config/collector-config.yml
     environment:
-      - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
     volumes:
       - .:/config
       - /tmp/awscreds:/tmp/awscreds
@@ -17,8 +18,9 @@ services:
     environment:
       - INSTANCE_ID
       - LISTEN_ADDRESS
-      - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
       - AWS_REGION=us-west-2
@@ -37,8 +39,9 @@ services:
       - otel
       - app
     environment:
-      - AWS_ROLE_ARN
-      - AWS_WEB_IDENTITY_TOKEN_FILE
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_REGION=us-west-2
     volumes:
       - /tmp/awscreds:/tmp/awscreds

--- a/.github/workflows/docker-build-corretto-slim.yml
+++ b/.github/workflows/docker-build-corretto-slim.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -23,11 +22,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/docker-build-smoke-tests-fake-backend.yml
+++ b/.github/workflows/docker-build-smoke-tests-fake-backend.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -28,11 +27,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -25,11 +24,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 
@@ -69,11 +67,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 
@@ -100,11 +97,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 
@@ -131,11 +127,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -25,11 +24,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -67,11 +66,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/awscreds
 
 permissions:
   id-token: write
@@ -25,11 +24,10 @@ jobs:
 
       - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
-        run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Login to ECR1
         run: aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
 

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       issues: write
     strategy:
       fail-fast: false
@@ -99,8 +100,6 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 21600 # 6 Hours
           aws-region: ${{ env.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
*Description of changes:*

Trying #110 again now that the action has released the changes as minor release to `v1`! In hindsight we could've tagged a commit on the https://github.com/aws-actions/configure-aws-credentials repository to have the changes right away, but this way we avoid the PR to move them all to be `@v1` again later.

I tested these changes on my fork, where I saw the `Configure AWS credentials` step succeed, but the test overall failed due to permissions needed to push to a public ECR repo. Here is a screenshot of the `main-build.yml` working, with the other workflows being very similar:

![image](https://user-images.githubusercontent.com/23139455/146450510-28396af1-511e-4963-b0b5-cc3f6d854422.png)

Soak Testing failed at first, but eventually worked when I added the `id-token: write` permissions to the workflow file:

![image](https://user-images.githubusercontent.com/23139455/146450660-c7185e2b-6660-496b-bd8a-728ded391370.png)

Soak Test eventually ran again and succeeded after 5 hours: https://github.com/NathanielRN/aws-otel-java-instrumentation/actions/runs/1592857236

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
