### PR TITLE
Updating e2e cluster versions

### DIFF
--- a/.github/workflows/testcases.json
+++ b/.github/workflows/testcases.json
@@ -4,11 +4,11 @@
 			"type": "EKS_ADOT_OPERATOR",
 			"targets": [
 				{
-					"name": "java-instrumentation-operator-ci-amd64-1-23",
+					"name": "java-instrumentation-operator-ci-amd64-1-24",
 					"region": "us-west-2"
 				},
 				{
-					"name": "java-instrumentation-operator-ci-amd64-1-26",
+					"name": "java-instrumentation-operator-ci-amd64-1-27",
 					"region": "us-west-2"
 				}
 			]
@@ -17,11 +17,11 @@
 			"type": "EKS_ADOT_OPERATOR_ARM64",
 			"targets": [
 				{
-					"name": "java-instrumentation-operator-ci-arm64-1-23",
+					"name": "java-instrumentation-operator-ci-arm64-1-24",
 					"region": "us-west-2"
 				},
 				{
-					"name": "java-instrumentation-operator-ci-arm64-1-26",
+					"name": "java-instrumentation-operator-ci-arm64-1-27",
 					"region": "us-west-2"
 				}
 			]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/aws-otel-java-instrumentation/issues/570

*Description of changes:*
Removing versions 23 and 26
and updating to versions 24 and 27

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
