### PR TITLE
Cleanup for release v1.19.0

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,8 +20,14 @@ jobs:
         with:
           java-version: 17
       - uses: gradle/wrapper-validation-action@v1
-      - name: Build with Gradle
+      - name: Build with Gradle with Integration tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --stacktrace -PenableCoverage=true -PlocalDocker=true
+          arguments: build integrationTests --stacktrace -PenableCoverage=true -PlocalDocker=true
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        with:
+          arguments: build --stacktrace -PenableCoverage=true
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --stacktrace -PenableCoverage=true
+          arguments: build --stacktrace -PenableCoverage=true -PlocalDocker=true
       - uses: codecov/codecov-action@v1

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+  `kotlin-dsl`
+}
+repositories {
+  mavenCentral()
+  gradlePluginPortal()
+  mavenLocal()
+}
+
+dependencies {
+  implementation("com.google.cloud.tools:jib-gradle-plugin:3.3.0")
+}

--- a/buildSrc/src/main/kotlin/software/amazon/adot/GradleUtils.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/adot/GradleUtils.kt
@@ -1,0 +1,37 @@
+package software.amazon.adot
+
+import com.google.cloud.tools.jib.gradle.JibExtension
+
+/**
+ * Utilitary extension function used to configure jib according to flags. Used to avoid having branching in each build
+ * script.
+ */
+fun JibExtension.configureImages(sourceImage:String, destinationImage: String, localDocker: Boolean, multiPlatform: Boolean, tags: Set<String> = setOf<String>()) {
+  to {
+    image = destinationImage
+    if (!tags.isEmpty()) {
+      this.tags = tags;
+    }
+  }
+
+  from {
+    if (localDocker) {
+      image = "docker://$sourceImage"
+    } else {
+      image = sourceImage
+    }
+
+    if (multiPlatform) {
+      platforms {
+        platform {
+          architecture = "amd64"
+          os = "linux"
+        }
+        platform {
+          architecture = "arm64"
+          os = "linux"
+        }
+      }
+    }
+  }
+}

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -34,7 +34,7 @@ val otelSnapshotVersion = "1.20.0"
 
 val DEPENDENCY_BOMS = listOf(
   "com.amazonaws:aws-java-sdk-bom:1.12.322",
-  "com.fasterxml.jackson:jackson-bom:2.14.0-rc2",
+  "com.fasterxml.jackson:jackson-bom:2.13.4.20221013",
   "com.google.guava:guava-bom:31.1-jre",
   "com.google.protobuf:protobuf-bom:3.21.7",
   "com.linecorp.armeria:armeria-bom:1.20.1",
@@ -60,7 +60,7 @@ val DEPENDENCY_SETS = listOf(
   ),
   DependencySet(
     "org.slf4j",
-    "2.0.3",
+    "1.7.36",
     listOf(
       "slf4j-api",
       "slf4j-simple"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs= \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+
+# Flag used in the jib plugin to inform if we should use multi platform and pull from local docker.
+localDocker=false

--- a/otelagent/build.gradle.kts
+++ b/otelagent/build.gradle.kts
@@ -14,7 +14,7 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
+import software.amazon.adot.configureImages
 plugins {
   java
   `maven-publish`
@@ -131,22 +131,13 @@ tasks {
 }
 
 jib {
-  to {
-    image = "public.ecr.aws/u0d6r4y4/aws-opentelemetry-java-base:alpha"
-  }
-  from {
-    image = "gcr.io/distroless/java17-debian11:debug"
-    platforms {
-      platform {
-        architecture = "amd64"
-        os = "linux"
-      }
-      platform {
-        architecture = "arm64"
-        os = "linux"
-      }
-    }
-  }
+  configureImages(
+    "gcr.io/distroless/java17-debian11:debug",
+    "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
+    localDocker = false,
+    multiPlatform = !rootProject.property("localDocker")!!.equals("true")
+  )
+
   container {
     appRoot = "/aws-observability"
     setEntrypoint("INHERIT")

--- a/sample-apps/spark-awssdkv1/build.gradle.kts
+++ b/sample-apps/spark-awssdkv1/build.gradle.kts
@@ -34,4 +34,7 @@ tasks {
   named("jib") {
     dependsOn(":otelagent:jib")
   }
+  named("jibDockerBuild") {
+    dependsOn(":otelagent:jibDockerBuild")
+  }
 }

--- a/sample-apps/spark-awssdkv1/build.gradle.kts
+++ b/sample-apps/spark-awssdkv1/build.gradle.kts
@@ -1,3 +1,5 @@
+import software.amazon.adot.configureImages
+
 plugins {
   java
 
@@ -19,23 +21,13 @@ application {
 }
 
 jib {
-  to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark-awssdkv1"
+  configureImages(
+    "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
+    "public.ecr.aws/aws-otel-test/aws-otel-java-spark-awssdkv1",
+    localDocker = rootProject.property("localDocker")!!.equals("true"),
+    multiPlatform = !rootProject.property("localDocker")!!.equals("true"),
     tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
-  }
-  from {
-    image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"
-    platforms {
-      platform {
-        architecture = "amd64"
-        os = "linux"
-      }
-      platform {
-        architecture = "arm64"
-        os = "linux"
-      }
-    }
-  }
+  )
 }
 
 tasks {

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -1,3 +1,5 @@
+import software.amazon.adot.configureImages
+
 plugins {
   java
 
@@ -22,27 +24,21 @@ application {
 }
 
 jib {
-  to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-spark"
+  configureImages(
+    "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
+    "public.ecr.aws/aws-otel-test/aws-otel-java-spark",
+    localDocker = rootProject.property("localDocker")!!.equals("true"),
+    multiPlatform = !rootProject.property("localDocker")!!.equals("true"),
     tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
-  }
-  from {
-    image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"
-    platforms {
-      platform {
-        architecture = "amd64"
-        os = "linux"
-      }
-      platform {
-        architecture = "arm64"
-        os = "linux"
-      }
-    }
-  }
+  )
 }
 
 tasks {
   named("jib") {
     dependsOn(":otelagent:jib")
   }
+}
+
+tasks.named("jibDockerBuild") {
+  dependsOn(":otelagent:jibDockerBuild")
 }

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -37,8 +37,7 @@ tasks {
   named("jib") {
     dependsOn(":otelagent:jib")
   }
-}
-
-tasks.named("jibDockerBuild") {
-  dependsOn(":otelagent:jibDockerBuild")
+  named("jibDockerBuild") {
+    dependsOn(":otelagent:jibDockerBuild")
+  }
 }

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -1,3 +1,5 @@
+import software.amazon.adot.configureImages
+
 plugins {
   java
   id("org.springframework.boot")
@@ -14,23 +16,13 @@ dependencies {
 }
 
 jib {
-  to {
-    image = "public.ecr.aws/aws-otel-test/aws-otel-java-springboot"
+  configureImages(
+    "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
+    "public.ecr.aws/aws-otel-test/aws-otel-java-springboot",
+    rootProject.property("localDocker")!!.equals("true"),
+    !rootProject.property("localDocker")!!.equals("true"),
     tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
-  }
-  from {
-    image = "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha"
-    platforms {
-      platform {
-        architecture = "amd64"
-        os = "linux"
-      }
-      platform {
-        architecture = "arm64"
-        os = "linux"
-      }
-    }
-  }
+  )
 }
 
 tasks {

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -29,4 +29,8 @@ tasks {
   named("jib") {
     dependsOn(":otelagent:jib")
   }
+
+  named("jibDockerBuild") {
+    dependsOn(":otelagent:jibDockerBuild")
+  }
 }

--- a/smoke-tests/runner/build.gradle.kts
+++ b/smoke-tests/runner/build.gradle.kts
@@ -44,4 +44,11 @@ tasks {
         .getAsFile().absolutePath}"
     )
   }
+  named("test") {
+    // Make sure that images used during tests are available locally.
+    dependsOn(":sample-apps:spark:jibDockerBuild")
+    dependsOn(":sample-apps:springboot:jibDockerBuild")
+    dependsOn(":smoke-tests:spring-boot:jibDockerBuild")
+    dependsOn(":smoke-tests:fakebackend:jibDockerBuild")
+  }
 }

--- a/smoke-tests/runner/build.gradle.kts
+++ b/smoke-tests/runner/build.gradle.kts
@@ -44,7 +44,17 @@ tasks {
         .getAsFile().absolutePath}"
     )
   }
-  named("test") {
+
+  register("jibDockerBuildAll")
+  register("integrationTests")
+
+  named("integrationTests") {
+    dependsOn("test")
+    dependsOn("jibDockerBuildAll")
+    findByName("test")?.mustRunAfter("jibDockerBuildAll")
+  }
+
+  named("jibDockerBuildAll") {
     // Make sure that images used during tests are available locally.
     dependsOn(":sample-apps:spark:jibDockerBuild")
     dependsOn(":sample-apps:springboot:jibDockerBuild")

--- a/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
+++ b/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/SpringBootSmokeTest.java
@@ -98,7 +98,7 @@ class SpringBootSmokeTest {
 
   @Container
   private static final GenericContainer<?> backend =
-      new GenericContainer<>("public.ecr.aws/u0d6r4y4/aws-otel-java-test-fakebackend:alpha")
+      new GenericContainer<>("public.ecr.aws/aws-otel-test/aws-otel-java-test-fakebackend:alpha")
           .withExposedPorts(8080)
           .waitingFor(Wait.forHttp("/health").forPort(8080))
           .withLogConsumer(new Slf4jLogConsumer(backendLogger))
@@ -107,7 +107,8 @@ class SpringBootSmokeTest {
 
   @Container
   private static final GenericContainer<?> application =
-      new GenericContainer<>("public.ecr.aws/u0d6r4y4/aws-otel-java-smoketests-springboot:latest")
+      new GenericContainer<>(
+              "public.ecr.aws/aws-otel-test/aws-otel-java-smoketests-springboot:latest")
           .dependsOn(backend)
           .withExposedPorts(8080)
           .withNetwork(network)
@@ -122,7 +123,8 @@ class SpringBootSmokeTest {
 
   @Container
   private static final GenericContainer<?> applicationXraySampler =
-      new GenericContainer<>("public.ecr.aws/u0d6r4y4/aws-otel-java-smoketests-springboot:latest")
+      new GenericContainer<>(
+              "public.ecr.aws/aws-otel-test/aws-otel-java-smoketests-springboot:latest")
           .dependsOn(backend)
           .withExposedPorts(8080)
           .withNetwork(network)

--- a/smoke-tests/spring-boot/build.gradle.kts
+++ b/smoke-tests/spring-boot/build.gradle.kts
@@ -13,6 +13,23 @@
  * permissions and limitations under the License.
  */
 
+import software.amazon.adot.configureImages
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 plugins {
   java
   id("com.google.cloud.tools.jib")
@@ -29,16 +46,19 @@ dependencies {
 }
 
 jib {
-  to {
-    image = "public.ecr.aws/u0d6r4y4/aws-otel-java-smoketests-springboot"
-  }
-  from {
-    image = "public.ecr.aws/u0d6r4y4/aws-opentelemetry-java-base:alpha"
-  }
+  configureImages(
+    "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
+    "public.ecr.aws/aws-otel-test/aws-otel-java-smoketests-springboot",
+    localDocker = rootProject.property("localDocker")!!.equals("true"),
+    multiPlatform = false
+  )
 }
 
 tasks {
   named("jib") {
     dependsOn(":otelagent:jib")
+  }
+  named("jibDockerBuild") {
+    dependsOn(":otelagent:jibDockerBuild")
   }
 }


### PR DESCRIPTION
*Description of changes:* 
* Update jacksom bom to the latest stable version.
* Revert update in org.slf4j dependency. This was breaking integration tests because the test application stopped working as intended.
* Updated all tests and workflows to point to the registry `aws-otel-test`
* Create `integrationTests` task that is able to run locally exclusively so that the pr-build gh action can be idempotent. (previously it was depending on artifacts generated during the main-build gh action). This required adding some specific logic in the `jib` plugin because local docker daemon does not handle multiplatform images.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
