### PR TITLE
E2E Test: Ensure the use of IMDSv2 in EC2 instances

### DIFF
--- a/testing/terraform/ec2/main.tf
+++ b/testing/terraform/ec2/main.tf
@@ -34,6 +34,9 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+  metadata_options {
+    http_tokens = "required"
+  }
 
   tags = {
     Name = "main-service-${var.test_id}"
@@ -92,6 +95,9 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+  metadata_options {
+    http_tokens = "required"
+  }
 
   tags = {
     Name = "remote-service-${var.test_id}"


### PR DESCRIPTION
Copy of PR to private repo.

Tested EC2 canary still passes and that the instances created by the test have IMDSv2 marked as `Required`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
