### PR TITLE
Adding latest tag and support arm64 architecture for the builds

### DIFF
--- a/sample-apps/spark-awssdkv1/build.gradle.kts
+++ b/sample-apps/spark-awssdkv1/build.gradle.kts
@@ -21,7 +21,7 @@ application {
 
 jib {
   to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark-awssdkv1:${System.getenv("COMMIT_HASH")}"
+    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark-awssdkv1"
     tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
   }
   from {

--- a/sample-apps/spark-awssdkv1/build.gradle.kts
+++ b/sample-apps/spark-awssdkv1/build.gradle.kts
@@ -22,9 +22,20 @@ application {
 jib {
   to {
     image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark-awssdkv1:${System.getenv("COMMIT_HASH")}"
+    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
   }
   from {
     image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"
+    platforms {
+      platform {
+        architecture = "amd64"
+        os = "linux"
+      }
+      platform {
+        architecture = "arm64"
+        os = "linux"
+      }
+    }
   }
 }
 

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -25,9 +25,20 @@ application {
 jib {
   to {
     image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:${System.getenv("COMMIT_HASH")}"
+    tags = setOf("latest")
   }
   from {
     image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"
+    platforms {
+      platform {
+        architecture = "amd64"
+        os = "linux"
+      }
+      platform {
+        architecture = "arm64"
+        os = "linux"
+      }
+    }
   }
 }
 

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -24,8 +24,8 @@ application {
 
 jib {
   to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark:${System.getenv("COMMIT_HASH")}"
-    tags = setOf("latest")
+    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark"
+    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
   }
   from {
     image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
 jib {
   to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-springboot:${System.getenv("COMMIT_HASH")}"
+    image = "public.ecr.aws/aws-otel-test/aws-otel-java-springboot"
     tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
   }
   from {

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -17,9 +17,20 @@ dependencies {
 jib {
   to {
     image = "public.ecr.aws/aws-otel-test/aws-otel-java-springboot:${System.getenv("COMMIT_HASH")}"
+    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
   }
   from {
     image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"
+    platforms {
+      platform {
+        architecture = "amd64"
+        os = "linux"
+      }
+      platform {
+        architecture = "arm64"
+        os = "linux"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
*Description of changes:*

This PR is to add the latest tag for spark-sample-app image and also to support the architecture arm64

expected image: `public.ecr.aws/aws-otel-test/aws-otel-java-spark:latest` 