### PR TITLE
Java Agent Main Build: Setting concurrency group

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -13,6 +13,10 @@ env:
   NUM_BATCHES: 2
   DDB_TABLE_NAME: BatchTestCache
 
+concurrency:
+  group: java-agent-main-build
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The recent failures of this workflow (while merging series of dependabot PRs) looks like caused by multiple jobs of java-agent-main-build running at the same time: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/5550810364/jobs/10136412203#step:9:1450

We don't want the multiple EKS Operator tests to run on same cluster as same time, as Operator is installed on default namespace. To ensure this, adding concurrency group; and also setting `cancel-in-progress` job as false for this workflow. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
