### PR TITLE
Bump com.diffplug.spotless from 6.13.0 to 6.20.0 and Resolve build error

### DIFF
--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerConfigurerTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerConfigurerTest.java
@@ -43,6 +43,7 @@ class AwsTracerConfigurerTest {
         .addPropertiesSupplier(() -> singletonMap("otel.traces.exporter", "none"))
         .addPropertiesSupplier(() -> singletonMap("otel.logs.exporter", "none"));
   }
+
   // The probability of this passing once without correct IDs is low, 20 times is inconceivable.
   @RepeatedTest(20)
   void providerGeneratesXrayIds() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ allprojects {
 
   spotless {
     kotlinGradle {
-      ktlint("0.40.0").userData(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
+      ktlint("0.48.0").userData(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
 
       // Doesn't support pluginManagement block
       targetExclude("settings.gradle.kts")
@@ -184,7 +184,7 @@ allprojects {
         relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
         relocate(
           "io.opentelemetry.extension.kotlin",
-          "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin"
+          "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin",
         )
       }
     }
@@ -224,7 +224,7 @@ allprojects {
           pom {
             name.set("AWS Distro for OpenTelemetry Java Agent")
             description.set(
-              "The Amazon Web Services distribution of the OpenTelemetry Java Instrumentation."
+              "The Amazon Web Services distribution of the OpenTelemetry Java Instrumentation.",
             )
             url.set("https:/github.com/aws-observability/aws-otel-java-instrumentation")
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -45,28 +45,28 @@ val DEPENDENCY_BOMS = listOf(
   "org.junit:junit-bom:5.10.0",
   "org.springframework.boot:spring-boot-dependencies:2.7.14",
   "org.testcontainers:testcontainers-bom:1.18.3",
-  "software.amazon.awssdk:bom:2.20.122"
+  "software.amazon.awssdk:bom:2.20.122",
 )
 
 val DEPENDENCY_SETS = listOf(
   DependencySet(
     "org.assertj",
     "3.24.2",
-    listOf("assertj-core")
+    listOf("assertj-core"),
   ),
   DependencySet(
     "org.curioswitch.curiostack",
     "2.2.0",
-    listOf("protobuf-jackson")
+    listOf("protobuf-jackson"),
   ),
   DependencySet(
     "org.slf4j",
     "1.7.36",
     listOf(
       "slf4j-api",
-      "slf4j-simple"
-    )
-  )
+      "slf4j-simple",
+    ),
+  ),
 )
 
 val DEPENDENCIES = listOf(
@@ -77,7 +77,7 @@ val DEPENDENCIES = listOf(
   "io.opentelemetry.contrib:opentelemetry-aws-resources:1.28.0-alpha",
   "io.opentelemetry.proto:opentelemetry-proto:1.0.0-alpha",
   "io.opentelemetry.javaagent:opentelemetry-javaagent:$otelJavaAgentVersion",
-  "net.bytebuddy:byte-buddy:1.14.6"
+  "net.bytebuddy:byte-buddy:1.14.6",
 )
 
 javaPlatform {

--- a/otelagent/build.gradle.kts
+++ b/otelagent/build.gradle.kts
@@ -136,14 +136,14 @@ jib {
     "gcr.io/distroless/java17-debian11:debug",
     "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
     localDocker = false,
-    multiPlatform = !rootProject.property("localDocker")!!.equals("true")
+    multiPlatform = !rootProject.property("localDocker")!!.equals("true"),
   )
 
   container {
     appRoot = "/aws-observability"
     setEntrypoint("INHERIT")
     environment = mapOf(
-      "JAVA_TOOL_OPTIONS" to "-javaagent:/aws-observability/classpath/aws-opentelemetry-agent-$version.jar"
+      "JAVA_TOOL_OPTIONS" to "-javaagent:/aws-observability/classpath/aws-opentelemetry-agent-$version.jar",
     )
   }
   containerizingMode = "packaged"

--- a/sample-apps/spark-awssdkv1/build.gradle.kts
+++ b/sample-apps/spark-awssdkv1/build.gradle.kts
@@ -26,7 +26,7 @@ jib {
     "public.ecr.aws/aws-otel-test/aws-otel-java-spark-awssdkv1",
     localDocker = rootProject.property("localDocker")!!.equals("true"),
     multiPlatform = !rootProject.property("localDocker")!!.equals("true"),
-    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
+    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}"),
   )
 }
 

--- a/sample-apps/spark-awssdkv1/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark-awssdkv1/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -185,6 +185,7 @@ public class MetricEmitter {
     apiNameValue = apiName;
     statusCodeValue = statusCode;
   }
+
   /**
    * update actual queue size, it will be collected by UpDownSumObserver
    *

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -31,7 +31,7 @@ jib {
     "public.ecr.aws/aws-otel-test/aws-otel-java-spark",
     localDocker = rootProject.property("localDocker")!!.equals("true"),
     multiPlatform = !rootProject.property("localDocker")!!.equals("true"),
-    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
+    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}"),
   )
 }
 
@@ -49,7 +49,7 @@ tasks {
       "public.ecr.aws/aws-otel-test/aws-otel-java-spark-without-auto-instrumentation-agent",
       localDocker = false,
       multiPlatform = !rootProject.property("localDocker")!!.equals("true"),
-      tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
+      tags = setOf("latest", "${System.getenv("COMMIT_HASH")}"),
     )
     setJibExtension(j)
   }

--- a/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -185,6 +185,7 @@ public class MetricEmitter {
     apiNameValue = apiName;
     statusCodeValue = statusCode;
   }
+
   /**
    * update actual queue size, it will be collected by UpDownSumObserver
    *

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -21,7 +21,7 @@ jib {
     "public.ecr.aws/aws-otel-test/aws-otel-java-springboot",
     rootProject.property("localDocker")!!.equals("true"),
     !rootProject.property("localDocker")!!.equals("true"),
-    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}")
+    tags = setOf("latest", "${System.getenv("COMMIT_HASH")}"),
   )
 }
 

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/MetricEmitter.java
@@ -185,6 +185,7 @@ public class MetricEmitter {
     apiNameValue = apiName;
     statusCodeValue = statusCode;
   }
+
   /**
    * update actual queue size, it will be collected by UpDownSumObserver
    *

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@
 
 pluginManagement {
   plugins {
-    id("com.diffplug.spotless") version "6.13.0"
+    id("com.diffplug.spotless") version "6.20.0"
     id("com.github.ben-manes.versions") version "0.47.0"
     id("com.github.jk1.dependency-license-report") version "2.5"
     id("com.github.johnrengelman.shadow") version "8.1.1"

--- a/smoke-tests/runner/build.gradle.kts
+++ b/smoke-tests/runner/build.gradle.kts
@@ -41,7 +41,7 @@ tasks {
 
     jvmArgs(
       "-Dio.awsobservability.instrumentation.smoketests.runner.agentPath=${otelAgentJarTask.get().archiveFile.get()
-        .getAsFile().absolutePath}"
+        .getAsFile().absolutePath}",
     )
   }
 

--- a/smoke-tests/spring-boot/build.gradle.kts
+++ b/smoke-tests/spring-boot/build.gradle.kts
@@ -50,7 +50,7 @@ jib {
     "public.ecr.aws/aws-otel-test/aws-opentelemetry-java-base:alpha",
     "public.ecr.aws/aws-otel-test/aws-otel-java-smoketests-springboot",
     localDocker = rootProject.property("localDocker")!!.equals("true"),
-    multiPlatform = false
+    multiPlatform = false,
   )
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

PR to Bump com.diffplug.spotless from 6.13.0 to 6.20.0 and resolve build error in this PR:  https://github.com/aws-observability/aws-otel-java-instrumentation/pull/496


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
