### PR TITLE
Use Opentelemetry SDK For Spark Sample App

### DIFF
--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
   implementation("org.apache.logging.log4j:log4j-core")
   implementation("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:sts")
+  implementation("io.opentelemetry:opentelemetry-sdk-metrics:1.10.0-alpha")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-metrics:1.10.0-alpha")
 
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl")
 }


### PR DESCRIPTION
*Description of changes:*
As of the newer versions of the api. It currently uses a no op provider. This will allow us to use the sdk provider so we can send metrics via grpc. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
