### PR TITLE
Feat: add support to releasing to private ECR

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,8 +7,12 @@ on:
         required: true
 
 env:
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_PUBLIC_ECR_REGION: us-east-1
+  AWS_PRIVATE_ECR_REGION: us-west-2
   TEST_TAG: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:test
+  PUBLIC_REPOSITORY: public.ecr.aws/aws-observability/adot-autoinstrumentation-java
+  PRIVATE_REPOSITORY: 020628701572.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java
+  PRIVATE_REGISTRY: 020628701572.dkr.ecr.us-west-2.amazonaws.com
 
 permissions:
   id-token: write
@@ -37,7 +41,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
 
       - name: Log in to AWS ECR
         uses: docker/login-action@v3
@@ -53,12 +57,23 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
 
       - name: Log in to AWS ECR
         uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
+
+      - name: Configure AWS Credentials for Private ECR
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
+          aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
+
+      - name: Log in to AWS private ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.PRIVATE_REGISTRY }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -88,7 +103,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ github.event.inputs.version }}
+            ${{ env.PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
+            ${{ env.PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
       - name: Build and Publish release with Gradle
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION

*Description of changes:*

Publish the the ADOT Java image to a private ECR repository as well.

This PR makes use of this feature: https://docs.docker.com/build/ci/github-actions/push-multi-registries/


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
