### PR TITLE
Fix main build workflow for release branch

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -157,9 +157,7 @@ jobs:
         id: setRef
         run: |
           if [[ ${{ github.ref_name }} == release/v* ]]; then
-            release_version = $(echo ${{ github.ref_name }} | cut -f 2 -d /)
-            major_minor = $(echo ${ release_version } | cut -f 1,2 -d .)
-            echo "ref = java-release/${major_minor}.x" >> $GITHUB_OUTPUT
+            echo "ref=java-${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "ref=terraform" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Fix main build workflow for release branch

There were space around the `=` in the script which caused a failure. this pr simplifies the process to get the name of the release branch in the test framework.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
