### PR TITLE
Cleanup patch repositories after build

### DIFF
--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -65,6 +65,11 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
 
+    - name: cleanup opentelemetry-java
+      run: rm -rf opentelemetry-java
+      if: ${{ env.patch_otel_java == 'true' }}
+      shell: bash
+
     - name: Build opentelemetry-java-contrib with tests
       uses: gradle/gradle-build-action@v2
       if: ${{ env.patch_otel_java_contrib == 'true' && inputs.run_tests != 'false' }}
@@ -85,6 +90,11 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
 
+    - name: cleanup opentelemetry-java-contrib
+      run: rm -rf opentelemetry-java-contrib
+      if: ${{ env.patch_otel_java_contrib == 'true' }}
+      shell: bash
+
     - name: Build opentelemetry-java-instrumentation with tests
       uses: gradle/gradle-build-action@v2
       if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests != 'false' }}
@@ -104,3 +114,8 @@ runs:
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         GPG_PASSWORD: ${{ inputs.gpg_password }}
+
+    - name: cleanup opentelmetry-java-instrumentation
+      run: rm -rf opentelemetry-java-instrumentation
+      if: ${{ env.patch_otel_java_instrumentation == 'true' }}
+      shell: bash


### PR DESCRIPTION
*Description of changes:* Cleanup patch repositories after build so that we don't fail the validation of the release process. https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/4061415093/jobs/6991406741#step:8:71

Signed-off-by: Raphael Silva <rapphil@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
