### PR TITLE
dependabot updates Mon Apr 30

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -33,8 +33,8 @@ val otelSnapshotVersion = "1.25.0"
 // All versions below are only used in testing and do not affect the released artifact.
 
 val DEPENDENCY_BOMS = listOf(
-  "com.amazonaws:aws-java-sdk-bom:1.12.454",
-  "com.fasterxml.jackson:jackson-bom:2.14.2",
+  "com.amazonaws:aws-java-sdk-bom:1.12.459",
+  "com.fasterxml.jackson:jackson-bom:2.15.0",
   "com.google.guava:guava-bom:31.1-jre",
   "com.google.protobuf:protobuf-bom:3.22.3",
   "com.linecorp.armeria:armeria-bom:1.23.1",
@@ -72,7 +72,7 @@ val DEPENDENCIES = listOf(
   "commons-logging:commons-logging:1.2",
   "com.sparkjava:spark-core:2.9.4",
   "com.squareup.okhttp3:okhttp:4.10.0",
-  "io.opentelemetry.contrib:opentelemetry-aws-xray:1.24.0",
+  "io.opentelemetry.contrib:opentelemetry-aws-xray:1.25.1",
   "io.opentelemetry.contrib:opentelemetry-aws-resources:1.24.0-alpha",
   "io.opentelemetry.proto:opentelemetry-proto:0.19.0-alpha",
   "io.opentelemetry.javaagent:opentelemetry-javaagent:${if (!TEST_SNAPSHOTS) otelVersion else "$otelSnapshotVersion-SNAPSHOT"}",

--- a/instrumentation/logback-1.0/build.gradle.kts
+++ b/instrumentation/logback-1.0/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   compileOnly("net.bytebuddy:byte-buddy")
 
-  compileOnly("ch.qos.logback:logback-classic:1.4.6")
+  compileOnly("ch.qos.logback:logback-classic:1.4.7")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@
 
 pluginManagement {
   plugins {
-    id("com.diffplug.spotless") version "6.11.0"
+    id("com.diffplug.spotless") version "6.18.0"
     id("com.github.ben-manes.versions") version "0.46.0"
     id("com.github.jk1.dependency-license-report") version "2.1"
     id("com.github.johnrengelman.shadow") version "7.1.2"

--- a/tools/cp-utility/Cargo.lock
+++ b/tools/cp-utility/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom",
  "rand",

--- a/tools/cp-utility/Cargo.toml
+++ b/tools/cp-utility/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dev-dependencies]
 # dependencies only used during tests
 tempfile = "3.5.0"
-uuid = { version = "1.3.1", features = ["v4", "fast-rng"] }
+uuid = { version = "1.3.2", features = ["v4", "fast-rng"] }
 
 [profile.release]
 # Levers to optimize the binary for size


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump uuid from 1.3.1 to 1.3.2 in /tools/cp-utility #396
Bump ch.qos.logback:logback-classic from 1.4.6 to 1.4.7 #395
Bump com.amazonaws:aws-java-sdk-bom from 1.12.454 to 1.12.459 #394
Bump com.fasterxml.jackson:jackson-bom from 2.14.2 to 2.15.0 #393
Bump io.opentelemetry.contrib:opentelemetry-aws-xray from 1.24.0 to 1.25.1 #390
Bump com.diffplug.spotless from 6.11.0 to 6.18.0  #374

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
