### PR TITLE
Add new process for patch releases

### DIFF
--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -2,7 +2,6 @@ name: "Patch dependencies"
 description: |
   Patches direct dependencies of this project leveraging maven local to publish the results.
 
-  This workflow will be noop if there is no dependency to patch, i.e.: no files in `.github/patchs`
   This workflow supports patching opentelemetry-java and opentelemetry-java-instrumentation repositories by executing
   the `patch.sh` script that will try to patch those repositories and after that will optionally test and then publish
   the artifacts to maven local.
@@ -14,6 +13,9 @@ inputs:
     default: "false"
     required: false
     description: "If the workflow should run tests of the dependencies. Anything different than false will evaluate to true"
+  branch:
+    required: true
+    description: "The branch where this patches are being applied e.g.: release/v1.21.x"
   gpg_private_key:
     description: "The gpg key used to sign the artifacts"
     required: true
@@ -25,19 +27,19 @@ runs:
   steps:
     - name: check patches
       run: |
-        if [[ -f .github/patchs/opentelemetry-java.patch ]]; then
+        if [[ -f .github/patches/${{ inputs.branch }}/opentelemetry-java.patch ]]; then
           echo 'patch_otel_java=true' >> $GITHUB_ENV
         fi
-        if [[ -f .github/patchs/opentelemetry-java-instrumentation.patch ]]; then
+        if [[ -f .github/patches/${{ inputs.branch }}/opentelemetry-java-instrumentation.patch ]]; then
             echo 'patch_otel_java_instrumentation=true' >> $GITHUB_ENV
         fi
-        if [[ -f .github/patchs/opentelemetry-java-contrib.patch ]]; then
+        if [[ -f .github/patches/${{ inputs.branch }}/opentelemetry-java-contrib.patch ]]; then
             echo 'patch_otel_java_contrib=true' >> $GITHUB_ENV
         fi
       shell: bash
 
     - name: Clone and patch repositories
-      run: .github/scripts/patch.sh
+      run: .github/scripts/patch.sh "${{ inputs.branch }}"
       if: ${{ env.patch_otel_java == 'true' ||
               env.patch_otel_java_instrumentation == 'true' ||
               env.patch_otel_java_contrib == 'true' }}

--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -1,0 +1,79 @@
+name: "Patch dependencies"
+description: |
+  Patches direct dependencies of this project leveraging maven local to publish the results.
+
+  This workflow will be noop if there is no dependency to patch, i.e.: no files in `.github/patchs`
+  This workflow supports patching opentelemetry-java and opentelemetry-java-instrumentation repositories by executing
+  the `patch.sh` script that will try to patch those repositories and after that will optionally test and then publish
+  the artifacts to maven local.
+  To add a patch you have to add a file in the `.github/patches/` directory with the name of the repository that must
+  be patched.
+  This action assumes that java was set correctly.
+inputs:
+  run_tests:
+    default: "false"
+    required: false
+    description: "If the workflow should run tests of the dependencies. Anything different than false will evaluate to true"
+  gpg_private_key:
+    description: "The gpg key used to sign the artifacts"
+    required: true
+  gpg_password:
+    description: "The gpg key password"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: check patches
+      run: |
+        if [[ -f .github/patchs/opentelemetry-java.patch ]]; then
+          echo 'patch_otel_java=true' >> $GITHUB_ENV
+        fi
+        if [[ -f .github/patchs/opentelemetry-java-instrumentation.patch ]]; then
+            echo 'patch_otel_java_instrumentation=true' >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Clone and patch repositories
+      if: ${{ env.patch_otel_java == 'true' && env.patch_otel_java_instrumentation == 'true' }}
+      run: .github/scripts/patch.sh
+      shell: bash
+
+    - name: Build opentelemetry-java with tests
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build publishToMavenLocal
+        build-root-directory: opentelemetry-java
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        GPG_PASSWORD: ${{ inputs.gpg_password }}
+      if: ${{ env.patch_otel_java == 'true' && inputs.run_tests != 'false' }}
+
+    - name: Build opentelemetry-java
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: publishToMavenLocal
+        build-root-directory: opentelemetry-java
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        GPG_PASSWORD: ${{ inputs.gpg_password }}
+      if: ${{ env.patch_otel_java == 'true' && inputs.run_tests == 'false' }}
+
+    - name: Build opentelemetry-java-instrumentation with tests
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: check -x spotlessCheck publishToMavenLocal
+        build-root-directory: opentelemetry-java-instrumentation
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        GPG_PASSWORD: ${{ inputs.gpg_password }}
+      if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests != 'false' }}
+
+    - name: Build opentelemetry java instrumentation
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: publishToMavenLocal
+        build-root-directory: opentelemetry-java-instrumentation
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        GPG_PASSWORD: ${{ inputs.gpg_password }}
+      if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests == 'false' }}

