### PR TITLE
Fix: Apply file permissions to match upstream operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ ARG ADOT_JAVA_VERSION
 COPY --from=builder /usr/src/cp-utility/bin/cp-utility /bin/cp
 
 
-COPY ./otelagent/build/libs/aws-opentelemetry-agent-${ADOT_JAVA_VERSION}.jar /javaagent.jar
+COPY --chmod=go+r ./otelagent/build/libs/aws-opentelemetry-agent-${ADOT_JAVA_VERSION}.jar  /javaagent.jar


### PR DESCRIPTION
*Description of changes:* Change permissions of the java agent file to match the [upstream operator image. 
](https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/java/Dockerfile#L13)


https://docs.docker.com/engine/reference/builder/#copy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
