### PR TITLE
Bump terraform version

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: "~1.4"
+          terraform_version: "~1.5"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3


### PR DESCRIPTION
*Issue #, if available:* We require terraform version 1.5 to use `strcontains` function. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
