### PR TITLE
Do not use entrypoint for cp-utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,7 @@ FROM scratch
 
 ARG ADOT_JAVA_VERSION
 
-COPY --from=builder /usr/src/cp-utility/bin/cp-utility /
+COPY --from=builder /usr/src/cp-utility/bin/cp-utility /bin/cp
+
 
 COPY ./otelagent/build/libs/aws-opentelemetry-agent-${ADOT_JAVA_VERSION}.jar /javaagent.jar
-
-ENTRYPOINT ["/cp-utility"]

--- a/tools/cp-utility/src/main.rs
+++ b/tools/cp-utility/src/main.rs
@@ -42,24 +42,24 @@ struct CopyOperation {
 
 /// Parse command line arguments and transform into `CopyOperation`
 fn parse_args(args: Vec<&str>) -> io::Result<CopyOperation> {
-    if !((args.len() == 4 || args.len() == 5 && args[2].eq("-a")) && args[1].eq("cp")) {
+    if !(args.len() == 3 || args.len() == 4 && args[1].eq("-a")) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "Invalid parameters. Expected cp [-a] <source> <destination>",
         ));
     }
 
-    if args.len() == 5 {
+    if args.len() == 4 {
         return Ok(CopyOperation {
-            source: PathBuf::from(args[3]),
-            destination: PathBuf::from(args[4]),
+            source: PathBuf::from(args[2]),
+            destination: PathBuf::from(args[3]),
             copy_type: CopyType::Archive,
         });
     }
 
     Ok(CopyOperation {
-        source: PathBuf::from(args[2]),
-        destination: PathBuf::from(args[3]),
+        source: PathBuf::from(args[1]),
+        destination: PathBuf::from(args[2]),
         copy_type: CopyType::SingleFile,
     })
 }
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn test_parser_archive() {
         // prepare
-        let input = vec!["cp-utility", "cp", "-a", "foo.txt", "dest.txt"];
+        let input = vec!["cp", "-a", "foo.txt", "dest.txt"];
 
         // act
         let result = parse_args(input).unwrap();
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn test_parser_single() {
         // prepare
-        let input: Vec<&str> = vec!["cp-utility", "cp", "foo.txt", "dest.txt"];
+        let input: Vec<&str> = vec!["cp", "foo.txt", "dest.txt"];
 
         // act
         let result = parse_args(input).unwrap();
@@ -172,11 +172,9 @@ mod tests {
     fn parser_failure() {
         // prepare
         let inputs = vec![
-            vec!["cp-utility", "cp", "-r", "foo.txt", "bar.txt"],
-            vec!["cp-utility", "cp", "-a", "param1", "param2", "param3"],
-            vec!["cp-utility", "cp", "param1", "param2", "param3"],
-            vec!["cp-utility", "mv", "param1", "param2"],
-            vec!["cp-utility", "mv", "-a", "param1", "param2"],
+            vec!["cp", "-r", "foo.txt", "bar.txt"],
+            vec!["cp", "-a", "param1", "param2", "param3"],
+            vec!["cp", "param1", "param2", "param3"],
         ];
 
         for input in inputs.into_iter() {


### PR DESCRIPTION
*Description of changes:* The operator uses the command property for Init containers, which overrides the `ENTRYPOINT` the definition inside the docker image. 

https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint
https://github.com/open-telemetry/opentelemetry-operator/blob/20ea43a43bbe5ba4a512ffc7742a92d14cc3d7d9/pkg/instrumentation/javaagent.go#L71

This change makes the cp-utility behave exactly like the cp command, not requiring an `ENTRYPOINT` meaning that `cp` will not be an argument of the cp-utility anymore.


I simulated what the operator does end to end with the following:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: java-sample-app
  namespace: java-sample-app
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: java-sample-app
  template:
    metadata:
      name: java-sample-app
      namespace: java-sample-app
      labels:
        app.kubernetes.io/name: java-sample-app
    spec:
      containers:
        - name: java-sample-app
          image: xxxx.dkr.ecr.us-west-2.amazonaws.com/java-sample-app:latest-auto
          imagePullPolicy: Always
          env:
            - name: "OTEL_EXPORTER_OTLP_ENDPOINT"
              value: "http://collector-serv.collector.svc.cluster.local:4317"
            - name: "LISTEN_ADDRESS"
              value: "0.0.0.0:4567"
            - name: "JAVA_TOOL_OPTIONS"
              value: "-javaagent:/otel-auto-instrumentation/javaagent.jar"
          volumeMounts:
            - name: instrumentation-volume
              mountPath: "/otel-auto-instrumentation"
      serviceAccountName: java-sample-app-serv-acc
      initContainers:
        - name: autoinstrumentation
         # This was created manually
          image: xxxx.dkr.ecr.us-west-2.amazonaws.com/adot-auto-instrumentation:latest
          command: ["cp", "/javaagent.jar", "/otel-auto-instrumentation/javaagent.jar"]
          volumeMounts:
            - name: instrumentation-volume
              mountPath: "/otel-auto-instrumentation"
      volumes:
        - name: cache-volume
          emptyDir:
            sizeLimit: 100Mi
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
