### PR TITLE
Remove Sleep from Docker Corretto Workflow

### DIFF
--- a/.github/workflows/docker-build-corretto-slim.yml
+++ b/.github/workflows/docker-build-corretto-slim.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/docker-build-smoke-tests-fake-backend.yml
+++ b/.github/workflows/docker-build-smoke-tests-fake-backend.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           java-version: 14
       - uses: gradle/wrapper-validation-action@v1
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           java-version: 14
       - uses: gradle/wrapper-validation-action@v1
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -64,8 +62,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 14
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -94,8 +90,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 14
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -124,8 +118,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 14
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           java-version: 14
       - uses: gradle/wrapper-validation-action@v1
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -63,8 +63,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 14
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           java-version: 14
       - uses: gradle/wrapper-validation-action@v1
-
-      - run: sleep 5 # there's still a race condition for now
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Following up with https://github.com/aws-observability/aws-otel-java-instrumentation/pull/130#discussion_r772858253, since we use GitHub OIDC to log in now, we should not need this sleep in our GH workflow. We used to do this because the AWS Creds GH action was in an alpha stage and failed without it. Now it is released and ready to be used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
