### PR TITLE
Fix release error testing in e2e testing sample apps

### DIFF
--- a/testing/sample-apps/springboot-remote-service/build.gradle.kts
+++ b/testing/sample-apps/springboot-remote-service/build.gradle.kts
@@ -34,7 +34,11 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web")
   implementation("org.springframework.boot:spring-boot-starter-logging")
 }
-
+tasks {
+  named("jib") {
+    enabled = false
+  }
+}
 jib {
   to {
     image = "<ECR_IMAGE_LINK>:<TAG>"

--- a/testing/sample-apps/springboot/build.gradle.kts
+++ b/testing/sample-apps/springboot/build.gradle.kts
@@ -38,7 +38,11 @@ dependencies {
   implementation("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:sts")
 }
-
+tasks {
+  named("jib") {
+    enabled = false
+  }
+}
 jib {
   to {
     image = "<ECR_IMAGE_LINK>:<TAG>"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
jib build is failing on local as ECR_IMAGE_LINK>:<TAG> do not have a value. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
