### PR TITLE
Remove deprecated instrumentLibrary method

### DIFF
--- a/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
+++ b/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
@@ -258,7 +258,7 @@ class SpringBootSmokeTest {
     }
     return exported.stream()
         .flatMap(req -> req.getResourceSpansList().stream())
-        .flatMap(rs -> rs.getInstrumentationLibrarySpansList().stream())
+        .flatMap(rs -> rs.getScopeSpansList().stream())
         .flatMap(ils -> ils.getSpansList().stream())
         .collect(toImmutableList());
   }


### PR DESCRIPTION
In [`v1.13.0`](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.13.0) of the upstream java sdk release the `instrumentLibrary` methods were deprecated and replaced by `InstrumentationScope`. In [`v1.14.0`](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.14.0) of the upstream sdk these deprecated methods were dropped. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
