### PR TITLE
Add e2e canary to public preview regions

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-canary-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-canary-test.yml
@@ -14,7 +14,12 @@ permissions:
 
 jobs:
   e2e-canary-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        aws-region: ['us-east-1', 'us-east-2', 'eu-west-1', 'ap-northeast-1', 'ap-southeast-2']
     uses: ./.github/workflows/appsignals-e2e-ec2-test.yml
     secrets: inherit
     with:
+      aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-e2e-ec2-canary-test'

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -5,6 +5,9 @@ name: App Signals Enablement E2E Testing - EC2 Use Case
 on:
   workflow_call:
     inputs:
+      aws-region:
+        required: true
+        type: string
       caller-workflow-name:
         required: true
         type: string
@@ -14,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} # Used by terraform and AWS CLI commands
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   SAMPLE_APP_FRONTEND_SERVICE_JAR: "s3://aws-appsignals-sample-app/main-service.jar"
   SAMPLE_APP_REMOTE_SERVICE_JAR: "s3://aws-appsignals-sample-app/remote-service.jar"
@@ -57,6 +60,11 @@ jobs:
             -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
             -var="cw_agent_rpm=${{ env.APP_SIGNALS_CW_AGENT_RPM }}" \
             -var="adot_jar=${{ env.APP_SIGNALS_ADOT_JAR }}"
+
+      - name: Get the ec2 instance ami id
+        run: |
+          echo "EC2_INSTANCE_AMI=$(terraform output ec2_instance_ami)" >> $GITHUB_ENV
+        working-directory: testing/terraform/ec2
 
       - name: Get the sample app endpoint
         run: |
@@ -103,6 +111,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
       - name: Validate generated metrics
@@ -119,6 +128,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
       - name: Validate generated traces
@@ -135,6 +145,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
       - name: Publish metric on test result

--- a/.github/workflows/appsignals-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-canary-test.yml
@@ -17,9 +17,14 @@ permissions:
   contents: read
 
 jobs:
-  e2e-canary-test:
+  e2e-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        aws-region: ['us-east-1', 'us-east-2', 'eu-west-1', 'ap-northeast-1', 'ap-southeast-2']
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit
     with:
+      aws-region: ${{ matrix.aws-region }}
       test-cluster-name: 'e2e-canary-test'
       caller-workflow-name: 'appsignals-e2e-eks-canary-test'

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -5,6 +5,9 @@ name: App Signals Enablement E2E Testing - EKS
 on:
   workflow_call:
     inputs:
+      aws-region:
+        required: true
+        type: string
       test-cluster-name:
         required: true
         type: string
@@ -20,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} # Used by terraform and AWS CLI commands
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   ENABLEMENT_SCRIPT_S3_BUCKET: ${{ secrets.APP_SIGNALS_E2E_ENABLEMENT_SCRIPT }}
   SAMPLE_APP_NAMESPACE: sample-app-namespace
@@ -30,7 +33,7 @@ env:
   LOG_GROUP_NAME: /aws/appsignals/eks
 
 jobs:
-  appsignals-e2e-test:
+  e2e-eks-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ env.AWS_DEFAULT_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -87,6 +90,7 @@ jobs:
           terraform validate
           terraform apply -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}" \
+            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
             -var="kube_directory_path=${{ github.workspace }}/.kube" \
             -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
             -var="eks_cluster_context_name=$(kubectl config current-context)" \
@@ -167,7 +171,7 @@ jobs:
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --cluster ${{ inputs.test-cluster-name }}
+          --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
           --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
@@ -184,7 +188,7 @@ jobs:
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --cluster ${{ inputs.test-cluster-name }}
+          --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
@@ -202,7 +206,7 @@ jobs:
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --cluster ${{ inputs.test-cluster-name }}
+          --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
           --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}

--- a/testing/terraform/ec2/main.tf
+++ b/testing/terraform/ec2/main.tf
@@ -26,8 +26,36 @@ locals {
   private_key_content = tls_private_key.ssh_key.private_key_pem
 }
 
