### PR TITLE
Update jackson-bom to 2.15.0

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -34,7 +34,7 @@ val otelSnapshotVersion = "1.25.0"
 
 val DEPENDENCY_BOMS = listOf(
   "com.amazonaws:aws-java-sdk-bom:1.12.459",
-  "com.fasterxml.jackson:jackson-bom:2.14.2",
+  "com.fasterxml.jackson:jackson-bom:2.15.0",
   "com.google.guava:guava-bom:31.1-jre",
   "com.google.protobuf:protobuf-bom:3.22.3",
   "com.linecorp.armeria:armeria-bom:1.23.1",


### PR DESCRIPTION
*Description of changes:* This has to be done manually because dependabot is trying to merge v2.15.1, but artifacts are still not available in maven central: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/406


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
