### PR TITLE
Updating Release and Nightly build workflows

### DIFF
--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
-  TEST_TAG: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:test
+  IMAGE_TAG: 611364707713.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java-nightly:nightly
 
 permissions:
   id-token: write
@@ -23,11 +23,13 @@ jobs:
         with:
           java-version: 17
       - uses: gradle/wrapper-validation-action@v1
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
       - name: Log in to AWS ECR
         uses: docker/login-action@v1
         with:
@@ -42,6 +44,17 @@ jobs:
           PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_NIGHTLY }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@v1
+        with:
+          registry: 611364707713.dkr.ecr.us-west-2.amazonaws.com
 
       - name: Get current version
         shell: bash
@@ -61,12 +74,22 @@ jobs:
           build-args: "ADOT_JAVA_VERSION=${{ env.ADOT_JAVA_VERSION }}"
           context: .
           platforms: linux/amd64
-          tags: ${{ env.TEST_TAG }}
+          tags: ${{ env.IMAGE_TAG }}
           load: true
 
       - name: Test docker image
         shell: bash
-        run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "${{ env.ADOT_JAVA_VERSION }}"
+        run: .github/scripts/test-adot-javaagent-image.sh "${{ env.IMAGE_TAG }}" "${{ env.ADOT_JAVA_VERSION }}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE_TAG }}
 
       - name: Upload to GitHub Actions
         uses: actions/upload-artifact@v2

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -49,7 +49,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_NIGHTLY }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Log in to AWS ECR
         uses: docker/login-action@v1

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          build-args: "ADOT_JAVA_VERSION=${{ env.ADOT_JAVA_VERSION }}"
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -91,14 +91,7 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build jib final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
-        env:
-          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
-          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
-          COMMIT_HASH: ${{ github.event.inputs.version }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          arguments: build integrationTests -PlocalDocker=true --stacktrace
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -128,7 +121,18 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ github.event.inputs.version }}, public.ecr.aws/aws-observability/adot-autoinstrumentation-java:latest
+            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ github.event.inputs.version }}
+
+      - name: Build and Publish release with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+        env:
+          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
+          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -93,6 +93,17 @@ jobs:
         with:
           arguments: build integrationTests -PlocalDocker=true --stacktrace
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
+          aws-region: us-west-2
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
       - name: Log in to AWS ECR
         uses: docker/login-action@v1
         with:
@@ -45,13 +46,18 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build integrationTests final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} -PlocalDocker=true --stacktrace
-        env:
-          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
-          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          arguments: build integrationTests -PlocalDocker=true --stacktrace
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -81,7 +87,18 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ github.event.inputs.version }}, public.ecr.aws/aws-observability/adot-autoinstrumentation-java:latest
+            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ github.event.inputs.version }}
+
+      - name: Build and Publish release with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+        env:
+          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
+          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Log in to AWS ECR
         uses: docker/login-action@v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Separating the Build and Publish of artifacts in separate steps.
- Removing the latest tag
- Using new java-image-release role for pushing the jar image to public ecr.
- Updating nightly build workflow to push a jar image to integ-test account with nightly tag.

TODO:

- [ ] Create repo secret for nightly build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
