### PR TITLE
Fix trace validation error follow up fix

### DIFF
--- a/testing/validator/src/main/java/com/amazon/aoc/services/XRayService.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/services/XRayService.java
@@ -58,8 +58,10 @@ public class XRayService {
             new GetTraceSummariesRequest()
                 .withStartTime(pastDate)
                 .withEndTime(currentDate)
-                .withFilterExpression("annotation.aws_local_service = " + serviceName)
-                .withFilterExpression("annotation.aws_local_service = \"local-root-client-call\""));
+                .withFilterExpression(
+                    "annotation.aws_local_service = \""
+                        + serviceName
+                        + "\" AND annotation.aws_local_service = \"local-root-client-call\""));
     return traceSummaryResult.getTraceSummaries();
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Follow up on this https://github.com/aws-observability/aws-otel-java-instrumentation/pull/617.
The previous PR applied two separate filter expressions while searching for xray traces, which returned any traces matching either conditions. Need to change the logic so that traces matching both conditions are returned.

*Description of changes:*
Combined the two filter expressions into one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
