### PR TITLE
Adding package permission

### DIFF
--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -11,6 +11,7 @@ env:
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 jobs:
   build:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -17,6 +17,7 @@ env:
 permissions:
   id-token: write
   contents: write
+  packages: write
 
 jobs:
   # Runs once for a patch series to any given minor version to create the initial release branch. Subsequent patches

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,7 @@ env:
 permissions:
   id-token: write
   contents: write
+  packages: write
 
 jobs:
   build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to current build failure of nightly snapshot build : https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/4690954991/jobs/8315006915

Creating this PR to add package permission to github actions referring to this doc: https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
