### PR TITLE
Update dependencies and Otel to v1.19.0

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -27,24 +27,24 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val TEST_SNAPSHOTS = rootProject.findProperty("testUpstreamSnapshots") == "true"
 
 // This is the only version that affects the released artifact.
-val otelVersion = "1.18.0"
-val otelSnapshotVersion = "1.19.0"
+val otelVersion = "1.19.0"
+val otelSnapshotVersion = "1.20.0"
 
 // All versions below are only used in testing and do not affect the released artifact.
 
 val DEPENDENCY_BOMS = listOf(
-  "com.amazonaws:aws-java-sdk-bom:1.12.321",
-  "com.fasterxml.jackson:jackson-bom:2.13.4",
+  "com.amazonaws:aws-java-sdk-bom:1.12.322",
+  "com.fasterxml.jackson:jackson-bom:2.14.0-rc2",
   "com.google.guava:guava-bom:31.1-jre",
   "com.google.protobuf:protobuf-bom:3.21.7",
   "com.linecorp.armeria:armeria-bom:1.20.1",
-  "io.grpc:grpc-bom:1.49.1",
+  "io.grpc:grpc-bom:1.50.0",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${if (!TEST_SNAPSHOTS) "$otelVersion-alpha" else "$otelSnapshotVersion-alpha-SNAPSHOT"}",
   "org.apache.logging.log4j:log4j-bom:2.19.0",
   "org.junit:junit-bom:5.9.1",
   "org.springframework.boot:spring-boot-dependencies:2.7.4",
   "org.testcontainers:testcontainers-bom:1.17.5",
-  "software.amazon.awssdk:bom:2.17.292"
+  "software.amazon.awssdk:bom:2.17.293"
 )
 
 val DEPENDENCY_SETS = listOf(
@@ -60,7 +60,7 @@ val DEPENDENCY_SETS = listOf(
   ),
   DependencySet(
     "org.slf4j",
-    "1.7.36",
+    "2.0.3",
     listOf(
       "slf4j-api",
       "slf4j-simple"
@@ -72,10 +72,10 @@ val DEPENDENCIES = listOf(
   "commons-logging:commons-logging:1.2",
   "com.sparkjava:spark-core:2.9.4",
   "com.squareup.okhttp3:okhttp:4.10.0",
-  "io.opentelemetry.contrib:opentelemetry-aws-xray:1.17.0",
+  "io.opentelemetry.contrib:opentelemetry-aws-xray:1.19.1",
   "io.opentelemetry.proto:opentelemetry-proto:0.19.0-alpha",
   "io.opentelemetry.javaagent:opentelemetry-javaagent:${if (!TEST_SNAPSHOTS) otelVersion else "$otelSnapshotVersion-SNAPSHOT"}",
-  "net.bytebuddy:byte-buddy:1.12.17"
+  "net.bytebuddy:byte-buddy:1.12.18"
 )
 
 javaPlatform {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@
 pluginManagement {
   plugins {
     id("com.diffplug.spotless") version "6.11.0"
-    id("com.github.ben-manes.versions") version "0.42.0"
+    id("com.github.ben-manes.versions") version "0.43.0"
     id("com.github.jk1.dependency-license-report") version "2.1"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("com.google.cloud.tools.jib") version "3.3.0"


### PR DESCRIPTION
**Description of changes:** Update dependencies to release v1.19.0

Obs.:
* org.slf4j 2.0.3 is backwards compatible with the last version published in the 1.x series. The only difference is that 2.0.3 requires Java 8.
* Updating jacksom-bom to 2.14.0-rc2 because it is only used in tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
