### PR TITLE
Fix nightly builds

### DIFF
--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -31,7 +31,9 @@ dependencies {
   implementation("io.opentelemetry.contrib:opentelemetry-aws-xray")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+  testImplementation("io.opentelemetry:opentelemetry-extension-aws")
+  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators")
   testImplementation("com.google.guava:guava")
 
   compileOnly("com.google.code.findbugs:jsr305:3.0.2")

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProvider.java
@@ -15,16 +15,20 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
-import io.opentelemetry.javaagent.extension.config.ConfigPropertySource;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import java.util.HashMap;
-import java.util.Map;
 
-public class AwsAgentProperties implements ConfigPropertySource {
+public class AwsAgentPropertiesCustomizerProvider implements AutoConfigurationCustomizerProvider {
   @Override
-  public Map<String, String> getProperties() {
-    Map<String, String> properties = new HashMap<>();
-    properties.put("otel.propagators", "xray,tracecontext,b3,b3multi");
-    properties.put("otel.instrumentation.aws-sdk.experimental-span-attributes", "true");
-    return properties;
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addPropertiesSupplier(
+        () ->
+            new HashMap<String, String>() {
+              {
+                put("otel.propagators", "xray,tracecontext,b3,b3multi");
+                put("otel.instrumentation.aws-sdk.experimental-span-attributes", "true");
+              }
+            });
   }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerCustomizerProvider.java
@@ -16,12 +16,10 @@
 package software.amazon.opentelemetry.javaagent.providers;
 
 import io.opentelemetry.contrib.awsxray.AwsXrayIdGenerator;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
-import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
-public class AwsTracerConfigurer implements SdkTracerProviderConfigurer {
-
+public class AwsTracerCustomizerProvider implements AutoConfigurationCustomizerProvider {
   static {
     if (System.getProperty("otel.aws.imds.endpointOverride") == null) {
       String overrideFromEnv = System.getenv("OTEL_AWS_IMDS_ENDPOINT_OVERRIDE");
@@ -32,8 +30,9 @@ public class AwsTracerConfigurer implements SdkTracerProviderConfigurer {
   }
 
   @Override
-  public void configure(
-      SdkTracerProviderBuilder sdkTracerProviderBuilder, ConfigProperties config) {
-    sdkTracerProviderBuilder.setIdGenerator(AwsXrayIdGenerator.getInstance());
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addTracerProviderCustomizer(
+        (tracerProviderBuilder, configProps) ->
+            tracerProviderBuilder.setIdGenerator(AwsXrayIdGenerator.getInstance()));
   }
 }

--- a/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.extension.config.ConfigPropertySource
+++ b/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.javaagent.extension.config.ConfigPropertySource
@@ -1,1 +1,0 @@
-software.amazon.opentelemetry.javaagent.providers.AwsAgentProperties

--- a/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/awsagentprovider/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,5 +1,5 @@
 #
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 # permissions and limitations under the License.
 #
 
-software.amazon.opentelemetry.javaagent.providers.AwsTracerConfigurer
+software.amazon.opentelemetry.javaagent.providers.AwsAgentPropertiesCustomizerProvider
+software.amazon.opentelemetry.javaagent.providers.AwsTracerCustomizerProvider


### PR DESCRIPTION
**Issue #, if available:** #203

**Description of changes:**
Nightly builds started to fail after the Otel dependency was changed to v1.18.0. This happened because some APIs that were previously deprecated, were removed in that version.

This PR uses AutoConfigurationCustomizerProvider instead of deprecated APIs that were removed in the Upstream Otel v1.18

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
