### PR TITLE
Use team for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/articles/about-codeowners/
 
-* @anuraaga @vasireddy99
+* @aws-observability/adot-sdk-maintainers


### PR DESCRIPTION
In the future perhaps there is a more appropriate team for this, but in the meantime it definitely shouldn't have me listed explicitly on it.