### PR TITLE
Add retry logic to sample app endpoint connection

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -5,6 +5,9 @@ name: App Signals Enablement E2E Testing - EKS
 on:
   workflow_call:
     inputs:
+      aws-region:
+        required: true
+        type: string
       test-cluster-name:
         required: true
         type: string
@@ -20,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} # Used by terraform and AWS CLI commands
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   ENABLEMENT_SCRIPT_S3_BUCKET: ${{ secrets.APP_SIGNALS_E2E_ENABLEMENT_SCRIPT }}
   SAMPLE_APP_NAMESPACE: sample-app-namespace
@@ -38,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ env.AWS_DEFAULT_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -87,6 +90,7 @@ jobs:
           terraform validate
           terraform apply -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}" \
+            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
             -var="kube_directory_path=${{ github.workspace }}/.kube" \
             -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
             -var="eks_cluster_context_name=$(kubectl config current-context)" \
@@ -112,53 +116,55 @@ jobs:
 
       # Application pods need to be restarted for the
       # app signals instrumentation to take effect
-      - name: Restart the app pods
-        run: kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
+      - name: Restart the app pods and wait for the endpoints to come online
+        id: restart-pod
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 6
+          shell: bash
+          # Restart the pod, then attempt to connect to the endpoint. It will try 30 times with 10 seconds delay. If
+          # it fails to establish connection, restart the pod and try again up to 3 tries.
+          command: | 
+            kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
+            kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
+            cd testing/terraform/eks
+            sample_app_endpoint=http://$(terraform output sample_app_endpoint)
+            cd ../../../              
+            curl --retry 30 --retry-delay 10 -s -o /dev/null $(echo "$sample_app_endpoint" | tr -d '"')
+            if [ $? != "0" ];then
+              echo "Failed to establish connection with endpoint"
+              exit 1
+            fi
 
-      - name: Wait for sample app pods to come up
-        run: |
-          kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
+      - name: Get the sample app endpoint
+        if: steps.restart-pod.outcome == 'success' && !cancelled()
+        run: echo "APP_ENDPOINT=$(terraform output sample_app_endpoint)" >> $GITHUB_ENV
+        working-directory: testing/terraform/eks
 
       - name: Get remote service pod name and IP
+        if: steps.restart-pod.outcome == 'success' && !cancelled()
         run: |
           echo "REMOTE_SERVICE_DEPLOYMENT_NAME=$(kubectl get deployments -n ${{ env.SAMPLE_APP_NAMESPACE }} --selector=app=remote-app -o jsonpath='{.items[0].metadata.name}')" >> $GITHUB_ENV
           echo "REMOTE_SERVICE_POD_IP=$(kubectl get pods -n ${{ env.SAMPLE_APP_NAMESPACE }} --selector=app=remote-app -o jsonpath='{.items[0].status.podIP}')" >> $GITHUB_ENV
 
       - name: Verify pod Adot image
+        if: steps.restart-pod.outcome == 'success' && !cancelled()
         run: |
           kubectl get pods -n ${{ env.SAMPLE_APP_NAMESPACE }} --output json | \
           jq '.items[0].status.initContainerStatuses[0].imageID'
 
       - name: Verify pod CWAgent image
+        if: steps.restart-pod.outcome == 'success' && !cancelled()
         run: |
           kubectl get pods -n amazon-cloudwatch --output json | \
           jq '.items[0].status.containerStatuses[0].imageID'
 
-      - name: Get the sample app endpoint
-        run: |
-          echo "APP_ENDPOINT=$(terraform output sample_app_endpoint)" >> $GITHUB_ENV
-        working-directory: testing/terraform/eks
-
-      - name: Wait for app endpoint to come online
-        id: endpoint-check
-        run: |
-          attempt_counter=0
-          max_attempts=30
-          until $(curl --output /dev/null --silent --head --fail http://${{ env.APP_ENDPOINT }}); do
-            if [ ${attempt_counter} -eq ${max_attempts} ];then
-              echo "Max attempts reached"
-              exit 1
-            fi
-
-            printf '.'
-            attempt_counter=$(($attempt_counter+1))
-            sleep 10
-          done
-
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs
         id: log-validation
-        if: steps.endpoint-check.outcome == 'success' && !cancelled()
+        if: steps.restart-pod.outcome == 'success' && !cancelled()
         run: ./gradlew testing:validator:run --args='-c eks/log-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}


### PR DESCRIPTION
*Issue #, if available:*
The E2E canary occasionally fails due to being unable to establish connection with the sample app. 
*Description of changes:*
If connecting to the endpoint fails, then restart the sample app again and reattempt establishing connection; up to 3 times

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