--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -31,49 +31,74 @@ runs:
         if [[ -f .github/patchs/opentelemetry-java-instrumentation.patch ]]; then
             echo 'patch_otel_java_instrumentation=true' >> $GITHUB_ENV
         fi
+        if [[ -f .github/patchs/opentelemetry-java-contrib.patch ]]; then
+            echo 'patch_otel_java_contrib=true' >> $GITHUB_ENV
+        fi
       shell: bash
 
     - name: Clone and patch repositories
-      if: ${{ env.patch_otel_java == 'true' && env.patch_otel_java_instrumentation == 'true' }}
       run: .github/scripts/patch.sh
+      if: ${{ env.patch_otel_java == 'true' OR
+              env.patch_otel_java_instrumentation == 'true' OR
+              env.patch_otel_java_contrib == 'true' }}
       shell: bash
 
     - name: Build opentelemetry-java with tests
       uses: gradle/gradle-build-action@v2
+      if: ${{ env.patch_otel_java == 'true' && inputs.run_tests != 'false' }}
       with:
         arguments: build publishToMavenLocal
         build-root-directory: opentelemetry-java
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
-      if: ${{ env.patch_otel_java == 'true' && inputs.run_tests != 'false' }}
 
     - name: Build opentelemetry-java
       uses: gradle/gradle-build-action@v2
+      if: ${{ env.patch_otel_java == 'true' && inputs.run_tests == 'false' }}
       with:
         arguments: publishToMavenLocal
         build-root-directory: opentelemetry-java
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
-      if: ${{ env.patch_otel_java == 'true' && inputs.run_tests == 'false' }}
+
+    - name: Build opentelemetry-java-contrib with tests
+      uses: gradle/gradle-build-action@v2
+      if: ${{ env.patch_otel_java_contrib == 'true' && inputs.run_tests != 'false' }}
+      with:
+        arguments: build publishToMavenLocal
+        build-root-directory: opentelemetry-java-contrib
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        GPG_PASSWORD: ${{ inputs.gpg_password }}
+
+    - name: Build opentelemetry-java-contrib
+      uses: gradle/gradle-build-action@v2
+      if: ${{ env.patch_otel_java_contrib == 'true' && inputs.run_tests == 'false' }}
+      with:
+        arguments: publishToMavenLocal
+        build-root-directory: opentelemetry-java-contrib
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        GPG_PASSWORD: ${{ inputs.gpg_password }}
 
     - name: Build opentelemetry-java-instrumentation with tests
       uses: gradle/gradle-build-action@v2
+      if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests != 'false' }}
       with:
         arguments: check -x spotlessCheck publishToMavenLocal
         build-root-directory: opentelemetry-java-instrumentation
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
-      if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests != 'false' }}
 
     - name: Build opentelemetry java instrumentation
       uses: gradle/gradle-build-action@v2
+      if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests == 'false' }}
       with:
         arguments: publishToMavenLocal
         build-root-directory: opentelemetry-java-instrumentation
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
-      if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests == 'false' }}

--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -38,8 +38,8 @@ runs:
 
     - name: Clone and patch repositories
       run: .github/scripts/patch.sh
