### PR TITLE
fix-e2e-eks-terraform-destroy-error

### DIFF
--- a/testing/terraform/eks/main.tf
+++ b/testing/terraform/eks/main.tf
@@ -16,9 +16,7 @@ terraform {
   }
 }
 
-provider "aws" {
-  region = var.aws_region
-}
+provider "aws" {}
 
 # get eks cluster
 data "aws_eks_cluster" "testing_cluster" {


### PR DESCRIPTION
*Issue #, if available:*
Although it's not causing functional problems, the `terraform destroy` step on the eks canary returns a failure due to having an invalid aws_region variable. Ex: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7093413738

*Description of changes:*
Removed aws_region on the terraform provider description

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
