### PR TITLE
Updating fasterxml jackson library to fix vulnerability

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -31,7 +31,7 @@ val otelSnapshotVersion = "1.13.0"
 
 val DEPENDENCY_BOMS = listOf(
   "com.amazonaws:aws-java-sdk-bom:1.12.185",
-  "com.fasterxml.jackson:jackson-bom:2.13.2",
+  "com.fasterxml.jackson:jackson-bom:2.13.2.1",
   "com.google.guava:guava-bom:31.1-jre",
   "com.google.protobuf:protobuf-bom:3.19.4",
   "com.linecorp.armeria:armeria-bom:1.14.1",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -31,7 +31,7 @@ val otelSnapshotVersion = "1.13.0"
 
 val DEPENDENCY_BOMS = listOf(
   "com.amazonaws:aws-java-sdk-bom:1.12.185",
-  "com.fasterxml.jackson:jackson-bom:2.13.2.1",
+  "com.fasterxml.jackson:jackson-bom:2.13.2.20220328",
   "com.google.guava:guava-bom:31.1-jre",
   "com.google.protobuf:protobuf-bom:3.19.4",
   "com.linecorp.armeria:armeria-bom:1.14.1",


### PR DESCRIPTION
*Issue #, if available:* 
N/A
*Description of changes:*
This is to update the Jackson library vulnerability. By updating the version, the databind nested dependency will be updated to version `2.13.2.1`, which will have fixed version.

Reference Link: https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom/2.13.2
![image](https://user-images.githubusercontent.com/55892686/162271815-6b39a574-9260-444c-8dc3-47c4d8c94890.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
