### PR TITLE
Don't exclude semantic conventions package from shaded dependencies

### DIFF
--- a/otelagent/build.gradle.kts
+++ b/otelagent/build.gradle.kts
@@ -40,7 +40,9 @@ val javaagentLibs by configurations.creating {
   exclude("io.opentelemetry", "opentelemetry-api")
   exclude("io.opentelemetry", "opentelemetry-sdk")
   exclude("io.opentelemetry", "opentelemetry-sdk-common")
-  exclude("io.opentelemetry", "opentelemetry-semconv")
+  // Once io.opentelemetry.contrib:opentelemetry-aws-resources starts using
+  // the new semantic convention packages we will need to exclude it here.
+  // io.opentelemetry.semconv:opentelemetry-semconv
 }
 
 val shadowClasspath by configurations.creating {


### PR DESCRIPTION
*Description of changes:* [This commit](https://github.com/open-telemetry/opentelemetry-java-instrumentation/commit/3b77cc4b2de90ca821d53234e76ea8f279cfc34f) removed the semantic convention package from the Java agent. Therefore we need to include this dependency from our side.

If we don't do this, we get this error:
```
    OpenTelemetry Javaagent failed to start
    java.lang.NoClassDefFoundError: io/opentelemetry/javaagent/shaded/io/opentelemetry/semconv/resource/attributes/ResourceAttributes
        at io.opentelemetry.contrib.aws.resource.Ec2Resource.buildResource(Ec2Resource.java:81)
        at io.opentelemetry.contrib.aws.resource.Ec2Resource.buildResource(Ec2Resource.java:49)
        at io.opentelemetry.contrib.aws.resource.Ec2Resource.<clinit>(Ec2Resource.java:35)
        at io.opentelemetry.contrib.aws.resource.Ec2ResourceProvider.createResource(Ec2ResourceProvider.java:16)
        at io.opentelemetry.sdk.autoconfigure.ResourceConfiguration.configureResource(ResourceConfiguration.java:107)
        at io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.build(AutoConfiguredOpenTelemetrySdkBuilder.java:335)
        at io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installOpenTelemetrySdk(OpenTelemetryInstaller.java:34)
        at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:121)
        at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:101)
        at io.opentelemetry.javaagent.tooling.AgentStarterImpl.start(AgentStarterImpl.java:98)
        at io.opentelemetry.javaagent.bootstrap.AgentInitializer$1.run(AgentInitializer.java:53)
        at io.opentelemetry.javaagent.bootstrap.AgentInitializer$1.run(AgentInitializer.java:47)
        at io.opentelemetry.javaagent.bootstrap.AgentInitializer.execute(AgentInitializer.java:64)
        at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:46)
        at io.opentelemetry.javaagent.OpenTelemetryAgent.startAgent(OpenTelemetryAgent.java:57)
        at io.opentelemetry.javaagent.OpenTelemetryAgent.agentmain(OpenTelemetryAgent.java:49)
        at software.amazon.opentelemetry.javaagent.bootstrap.AwsAgentBootstrap.agentmain(AwsAgentBootstrap.java:28)
        at software.amazon.opentelemetry.javaagent.bootstrap.AwsAgentBootstrap.premain(AwsAgentBootstrap.java:24)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:491)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:503)
    Caused by: java.lang.ClassNotFoundException: io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv.resource.attributes.ResourceAttributes
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:587)
        at io.opentelemetry.javaagent.bootstrap.AgentClassLoader.loadClass(AgentClassLoader.java:161)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 24 more
```
Because the class was moved to a different package in the new semantic convention maven package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
