### PR TITLE
Fix default value for when the otel.smp.enabled property is not set

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -63,7 +63,7 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
   }
 
   private boolean isSmpEnabled(ConfigProperties configProps) {
-    return configProps.getBoolean("otel.smp.enabled", true);
+    return configProps.getBoolean("otel.smp.enabled", false);
   }
 
   private Sampler customizeSampler(Sampler sampler, ConfigProperties configProps) {


### PR DESCRIPTION
*Description of changes:*
The functionality should be explicitly opt-in.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
