### PR TITLE
Update dependencies and Otel to v1.18.0

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -27,24 +27,24 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val TEST_SNAPSHOTS = rootProject.findProperty("testUpstreamSnapshots") == "true"
 
 // This is the only version that affects the released artifact.
-val otelVersion = "1.17.0"
-val otelSnapshotVersion = "1.18.0"
+val otelVersion = "1.18.0"
+val otelSnapshotVersion = "1.19.0"
 
 // All versions below are only used in testing and do not affect the released artifact.
 
 val DEPENDENCY_BOMS = listOf(
-  "com.amazonaws:aws-java-sdk-bom:1.12.286",
-  "com.fasterxml.jackson:jackson-bom:2.13.3",
+  "com.amazonaws:aws-java-sdk-bom:1.12.307",
+  "com.fasterxml.jackson:jackson-bom:2.13.4",
   "com.google.guava:guava-bom:31.1-jre",
-  "com.google.protobuf:protobuf-bom:3.21.5",
-  "com.linecorp.armeria:armeria-bom:1.18.0",
-  "io.grpc:grpc-bom:1.48.1",
+  "com.google.protobuf:protobuf-bom:3.21.6",
+  "com.linecorp.armeria:armeria-bom:1.19.0",
+  "io.grpc:grpc-bom:1.49.1",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${if (!TEST_SNAPSHOTS) "$otelVersion-alpha" else "$otelSnapshotVersion-alpha-SNAPSHOT"}",
-  "org.apache.logging.log4j:log4j-bom:2.18.0",
-  "org.junit:junit-bom:5.9.0",
+  "org.apache.logging.log4j:log4j-bom:2.19.0",
+  "org.junit:junit-bom:5.9.1",
   "org.springframework.boot:spring-boot-dependencies:2.7.3",
   "org.testcontainers:testcontainers-bom:1.17.3",
-  "software.amazon.awssdk:bom:2.17.257"
+  "software.amazon.awssdk:bom:2.17.278"
 )
 
 val DEPENDENCY_SETS = listOf(


### PR DESCRIPTION
*Description of changes:* Updating dependencies and Otel Java version to 1.18

```
------------------------------------------------------------
:dependencyManagement Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.42.0
 - com.google.guava:guava-bom:31.1-jre
 - com.sparkjava:spark-core:2.9.4
 - com.squareup.okhttp3:okhttp:4.10.0
 - commons-logging:commons-logging:1.2
 - org.assertj:assertj-core:3.23.1
 - org.curioswitch.curiostack:protobuf-jackson:2.0.0
 - org.springframework.boot:spring-boot-dependencies:2.7.3
 - org.testcontainers:testcontainers-bom:1.17.3

The following dependencies have later release versions:
 - com.amazonaws:aws-java-sdk-bom [1.12.286 -> 1.12.307]
     https://aws.amazon.com/sdkforjava
 - com.fasterxml.jackson:jackson-bom [2.13.3 -> 2.13.4]
     https://github.com/FasterXML/jackson-bom
 - com.google.protobuf:protobuf-bom [3.21.5 -> 3.21.6]
     https://developers.google.com/protocol-buffers/
 - com.linecorp.armeria:armeria-bom [1.18.0 -> 1.19.0]
     https://armeria.dev/
 - io.grpc:grpc-bom [1.48.1 -> 1.49.1]
     https://github.com/grpc/grpc-java
 - io.opentelemetry.contrib:opentelemetry-aws-xray [1.17.0 -> 1.18.0]
     https://github.com/open-telemetry/opentelemetry-java-contrib
 - io.opentelemetry.javaagent:opentelemetry-javaagent [1.17.0 -> 1.18.0]
     https://github.com/open-telemetry/opentelemetry-java-instrumentation
 - net.bytebuddy:byte-buddy [1.12.13 -> 1.12.17]
     https://bytebuddy.net
 - org.apache.logging.log4j:log4j-bom [2.18.0 -> 2.19.0]
     https://logging.apache.org/
 - org.junit:junit-bom [5.9.0 -> 5.9.1]
     https://junit.org/junit5/
 - org.slf4j:slf4j-api [1.7.36 -> 2.0.2]
     http://www.slf4j.org
 - org.slf4j:slf4j-simple [1.7.36 -> 2.0.2]
     http://www.slf4j.org
 - software.amazon.awssdk:bom [2.17.257 -> 2.17.278]
     https://aws.amazon.com/sdkforjava

Failed to determine the latest version for the following dependencies (use --info for details):
 - io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha
 - io.opentelemetry.proto:opentelemetry-proto

Gradle release-candidate updates:
 - Gradle: [7.4.2 -> 7.5.1]

Generated report file build/dependencyUpdates/report.txt

BUILD SUCCESSFUL in 1m 21s
1 actionable task: 1 executed
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
