### PR TITLE
Use reusable workflow to publish status

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -145,29 +145,17 @@ jobs:
           VALIDATOR_COMMAND: -c spark-otel-trace-metric-validation.yml --endpoint http://app:4567 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}
 
   publish-build-status:
-    runs-on: ubuntu-latest
     needs: [test_Spring_App_With_Java_Agent, test_Spark_App_With_Java_Agent, test_Spark_AWS_SDK_V1_App_With_Java_Agent]
-    if: always()
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.METRICS_ROLE_ARN }}
-          aws-region: us-west-2
-          role-duration-seconds: 21600
-
-      - name: Publish CI status
-        run: |
-          if [ '${{ needs.test_Spring_App_With_Java_Agent.result }}' = 'success' ] && \
-             [ '${{ needs.test_Spark_App_With_Java_Agent.result }}' = 'success' ] && \
-             [ '${{ needs.test_Spark_AWS_SDK_V1_App_With_Java_Agent.result }}' = 'success' ]; then
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main-build \
-              --value 1.0
-          else
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main-build \
-              --value 0.0
-          fi
+    if: ${{ always() }}
+    uses: ./.github/workflows/publish-status.yml
+    with:
+      namespace: 'ADOT/GitHubActions'
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      workflow: main-build
+      success: ${{ needs.test_Spring_App_With_Java_Agent.result == 'success'  &&
+                   needs.test_Spark_App_With_Java_Agent.result }}' == 'success'  &&
+                   needs.test_Spark_AWS_SDK_V1_App_With_Java_Agent.result == 'success' }}
+      region: us-west-2
+    secrets:
+      roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -47,27 +47,16 @@ jobs:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar
   publish-build-status:
-    runs-on: ubuntu-latest
     needs: [build]
-    if: always()
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.METRICS_ROLE_ARN }}
-          aws-region: us-west-2
-          role-duration-seconds: 21600
+    if: ${{ always() }}
+    uses: ./.github/workflows/publish-status.yml
+    with:
+      namespace: 'ADOT/GitHubActions'
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      workflow: nightly-upstream-snapshot-build
+      success: ${{ needs.build.result == 'success' }}
+      region: us-west-2
+    secrets:
+      roleArn: ${{ secrets.METRICS_ROLE_ARN }}
 
-      - name: Publish CI status
-        run: |
-          if [ '${{ needs.build.result }}' = 'success' ]; then
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=nightly-upstream-snapshot-build \
-              --value 1.0
-          else
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=nightly-upstream-snapshot-build \
-              --value 0.0
-          fi

--- a/.github/workflows/publish-status.yml
+++ b/.github/workflows/publish-status.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       branch:
-        require: true
+        required: true
         type: string
       workflow:
         required: true

--- a/.github/workflows/publish-status.yml
+++ b/.github/workflows/publish-status.yml
@@ -1,0 +1,59 @@
+# Reusable workflow used to publish status of the caller github workflow to Cloudwatch metrics
+name: Publish status
+on:
+  workflow_call:
+    inputs:
+      # Cloudwatch Metrics namespace
+      namespace:
+        required: true
+        type: string
+      # Dimensions
+      repository:
+        required: true
+        type: string
+      branch:
+        require: true
+        type: string
+      workflow:
+        required: true
+        type: string
+      # Metric name
+      success:
+        required: true
+        type: boolean
+      # Region where the metric is published
+      region:
+        required: true
+        type: string
+    secrets:
+      roleArn:
+        required: true
+
+jobs:
+  publish-status:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.roleArn }}
+          aws-region: ${{ inputs.region }}
+          role-duration-seconds: 21600
+
+      - name: Publish status success
+        if: ${{ inputs.success }}
+        run: |
+          aws cloudwatch put-metric-data --namespace '${{ inputs.namespace }}' \
+            --metric-name Success \
+            --dimensions repository=${{ inputs.repository }},branch=${{ inputs.branch }},workflow=${{ inputs.workflow }} \
+            --value 1.0
+      - name: Publish status failure
+        if: ${{ !inputs.success }}
+        run: |
+          aws cloudwatch put-metric-data --namespace '${{ inputs.namespace }}' \
+            --metric-name Success \
+            --dimensions repository=${{ inputs.repository }},branch=${{ inputs.branch }},workflow=${{ inputs.workflow }} \
+            --value 0.0


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

*Description of changes:* Use reusable workflow to publish status of other workflows. This will make it easier to have a central place for storing reusable workflows in the future as we will need to change just the name of the workflow while the parameters will remain the same.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
