### PR TITLE
Fix: Make sure name of artifact is aligned in release workflow

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build integrationTests -PlocalDocker=true --stacktrace
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build integrationTests -PlocalDocker=true --stacktrace
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }}  --stacktrace
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }}  --stacktrace
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
*Description of changes:* This will make sure that the name of the jar is exactly the same during the build for the the docker image and for maven central. 

If we did not make this change the docker step will fail, because it will not be able to find the artifact.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
