### PR TITLE
Fix trace validation bug

### DIFF
--- a/testing/validator/src/main/java/com/amazon/aoc/services/XRayService.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/services/XRayService.java
@@ -50,12 +50,16 @@ public class XRayService {
   }
 
   // Search for traces generated within the last 60 second.
-  public List<TraceSummary> searchTraces() {
+  public List<TraceSummary> searchClientCallTraces(String serviceName) {
     Date currentDate = new Date();
     Date pastDate = new DateTime(currentDate).minusSeconds(SEARCH_PERIOD).toDate();
     GetTraceSummariesResult traceSummaryResult =
         awsxRay.getTraceSummaries(
-            new GetTraceSummariesRequest().withStartTime(pastDate).withEndTime(currentDate));
+            new GetTraceSummariesRequest()
+                .withStartTime(pastDate)
+                .withEndTime(currentDate)
+                .withFilterExpression("annotation.aws_local_service = " + serviceName)
+                .withFilterExpression("annotation.aws_local_service = \"local-root-client-call\""));
     return traceSummaryResult.getTraceSummaries();
   }
 }


### PR DESCRIPTION
Issue:
There are occasional errors in the E2E testing when the EKS and EC2 tests run simultaneously. Sometimes one of the tests may retrieve traces generated by the /client-call API from the other test.

Description of changes:
The /client-call trace validator now filters retrieved trace with `aws_local_service = serviceName` and `aws_local_service = "local_root_client_call"`. Since each test run has a unique service name, this will ensure that the trace retrieved is specific towards the test being run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