+data "aws_ami" "ami" {
+  executable_users = ["self"]
+  most_recent      = true
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "root-device-name"
+    values = ["/dev/xvda"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "aws_instance" "main_service_instance" {
-  ami                                   = "ami-0b021814637c6d457" # Amazon Linux 2 (free tier)
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
   instance_type                         = "t2.micro"
   key_name                              = local.ssh_key_name
   iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"
@@ -85,7 +113,7 @@ resource "null_resource" "main_service_setup" {
 }
 
 resource "aws_instance" "remote_service_instance" {
-  ami                                   = "ami-0b021814637c6d457" # Amazon Linux 2 (free tier)
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
   instance_type                         = "t2.micro"
   key_name                              = local.ssh_key_name
   iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"

--- a/testing/terraform/ec2/output.tf
+++ b/testing/terraform/ec2/output.tf
@@ -5,3 +5,7 @@ output "sample_app_main_service_public_dns" {
 output "sample_app_remote_service_public_ip" {
   value = aws_instance.remote_service_instance.public_ip
 }
+
+output "ec2_instance_ami" {
+  value = data.aws_ami.ami.id
+}

--- a/testing/terraform/eks/main.tf
+++ b/testing/terraform/eks/main.tf
@@ -17,7 +17,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = var.aws_region
 }
 
 # get eks cluster

--- a/testing/terraform/eks/variables.tf
+++ b/testing/terraform/eks/variables.tf
@@ -21,6 +21,10 @@ variable "kube_directory_path" {
     default = "./.kube"
 }
 
+variable "aws_region" {
+  default = "<e.g. us-east-1>"
+}
+
 variable "eks_cluster_name" {
   default = "<cluster-name>"
 }

--- a/testing/validator/src/main/java/com/amazon/aoc/App.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/App.java
@@ -60,9 +60,9 @@ public class App implements Callable<Integer> {
   private String appNamespace;
 
   @CommandLine.Option(
-      names = {"--cluster"},
+      names = {"--platform-info"},
       defaultValue = "demo-cluster")
-  private String cluster;
+  private String platformInfo;
 
   @CommandLine.Option(
       names = {"--service-name"},
@@ -133,6 +133,11 @@ public class App implements Callable<Integer> {
       defaultValue = "true")
   private boolean isRollup;
 
+  @CommandLine.Option(
+      names = {"--instance-ami"},
+      defaultValue = "")
+  private String instanceAmi;
+
   private static final String TEST_CASE_DIM_KEY = "testcase";
   private static final String CANARY_NAMESPACE = "Otel/Canary";
   private static final String CANARY_METRIC_NAME = "Success";
@@ -151,7 +156,7 @@ public class App implements Callable<Integer> {
     context.setAvailabilityZone(this.availabilityZone);
     context.setMetricNamespace(this.metricNamespace);
     context.setAppNamespace(this.appNamespace);
-    context.setCluster(this.cluster);
+    context.setPlatformInfo(this.platformInfo);
     context.setServiceName(this.serviceName);
     context.setRemoteServiceName(this.remoteServiceName);
     context.setRemoteServiceDeploymentName(this.remoteServiceDeploymentName);
@@ -166,6 +171,7 @@ public class App implements Callable<Integer> {
     context.setCortexInstanceEndpoint(this.cortexInstanceEndpoint);
     context.setTestcase(testcase);
     context.setLanguage(language);
+    context.setInstanceAmi(this.instanceAmi);
 
     log.info(context);
 

--- a/testing/validator/src/main/java/com/amazon/aoc/models/Context.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/models/Context.java
@@ -39,7 +39,9 @@ public class Context {
 
   private String appNamespace;
 
-  private String cluster;
+  // Variable containing platform specific information. Ex: For EKS, the cluster where the sample
+  // app is deployed is needed.
+  private String platformInfo;
 
   private String serviceName;
 
@@ -52,6 +54,8 @@ public class Context {
   private String requestBody;
 
   private String logGroup;
+
+  private String instanceAmi;
 
   private ECSContext ecsContext;
 

--- a/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
@@ -20,7 +20,7 @@
   "metadata": {
     "default": {
         "otel.resource.aws.hostedin.environment": "^EC2$",
-        "otel.resource.host.image.id": "^ami-0b021814637c6d457$",
+        "otel.resource.host.image.id": "^{{instanceAmi}}$",
         "otel.resource.host.type": "^t2.micro$",
         "aws.span.kind": "^LOCAL_ROOT$"
     }

--- a/testing/validator/src/main/resources/expected-data-template/ec2/client-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/client-call-trace.mustache
@@ -8,7 +8,7 @@
   "metadata": {
     "default": {
         "otel.resource.aws.hostedin.environment": "^EC2$",
-        "otel.resource.host.image.id": "^ami-0b021814637c6d457$",
+        "otel.resource.host.image.id": "^{{instanceAmi}}$",
         "otel.resource.host.type": "^t2.micro$"
 
     }

--- a/testing/validator/src/main/resources/expected-data-template/ec2/outgoing-http-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/outgoing-http-call-trace.mustache
@@ -20,7 +20,7 @@
   "metadata": {
       "default": {
           "otel.resource.aws.hostedin.environment": "^EC2$",
-          "otel.resource.host.image.id": "^ami-0b021814637c6d457$",
+          "otel.resource.host.image.id": "^{{instanceAmi}}$",
           "otel.resource.host.type": "^t2.micro$",
           "aws.span.kind": "^LOCAL_ROOT$"
       }

--- a/testing/validator/src/main/resources/expected-data-template/ec2/remote-service-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/remote-service-trace.mustache
@@ -20,7 +20,7 @@
   "metadata": {
       "default": {
           "otel.resource.aws.hostedin.environment": "^EC2$",
-          "otel.resource.host.image.id": "^ami-0b021814637c6d457$",
+          "otel.resource.host.image.id": "^{{instanceAmi}}$",
           "otel.resource.host.type": "^t2.micro$",
           "aws.span.kind": "^LOCAL_ROOT$"
       }
@@ -69,7 +69,7 @@
   "metadata": {
       "default": {
           "otel.resource.aws.hostedin.environment": "^EC2$",
-          "otel.resource.host.image.id": "^ami-0b021814637c6d457$",
+          "otel.resource.host.image.id": "^{{instanceAmi}}$",
           "otel.resource.host.type": "^t2.micro$",
           "aws.span.kind": "^LOCAL_ROOT$"
       }

--- a/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-log.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-log.mustache
@@ -1,5 +1,5 @@
 [{
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-(remote-)?app-deployment(-[A-Za-z0-9]*)*$",
@@ -10,7 +10,7 @@
   "aws.span.kind": "^LOCAL_ROOT$"
 },
 {
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment(-[A-Za-z0-9]*)*$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
@@ -10,7 +10,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -27,7 +27,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -47,7 +47,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -61,7 +61,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -78,7 +78,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -101,7 +101,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -124,7 +124,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -150,7 +150,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -167,7 +167,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -187,7 +187,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -201,7 +201,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -218,7 +218,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -241,7 +241,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -264,7 +264,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -290,7 +290,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -307,7 +307,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -327,7 +327,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -341,7 +341,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -358,7 +358,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -381,7 +381,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -404,7 +404,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}

--- a/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
@@ -15,7 +15,7 @@
   "annotations": {
     "aws_local_service": "^{{serviceName}}$",
     "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{cluster}}$",
+    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
     "aws_local_operation": "^GET /aws-sdk-call$"
   },
   "metadata": {
@@ -39,7 +39,7 @@
           },
           "annotations": {
             "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-            "HostedIn_EKS_Cluster": "^{{cluster}}$",
+            "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
             "aws_local_service": "^{{serviceName}}$",
             "aws_local_operation": "^GET /aws-sdk-call$",
             "aws_remote_service": "^AWS\\.SDK\\.S3$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/client-call-log.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/client-call-log.mustache
@@ -1,5 +1,5 @@
 [{
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
@@ -10,7 +10,7 @@
   "aws.span.kind": "^LOCAL_ROOT$"
 },
 {
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
@@ -21,7 +21,7 @@
   "aws.span.kind": "^LOCAL_ROOT$"
 },
 {
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/client-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/client-call-metric.mustache
@@ -10,7 +10,7 @@
       value: GET /client-call
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -24,24 +24,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Operation
-      value: InternalOperation
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -58,7 +41,24 @@
       value: InternalOperation
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -78,7 +78,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -98,7 +98,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -118,7 +118,7 @@
       value: GET /client-call
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -132,24 +132,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Operation
-      value: InternalOperation
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -166,7 +149,24 @@
       value: InternalOperation
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -186,7 +186,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -206,7 +206,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -226,7 +226,7 @@
       value: GET /client-call
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -240,24 +240,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Fault
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Operation
-      value: InternalOperation
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -274,7 +257,24 @@
       value: InternalOperation
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -294,7 +294,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -314,7 +314,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}

--- a/testing/validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
@@ -3,7 +3,7 @@
   "annotations": {
     "aws_local_service": "^{{serviceName}}$",
     "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{cluster}}$",
+    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
     "aws_local_operation": "^InternalOperation$"
   },
   "metadata": {
@@ -24,7 +24,7 @@
       },
       "annotations": {
         "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-        "HostedIn_EKS_Cluster": "^{{cluster}}$",
+        "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
         "aws_local_service": "^{{serviceName}}$",
         "aws_local_operation": "^InternalOperation$",
         "aws_remote_service": "^local-root-client-call$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-log.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-log.mustache
@@ -1,5 +1,5 @@
 [{
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment(-[A-Za-z0-9]*)*$",
@@ -10,7 +10,7 @@
   "aws.span.kind": "^LOCAL_ROOT$"
 },
 {
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment(-[A-Za-z0-9]*)*$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-metric.mustache
@@ -10,7 +10,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -27,41 +27,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /
-    -
-      name: RemoteService
-      value: www.amazon.com
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -81,7 +47,41 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -101,7 +101,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -118,7 +118,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -138,7 +138,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -152,7 +152,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -172,7 +172,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -192,7 +192,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -209,7 +209,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -229,7 +229,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -243,7 +243,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -263,7 +263,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}

--- a/testing/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
@@ -15,7 +15,7 @@
   "annotations": {
     "aws_local_service": "^{{serviceName}}$",
     "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{cluster}}$",
+    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
     "aws_local_operation": "^GET /outgoing-http-call$"
   },
   "metadata": {
@@ -39,7 +39,7 @@
           },
           "annotations": {
             "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-            "HostedIn_EKS_Cluster": "^{{cluster}}$",
+            "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
             "aws_local_service": "^{{serviceName}}$",
             "aws_local_operation": "^GET /outgoing-http-call$",
             "aws_remote_service": "^www.amazon.com$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/remote-service-log.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/remote-service-log.mustache
@@ -1,5 +1,5 @@
 [{
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",
   "K8s.Pod": "^sample-app-deployment(-[A-Za-z0-9]*)*$",
@@ -10,7 +10,7 @@
   "aws.span.kind": "^LOCAL_ROOT$"
 },
 {
-  "HostedIn.EKS.Cluster": "^{{cluster}}$",
+  "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
   "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
   "K8s.RemoteNamespace": "^{{appNamespace}}$",
   "K8s.Node": "^i-[A-Za-z0-9]{17}$",

--- a/testing/validator/src/main/resources/expected-data-template/eks/remote-service-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/remote-service-metric.mustache
@@ -10,7 +10,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -27,7 +27,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -44,7 +44,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -64,7 +64,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -78,7 +78,7 @@
       value: {{remoteServiceDeploymentName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -92,7 +92,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -109,7 +109,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -134,7 +134,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -154,7 +154,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -177,206 +177,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: K8s.RemoteNamespace
-      value: {{appNamespace}}
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: Operation
-      value: GET /healthcheck
-    -
-      name: Service
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: K8s.RemoteNamespace
-      value: {{appNamespace}}
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
-    -
-      name: K8s.RemoteNamespace
-      value: {{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -397,6 +198,205 @@
       value: {{serviceName}}
 
 -
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
   metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
@@ -408,7 +408,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -425,7 +425,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -442,7 +442,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -462,7 +462,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -476,7 +476,7 @@
       value: {{remoteServiceDeploymentName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -490,7 +490,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -507,7 +507,7 @@
       value: {{serviceName}}
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -532,7 +532,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -552,7 +552,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}
@@ -575,7 +575,7 @@
   dimensions:
     -
       name: HostedIn.EKS.Cluster
-      value: {{cluster}}
+      value: {{platformInfo}}
     -
       name: HostedIn.K8s.Namespace
       value: {{appNamespace}}

--- a/testing/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
@@ -15,7 +15,7 @@
   "annotations": {
     "aws_local_service": "^{{serviceName}}$",
     "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{cluster}}$",
+    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
     "aws_local_operation": "^GET /remote-service$"
   },
   "metadata": {
@@ -65,7 +65,7 @@
   "annotations": {
     "aws_local_service": "^{{remoteServiceDeploymentName}}$",
     "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{cluster}}$",
+    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
     "aws_local_operation": "^GET /healthcheck$"
   },
   "metadata": {
@@ -81,7 +81,7 @@
       "name": "^RemoteServiceController.healthcheck$",
       "annotations": {
         "HostedIn_K8s_Namespace": "^sample-app-namespace$",
-        "HostedIn_EKS_Cluster": "^{{cluster}}$",
+        "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
         "aws_local_operation": "^GET /healthcheck$"
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
The main goal of this PR is to add the E2E canaries to the following regions: CMH, DUB, NRT, SYD.
Also includes minor additional changes to the code.

*Description of changes:*
- Added region as input to workflow
- Add region to test ID so that runs make different service accounts
- Change the validator input variable `--cluster` to `--platformInfo` to use one variable for platform specific information rather than making multiple for each platform. 
- Look for the most recent AMI for EC2 instances. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