-      if: ${{ env.patch_otel_java == 'true' OR
-              env.patch_otel_java_instrumentation == 'true' OR
+      if: ${{ env.patch_otel_java == 'true' ||
+              env.patch_otel_java_instrumentation == 'true' ||
               env.patch_otel_java_contrib == 'true' }}
       shell: bash
 

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -1,11 +1,19 @@
-#!/bin/bash -x
+#!/bin/bash -x -e -o nounset
 
-exit 1 # Remove this lock after updating the following values
+# .github/patchs/.versions.sh should define all the versions of the dependencies that we are going to patch
+# This is used so that we can properly clone the upstream repositories.
+# This file should define the following variables:
+# OTEL_JAVA_VERSION. Tag of the opentelemetry-java repository to use. E.g.: JAVA_OTEL_JAVA_VERSION=v1.21.0
+# OTEL_JAVA_INSTRUMENTATION_VERSION. Tag of the opentelemetry-java-instrumentation repository to use, e.g.: OTEL_JAVA_INSTRUMENTATION_VERSION=v1.21.0
+# OTEL_JAVA_CONTRIB_VERSION. Tag of the opentelemetry-java-contrib repository. E.g.: OTEL_JAVA_CONTRIB_VERSION=v1.21.0
+# This script will fail if a variable that is supposed to exist is referenced.
 
-OTEL_JAVA_VERSION=1.21.0
-OTEL_JAVA_INSTRUMENTATION_VERSION=1.21.0
-OTEL_CONTRIB_VERSION=1.21.0
-PATCH_VERSION=1.21.1-adot
+if [[ ! -f .github/patchs/versions ]]; then
+  echo "No versions file found. Skipping patching"
+  exit 0
+fi
+
+source .github/patchs/versions
 
 git config --global user.email "github-actions@github.com"
 git config --global user.name "github-actions"
@@ -15,9 +23,9 @@ OTEL_JAVA_PATCH=".github/patchs/opentelemetry-java.patch"
 if [[ -f "$OTEL_JAVA_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java.git
   cd opentelemetry-java
-  git checkout v${OTEL_JAVA_VERSION} -b tag-v${OTEL_JAVA_VERSION}
+  git checkout ${OTEL_JAVA_VERSION} -b tag-${OTEL_JAVA_VERSION}
   patch -p1 < ../${OTEL_JAVA_PATCH}
-  git commit -a -m "Patching to release ${PATCH_VERSION}"
+  git commit -a -m "ADOT Patch release"
   cd -
 else
   echo "Skiping patching opentelemetry-java"
@@ -28,9 +36,9 @@ OTEL_JAVA_CONTRIB_PATCH=".github/patchs/opentelemetry-java-contrib.patch"
 if [[ -f "$OTEL_JAVA_CONTRIB_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-contrib.git
   cd opentelemetry-java-contrib
-  git checkout v${OTEL_JAVA_CONTRIB_VERSION} -b tag-v${OTEL_JAVA_CONTRIB_VERSION}
+  git checkout ${OTEL_JAVA_CONTRIB_VERSION} -b tag-${OTEL_JAVA_CONTRIB_VERSION}
   patch -p1 < "../${OTEL_JAVA_CONTRIB_PATCH}"
-  git commit -a -m "Patching to release ${PATCH_VERSION}"
+  git commit -a -m "ADOT Patch release"
   cd -
 else
   echo "Skipping patching opentelemetry-java-contrib"
@@ -41,9 +49,9 @@ OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patchs/opentelemetry-java-instrumentati
 if [[ -f "$OTEL_JAVA_INSTRUMENTATION_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-instrumentation.git
   cd opentelemetry-java-instrumentation
-  git checkout v${OTEL_JAVA_INSTRUMENTATION_VERSION} -b tag-v${OTEL_JAVA_INSTRUMENTATION_VERSION}
+  git checkout ${OTEL_JAVA_INSTRUMENTATION_VERSION} -b tag-${OTEL_JAVA_INSTRUMENTATION_VERSION}
   patch -p1 < "../${OTEL_JAVA_INSTRUMENTATION_PATCH}"
-  git commit -a -m "Patching to release ${PATCH_VERSION}"
+  git commit -a -m "ADOT Patch release"
   cd -
 else
   echo "Skipping patching opentelemetry-java-instrumentation"

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -33,7 +33,7 @@ if [[ -f "$OTEL_JAVA_CONTRIB_PATCH" ]]; then
   git commit -a -m "Patching to release ${PATCH_VERSION}"
   cd -
 else
-  echo "Skipping patching opentelemetry-java-instrumentation"
+  echo "Skipping patching opentelemetry-java-contrib"
 fi
 
 

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -x -e -o nounset
+#!/bin/bash
+# Enable debug mode, fail on any command that fail in this script and fail on unset variables
+set -x -e -u
 
 # .github/patchs/.versions.sh should define all the versions of the dependencies that we are going to patch
 # This is used so that we can properly clone the upstream repositories.

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -x
 
-exit 1 # The following values must be change before every new patch release
+exit 1 # Remove this lock after updating the following values
+
 OTEL_JAVA_VERSION=1.21.0
 OTEL_JAVA_INSTRUMENTATION_VERSION=1.21.0
 OTEL_CONTRIB_VERSION=1.21.0
 PATCH_VERSION=1.21.1-adot
 
-git config user.name github-actions
-git config user.email github-actions@github.com
+git config --global user.email "github-actions@github.com"
+git config --global user.name "github-actions"
+
 
 OTEL_JAVA_PATCH=".github/patchs/opentelemetry-java.patch"
 if [[ -f "$OTEL_JAVA_PATCH" ]]; then
@@ -21,6 +23,20 @@ else
   echo "Skiping patching opentelemetry-java"
 fi
 
+
+OTEL_JAVA_CONTRIB_PATCH=".github/patchs/opentelemetry-java-contrib.patch"
+if [[ -f "$OTEL_JAVA_CONTRIB_PATCH" ]]; then
+  git clone https://github.com/open-telemetry/opentelemetry-java-contrib.git
+  cd opentelemetry-java-contrib
+  git checkout v${OTEL_JAVA_CONTRIB_VERSION} -b tag-v${OTEL_JAVA_CONTRIB_VERSION}
+  patch -p1 < "../${OTEL_JAVA_CONTRIB_PATCH}"
+  git commit -a -m "Patching to release ${PATCH_VERSION}"
+  cd -
+else
+  echo "Skipping patching opentelemetry-java-instrumentation"
+fi
+
+
 OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patchs/opentelemetry-java-instrumentation.patch"
 if [[ -f "$OTEL_JAVA_INSTRUMENTATION_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-instrumentation.git
@@ -28,6 +44,7 @@ if [[ -f "$OTEL_JAVA_INSTRUMENTATION_PATCH" ]]; then
   git checkout v${OTEL_JAVA_INSTRUMENTATION_VERSION} -b tag-v${OTEL_JAVA_INSTRUMENTATION_VERSION}
   patch -p1 < "../${OTEL_JAVA_INSTRUMENTATION_PATCH}"
   git commit -a -m "Patching to release ${PATCH_VERSION}"
+  cd -
 else
   echo "Skipping patching opentelemetry-java-instrumentation"
 fi

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+
+exit 1 # The following values must be change before every new patch release
+OTEL_JAVA_VERSION=1.21.0
+OTEL_JAVA_INSTRUMENTATION_VERSION=1.21.0
+OTEL_CONTRIB_VERSION=1.21.0
+PATCH_VERSION=1.21.1-adot
+
+git config user.name github-actions
+git config user.email github-actions@github.com
+
+OTEL_JAVA_PATCH=".github/patchs/opentelemetry-java.patch"
+if [[ -f "$OTEL_JAVA_PATCH" ]]; then
+  git clone https://github.com/open-telemetry/opentelemetry-java.git
+  cd opentelemetry-java
+  git checkout v${OTEL_JAVA_VERSION} -b tag-v${OTEL_JAVA_VERSION}
+  patch -p1 < ../${OTEL_JAVA_PATCH}
+  git commit -a -m "Patching to release ${PATCH_VERSION}"
+  cd -
+else
+  echo "Skiping patching opentelemetry-java"
+fi
+
+OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patchs/opentelemetry-java-instrumentation.patch"
+if [[ -f "$OTEL_JAVA_INSTRUMENTATION_PATCH" ]]; then
+  git clone https://github.com/open-telemetry/opentelemetry-java-instrumentation.git
+  cd opentelemetry-java-instrumentation
+  git checkout v${OTEL_JAVA_INSTRUMENTATION_VERSION} -b tag-v${OTEL_JAVA_INSTRUMENTATION_VERSION}
+  patch -p1 < "../${OTEL_JAVA_INSTRUMENTATION_PATCH}"
+  git commit -a -m "Patching to release ${PATCH_VERSION}"
+else
+  echo "Skipping patching opentelemetry-java-instrumentation"
+fi

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -2,7 +2,10 @@
 # Enable debug mode, fail on any command that fail in this script and fail on unset variables
 set -x -e -u
 
-# .github/patchs/.versions.sh should define all the versions of the dependencies that we are going to patch
+# This parameter will help find the patches to be applied
+BRANCH=$1
+
+# .github/patches/$BRANCH/versions.sh should define all the versions of the dependencies that we are going to patch
 # This is used so that we can properly clone the upstream repositories.
 # This file should define the following variables:
 # OTEL_JAVA_VERSION. Tag of the opentelemetry-java repository to use. E.g.: JAVA_OTEL_JAVA_VERSION=v1.21.0
@@ -10,18 +13,18 @@ set -x -e -u
 # OTEL_JAVA_CONTRIB_VERSION. Tag of the opentelemetry-java-contrib repository. E.g.: OTEL_JAVA_CONTRIB_VERSION=v1.21.0
 # This script will fail if a variable that is supposed to exist is referenced.
 
-if [[ ! -f .github/patchs/versions ]]; then
+if [[ ! -f .github/patches/${BRANCH}/versions ]]; then
   echo "No versions file found. Skipping patching"
   exit 0
 fi
 
-source .github/patchs/versions
+source .github/patches/${BRANCH}/versions
 
-git config --global user.email "github-actions@github.com"
-git config --global user.name "github-actions"
+git config --global user.email "adot-patch-workflow@github.com"
+git config --global user.name "ADOT Patch workflow"
 
 
-OTEL_JAVA_PATCH=".github/patchs/opentelemetry-java.patch"
+OTEL_JAVA_PATCH=".github/patches/${BRANCH}/opentelemetry-java.patch"
 if [[ -f "$OTEL_JAVA_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java.git
   cd opentelemetry-java
@@ -34,7 +37,7 @@ else
 fi
 
 
-OTEL_JAVA_CONTRIB_PATCH=".github/patchs/opentelemetry-java-contrib.patch"
+OTEL_JAVA_CONTRIB_PATCH=".github/patches/${BRANCH}/opentelemetry-java-contrib.patch"
 if [[ -f "$OTEL_JAVA_CONTRIB_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-contrib.git
   cd opentelemetry-java-contrib
@@ -47,7 +50,7 @@ else
 fi
 
 
-OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patchs/opentelemetry-java-instrumentation.patch"
+OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patches/${BRANCH}/opentelemetry-java-instrumentation.patch"
 if [[ -f "$OTEL_JAVA_INSTRUMENTATION_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-instrumentation.git
   cd opentelemetry-java-instrumentation

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,7 +15,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
+    if: ${{ startsWith(github.ref_name, 'release/v') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
@@ -42,7 +42,7 @@ jobs:
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
+        if: ${{ startsWith(github.ref_name, 'release/v') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           run_tests: "true"
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_password: ${{ secrets.GPG_PASSWORD }}
+          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
   build:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
         if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_password: ${{ secrets.GPG_PASSWORD }}
+          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
       - uses: gradle/wrapper-validation-action@v1
       - name: Configure AWS Credentials

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - "release-*"
+      - "release/v*"
 env:
   AWS_DEFAULT_REGION: us-east-1
 
@@ -15,7 +15,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, 'refs/heads/release-') }}
+    if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
@@ -39,12 +39,14 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
+        if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSWORD }}
-        if: ${{ contains(github.ref, 'refs/heads/release-') }}
+
       - uses: gradle/wrapper-validation-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"
+          branch: ${{ github.ref_name }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -44,6 +45,7 @@ jobs:
         uses: ./.github/actions/patch-dependencies
         if: ${{ startsWith(github.ref_name, 'release/v') }}
         with:
+          branch: ${{ github.ref_name }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-
+      - "release-*"
 env:
   AWS_DEFAULT_REGION: us-east-1
 
@@ -12,15 +12,39 @@ permissions:
   contents: read
 
 jobs:
+  testpatch:
+    name: Test patches applied to dependencies
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'refs/heads/release-') }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: ./.github/actions/patch-dependencies
+        with:
+          run_tests: "true"
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_password: ${{ secrets.GPG_PASSWORD }}
+
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: temurin
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_password: ${{ secrets.GPG_PASSWORD }}
+        if: ${{ contains(github.ref, 'refs/heads/release-') }}
       - uses: gradle/wrapper-validation-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,7 +9,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, 'refs/heads/release-') }}
+    if: ${{ contains(github.event.pull_request.base.ref, 'refs/heads/release-') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
@@ -47,7 +47,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSWORD }}
-        if: ${{ contains(github.ref, 'refs/heads/release-') }}
+        if: ${{ contains(github.event.pull_request.base.ref, 'refs/heads/release-') }}
       - name: Build with Gradle with Integration tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,20 +3,23 @@ on:
   pull_request:
     branches:
       - main
-      - "release-*"
+      - "release/v*"
 
 jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.base.ref, 'release-') }}
+    if: ${{ contains(github.event.pull_request.base.ref, 'release/v') }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
+
       - uses: gradle/wrapper-validation-action@v1
+
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"
@@ -37,22 +40,27 @@ jobs:
           # - windows-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
+
       - uses: gradle/wrapper-validation-action@v1
+
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
+        if: ${{ contains(github.event.pull_request.base.ref, 'release/v') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSWORD }}
-        if: ${{ contains(github.event.pull_request.base.ref, 'release-') }}
+
       - name: Build with Gradle with Integration tests
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/gradle-build-action@v2
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           arguments: build integrationTests --stacktrace -PenableCoverage=true -PlocalDocker=true
+
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         if: ${{ matrix.os != 'ubuntu-latest' }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"
+          branch: ${{ github.event.pull_request.base.ref }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -52,6 +53,7 @@ jobs:
         uses: ./.github/actions/patch-dependencies
         if: ${{ startsWith(github.event.pull_request.base.ref, 'release/v') }}
         with:
+          branch: ${{ github.event.pull_request.base.ref }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,10 +35,14 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
+        exclude:
+          # Skip windows on patch workflow because it is not possible to build opentelemetry-java on windows
+          # when the cache is in a different drive than the source code
           # Windows is not working for patch workflows, therefore we disable it here
           # https://github.com/square/wire/issues/2188
           # https://github.com/open-telemetry/opentelemetry-java/issues/4560
-          # - windows-latest
+          - os: ${{ startsWith(github.event.pull_request.base.ref, 'release/v') && 'windows-latest' || '' }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,7 +9,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.base.ref, 'refs/heads/release-') }}
+    if: ${{ contains(github.event.pull_request.base.ref, 'release-') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
@@ -47,7 +47,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSWORD }}
-        if: ${{ contains(github.event.pull_request.base.ref, 'refs/heads/release-') }}
+        if: ${{ contains(github.event.pull_request.base.ref, 'release-') }}
       - name: Build with Gradle with Integration tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           run_tests: "true"
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_password: ${{ secrets.GPG_PASSWORD }}
+          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
   build:
     name: Build on ${{ matrix.os }}
@@ -53,7 +53,7 @@ jobs:
         if: ${{ contains(github.event.pull_request.base.ref, 'release/v') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_password: ${{ secrets.GPG_PASSWORD }}
+          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Build with Gradle with Integration tests
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,7 +9,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.base.ref, 'release/v') }}
+    if: ${{ startsWith(github.event.pull_request.base.ref, 'release/v') }}
     steps:
       - uses: actions/checkout@v2
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ contains(github.event.pull_request.base.ref, 'release/v') }}
+        if: ${{ startsWith(github.event.pull_request.base.ref, 'release/v') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,8 +3,26 @@ on:
   pull_request:
     branches:
       - main
+      - "release-*"
 
 jobs:
+  testpatch:
+    name: Test patches applied to dependencies
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'refs/heads/release-') }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: ./.github/actions/patch-dependencies
+        with:
+          run_tests: "true"
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_password: ${{ secrets.GPG_PASSWORD }}
+
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -13,13 +31,23 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # Windows is not working for patch workflows, therefore we disable it here
+          # https://github.com/square/wire/issues/2188
+          # https://github.com/open-telemetry/opentelemetry-java/issues/4560
+          # - windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: temurin
       - uses: gradle/wrapper-validation-action@v1
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_password: ${{ secrets.GPG_PASSWORD }}
+        if: ${{ contains(github.ref, 'refs/heads/release-') }}
       - name: Build with Gradle with Integration tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           java-version: 17
       - uses: gradle/wrapper-validation-action@v1
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_password: ${{ secrets.GPG_PASSWORD }}
+        if: ${{ contains(github.ref, 'refs/heads/release-') }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
+        if: ${{ startsWith(github.ref_name, 'release/v') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_password: ${{ secrets.GPG_PASSWORD }}
+          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,6 +27,7 @@ jobs:
         uses: ./.github/actions/patch-dependencies
         if: ${{ startsWith(github.ref_name, 'release/v') }}
         with:
+          branch: ${{ github.ref_name }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,12 +22,14 @@ jobs:
         with:
           java-version: 17
       - uses: gradle/wrapper-validation-action@v1
+
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
+        if: ${{ contains(github.ref, 'refs/heads/release/v*') }}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSWORD }}
-        if: ${{ contains(github.ref, 'refs/heads/release-') }}
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ All patch releases should include only bug-fixes, and must avoid
 adding/modifying the public APIs. 
 
 Steps:
-1. Create a branch from the release that you want to patch. It should follow the convention `release-<major>.<minor>.x`. E.g.: if you want to patch release 1.21.0, the name of the branch should be `release-1.21.x`.
+1. Create a branch from the release that you want to patch. It should follow the convention `release/v<major>.<minor>.x`. E.g.: if you want to patch release 1.21.0, the name of the branch should be `release/v1.21.x`.
 1. Mark the branch as protected.
 1. Modify the source code/dependencies. You can only update the patch version of opentelemetry dependencies.
 1. Optionally prepare patches that can be applied to opentelemetry-java and opentelemetry-java-instrumentation. Use the sufix `-adot` in the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,10 +51,10 @@ Select the branch and provide the version.
 
 If you need to patch upstream dependencies, you need:
 
-* Provide patch files for each repository that will need to be patched. These files should be located in `.github/patchs` and should be named
+* Provide patch files for each repository that will need to be patched. These files should be located in `.github/patches/release/v<major>.<minor>.x` and should be named
 using the convention `<repository name>.patch`. The following repositories are supported: opentelemetry-java, opentelemetry-java-instrumentation and opentelemetry-java-contrib. Provide one patch file per repository. The adot patch version of each upstream dependency should be `<version>-adot<number>` where `version` is the version of the upstream dependency and `number` is the number of this patch that should be incremented from 1 per patch version.
 
-* Create a `versions` file in the directory `.github/patchs`. This file should contain shell variables with the versions of the tags of the repositories which will receive patchs.
+* Create a `versions` file in the directory `.github/patches/release/v<major>.<minor>.x`. This file should contain shell variables with the versions of the tags of the repositories which will receive patches.
   This file should define the following variables:
     * `OTEL_JAVA_VERSION`. Tag of the opentelemetry-java repository to use. E.g.: `JAVA_OTEL_JAVA_VERSION=v1.21.0`
     * `OTEL_JAVA_INSTRUMENTATION_VERSION`. Tag of the opentelemetry-java-instrumentation repository to use, e.g.: `OTEL_JAVA_INSTRUMENTATION_VERSION=v1.21.0`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,7 +52,7 @@ Select the branch and provide the version.
 If you need to patch upstream dependencies, you need:
 
 * Provide patch files for each repository that will need to be patched. These files should be located in `.github/patchs` and should be named
-using the convention `<repository name>.patch`. The following repositories are supported: opentelemetry-java, opentelemetry-java-instrumentation and opentelemetry-java-contrib. Provide one patch file per repository. The adot patch version of each upstream dependency should be `<version>+adot<number>` where `version` is the version of the upstream dependency and `number` is the number of this patch that should be incremented from 1 per patch version.
+using the convention `<repository name>.patch`. The following repositories are supported: opentelemetry-java, opentelemetry-java-instrumentation and opentelemetry-java-contrib. Provide one patch file per repository. The adot patch version of each upstream dependency should be `<version>-adot<number>` where `version` is the version of the upstream dependency and `number` is the number of this patch that should be incremented from 1 per patch version.
 
 * Create a `versions` file in the directory `.github/patchs`. This file should contain shell variables with the versions of the tags of the repositories which will receive patchs.
   This file should define the following variables:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,49 +36,17 @@ to view a summary of all commits since last release as a reference.
 All patch releases should include only bug-fixes, and must avoid
 adding/modifying the public APIs. 
 
-Open the patch release build workflow in your browser [here](https://github.com/aws-observability/aws-otel-java-instrumentation/actions?query=workflow%3A%22Patch+Release+Build%22).
+Steps:
+1. Create a branch from the release that you want to patch. It should follow the convention `release-<major>.<minor>.x`. E.g.: if you want to patch release 1.21.0, the name of the branch should be `release-1.21.x`.
+1. Mark the branch as protected.
+1. Modify the source code/dependencies. You can only update the patch version of opentelemetry dependencies.
+1. Optionally prepare patches that can be applied to opentelemetry-java and opentelemetry-java-instrumentation. Use the sufix `-adot` in the
+patched versions.
+1. Create pull request to merge in the release branch.
 
-You will see a button that says "Run workflow". Press the button, enter the version number you want
-to release in the input field for version that pops up and the commits you want to cherrypick for the
-patch as a comma-separated list. Then, press "Run workflow".
+After the pull request is merged, open the release build workflow in your browser [here](https://github.com/aws-observability/aws-otel-java-instrumentation/actions?query=workflow%3A%22Release+Build%22).
 
-If the commits cannot be cleanly applied to the release branch, for example because it has diverged
-too much from main, then the workflow will fail before building. In this case, you will need to
-prepare the release branch manually.
-
-This example will assume patching into release branch `v1.2.x` from a git repository with remotes
-named `origin` and `upstream`.
-
-```
-$ git remote -v
-origin	git@github.com:username/opentelemetry-java.git (fetch)
-origin	git@github.com:username/opentelemetry-java.git (push)
-upstream	git@github.com:open-telemetry/opentelemetry-java.git (fetch)
-upstream	git@github.com:open-telemetry/opentelemetry-java.git (push)
-```
-
-First, checkout the release branch
-
-```
-git fetch upstream v1.2.x
-git checkout upstream/v1.2.x
-```
-
-Apply cherrypicks manually and commit. It is ok to apply multiple cherrypicks in a single commit.
-Use a commit message such as "Manual cherrypick for commits commithash1, commithash2".
-
-After commiting the change, push to your fork's branch.
-
-```
-git push origin v1.2.x
-```
-
-Create a PR to have code review and merge this into upstream's release branch. As this was not
-applied automatically, we need to do code review to make sure the manual cherrypick is correct.
-
-After it is merged, Run the patch release workflow again, but leave the commits input field blank.
-The release will be made with the current state of the release branch, which is what you prepared
-above.
+Select the branch and provide the version.
 
 ## Release candidates
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,7 +38,6 @@ adding/modifying the public APIs.
 
 Steps:
 1. Create a branch from the release that you want to patch. It should follow the convention `release/v<major>.<minor>.x`. E.g.: if you want to patch release 1.21.0, the name of the branch should be `release/v1.21.x`.
-1. Mark the branch as protected.
 1. Modify the source code/dependencies. You can only update the patch version of opentelemetry dependencies.
 1. Optionally prepare patches that can be applied to opentelemetry-java and opentelemetry-java-instrumentation. More details about this in the following section.
 1. Create pull request to merge in the release branch.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,13 +40,27 @@ Steps:
 1. Create a branch from the release that you want to patch. It should follow the convention `release/v<major>.<minor>.x`. E.g.: if you want to patch release 1.21.0, the name of the branch should be `release/v1.21.x`.
 1. Mark the branch as protected.
 1. Modify the source code/dependencies. You can only update the patch version of opentelemetry dependencies.
-1. Optionally prepare patches that can be applied to opentelemetry-java and opentelemetry-java-instrumentation. Use the sufix `-adot` in the
-patched versions.
+1. Optionally prepare patches that can be applied to opentelemetry-java and opentelemetry-java-instrumentation. More details about this in the following section.
 1. Create pull request to merge in the release branch.
 
 After the pull request is merged, open the release build workflow in your browser [here](https://github.com/aws-observability/aws-otel-java-instrumentation/actions?query=workflow%3A%22Release+Build%22).
 
 Select the branch and provide the version.
+
+### Patching upstream dependencies
+
+If you need to patch upstream dependencies, you need:
+
+* Provide patch files for each repository that will need to be patched. These files should be located in `.github/patchs` and should be named
+using the convention `<repository name>.patch`. The following repositories are supported: opentelemetry-java, opentelemetry-java-instrumentation and opentelemetry-java-contrib. Provide one patch file per repository. The adot patch version of each upstream dependency should be `<version>+adot<number>` where `version` is the version of the upstream dependency and `number` is the number of this patch that should be incremented from 1 per patch version.
+
+* Create a `versions` file in the directory `.github/patchs`. This file should contain shell variables with the versions of the tags of the repositories which will receive patchs.
+  This file should define the following variables:
+    * `OTEL_JAVA_VERSION`. Tag of the opentelemetry-java repository to use. E.g.: `JAVA_OTEL_JAVA_VERSION=v1.21.0`
+    * `OTEL_JAVA_INSTRUMENTATION_VERSION`. Tag of the opentelemetry-java-instrumentation repository to use, e.g.: `OTEL_JAVA_INSTRUMENTATION_VERSION=v1.21.0`
+    * `OTEL_JAVA_CONTRIB_VERSION`. Tag of the opentelemetry-java-contrib repository. E.g.: `OTEL_JAVA_CONTRIB_VERSION=v1.21.0`
+
+During the build, ephemeral artifacts will be generated and stored into maven local and those will be used to build the ADOT Java Agent.
 
 ## Release candidates
 


### PR DESCRIPTION

**Description of changes:** Add process for creating patch releases that is able to patch opentelemetry dependencies.

The idea is to checkout the upstream dependencies, apply carefully created patches and publish these patched dependencies to maven local.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
