### PR TITLE
Fix regex in log4j test

### DIFF
--- a/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/LogInjectionTest.java
+++ b/smoke-tests/runner/src/test/java/io/awsobservability/instrumentation/smoketests/runner/LogInjectionTest.java
@@ -74,12 +74,11 @@ class LogInjectionTest {
         .get("/outgoing-http-call")
         .aggregate()
         .join();
-
     // Log message has X-Ray trace ID.
     assertThat(log4jString.toUtf8String())
         .matches(
             Pattern.compile(
-                ".*1-[0-9a-f]{8}-[0-9a-f]{24}@[0-9a-f]{16} - Executing outgoing-http-call.*",
+                ".*1-[0-9a-f]{8}-[0-9a-f]{24}@[0-9a-f]{16} INFO  Executing outgoing-http-call.*",
                 Pattern.DOTALL));
   }
 


### PR DESCRIPTION
Fixes regex used in in log4j injection test because of changes made in PR #227 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
