### PR TITLE
Fix mainbuild workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -259,8 +259,8 @@ jobs:
       - name: run tests
         run: |
           export TTL_DATE=${{ steps.date.outputs.ttldate }} 
-          export TF_VAR_JAVA_AUTO_INSTRUMENTATION_TAG=${{ needs.build.outputs.java_agent_tag }}
-          export TF_VAR_JAVA_AUTO_INSTRUMENTATION_REPOSITORY="${{ env.STAGING_ECR_REGISTRY }}/${{ env.STAGING_ECR_REPOSITORY }}"
+          export TF_VAR_java_auto_instrumentation_tag=${{ needs.build.outputs.java_agent_tag }}
+          export TF_VAR_java_auto_instrumentation_repository="${{ env.STAGING_ECR_REGISTRY }}/${{ env.STAGING_ECR_REPOSITORY }}"
           export DDB_BATCH_CACHE_SK=${{ needs.build.outputs.java_agent_tag }}
           cd testing-framework/terraform
           make execute-batch-test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
PR to fix this error due to recent java_agent_e2e_operator testcase introduction to mainbuild workflow: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/5482566007/jobs/10001324855
changing var name to lowercase - to match it variable name in the eks testcase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
