### PR TITLE
Use us-west-2 region for publishing Github workflow metrics

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -153,7 +153,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Publish CI status
         run: |

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Publish CI status
         run: |


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

Use us-west-2 region for publishing Github workflow metrics


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
