### PR TITLE
Add Retry Mechanism to E2E EC2 Terraform Deployment

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -48,18 +48,61 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Deploy sample app via terraform
+      - name: Deploy sample app via terraform and wait for endpoint to come online
         working-directory: testing/terraform/ec2
         run: |
           terraform init
           terraform validate
-          terraform apply -auto-approve \
-            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
-            -var="test_id=${{ env.TESTING_ID }}" \
-            -var="sample_app_jar=${{ env.SAMPLE_APP_FRONTEND_SERVICE_JAR }}" \
-            -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
-            -var="cw_agent_rpm=${{ env.APP_SIGNALS_CW_AGENT_RPM }}" \
-            -var="adot_jar=${{ env.APP_SIGNALS_ADOT_JAR }}"
+          
+          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online. 
+          # There may be occasional failures due to transitivity issues, so try up to 2 times. 
+          # Success of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
+          # that it failed at some point
+          retry_counter=0
+          max_retry=2
+          success=1 
+          while [ $success -eq 1 ]; do
+            if [ $retry_counter -ge $max_retry ]; then
+              exit 1
+            fi
+            success=0
+            terraform apply -auto-approve \
+              -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
+              -var="test_id=${{ env.TESTING_ID }}" \
+              -var="sample_app_jar=${{ env.SAMPLE_APP_FRONTEND_SERVICE_JAR }}" \
+              -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
+              -var="cw_agent_rpm=${{ env.APP_SIGNALS_CW_AGENT_RPM }}" \
+              -var="adot_jar=${{ env.APP_SIGNALS_ADOT_JAR }}" || success=$?
+          
+            # If the success is still 0, then the terraform deployment succeeded and now try to connect to the endpoint.
+            # Attempts to connect will be made for up to 10 minutes
+            if [ $success -eq 0 ]; then
+              echo "Attempting to connect to the endpoint"
+              sample_app_endpoint=http://$(terraform output sample_app_main_service_public_dns):8080
+              attempt_counter=0
+              max_attempts=60
+              until $(curl --output /dev/null --silent --head --fail $(echo "$sample_app_endpoint" | tr -d '"')); do
+                if [ ${attempt_counter} -eq ${max_attempts} ];then
+                  echo "Max attempts reached"
+                  success=1
+                  break
+                fi
+          
+                printf '.'
+                attempt_counter=$(($attempt_counter+1))
+                sleep 10
+              done
+            fi
+          
+            # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
+            # resources created from terraform and try again.
+            if [ $success -eq 1 ]; then
+              terraform destroy -auto-approve \
+                -var="test_id=${{ env.TESTING_ID }}" 
+          
+              retry_counter=$(($retry_counter+1))
+            fi
+          done
 
       - name: Get the ec2 instance ami id
         run: |
@@ -71,22 +114,6 @@ jobs:
           echo "MAIN_SERVICE_ENDPOINT=$(terraform output sample_app_main_service_public_dns):8080" >> $GITHUB_ENV
           echo "REMOTE_SERVICE_IP=$(terraform output sample_app_remote_service_public_ip)" >> $GITHUB_ENV
         working-directory: testing/terraform/ec2
-
-      - name: Wait for app endpoint to come online
-        id: endpoint-check
-        run: |
-          attempt_counter=0
-          max_attempts=30
-          until $(curl --output /dev/null --silent --head --fail http://${{ env.MAIN_SERVICE_ENDPOINT }}); do
-            if [ ${attempt_counter} -eq ${max_attempts} ];then
-              echo "Max attempts reached"
-              exit 1
-            fi
-
-            printf '.'
-            attempt_counter=$(($attempt_counter+1))
-            sleep 10
-          done
 
       # This steps increases the speed of the validation by creating the telemetry data in advance
       - name: Call all test APIs
@@ -174,4 +201,4 @@ jobs:
         working-directory: testing/terraform/ec2
         run: |
           terraform destroy -auto-approve \
-            -var="test_id=${{ env.TESTING_ID }}" 
+            -var="test_id=${{ env.TESTING_ID }}"

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -56,33 +56,29 @@ jobs:
           
           # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online. 
           # There may be occasional failures due to transitivity issues, so try up to 2 times. 
-          # Success of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
+          # deployment_failed of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
           # that it failed at some point
           retry_counter=0
           max_retry=2
-          success=1 
-          while [ $success -eq 1 ]; do
-            if [ $retry_counter -ge $max_retry ]; then
-              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
-              exit 1
-            fi
+          while [ $retry_counter -lt $max_retry ]; do
             echo "Attempt $retry_counter"
-            success=0
+            deployment_failed=0
             terraform apply -auto-approve \
               -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
               -var="sample_app_jar=${{ env.SAMPLE_APP_FRONTEND_SERVICE_JAR }}" \
               -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
               -var="cw_agent_rpm=${{ env.APP_SIGNALS_CW_AGENT_RPM }}" \
-              -var="adot_jar=${{ env.APP_SIGNALS_ADOT_JAR }}" || success=$?
+              -var="adot_jar=${{ env.APP_SIGNALS_ADOT_JAR }}" \
+            || deployment_failed=$?
           
-            if [ $success -eq 1 ]; then
+            if [ $deployment_failed -eq 1 ]; then
               echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
             fi
           
-            # If the success is still 0, then the terraform deployment succeeded and now try to connect to the endpoint.
+            # If the deployment_failed is still 0, then the terraform deployment succeeded and now try to connect to the endpoint.
             # Attempts to connect will be made for up to 10 minutes
-            if [ $success -eq 0 ]; then
+            if [ $deployment_failed -eq 0 ]; then
               echo "Attempting to connect to the endpoint"
               sample_app_endpoint=http://$(terraform output sample_app_main_service_public_dns):8080
               attempt_counter=0
@@ -90,7 +86,7 @@ jobs:
               until $(curl --output /dev/null --silent --head --fail $(echo "$sample_app_endpoint" | tr -d '"')); do
                 if [ ${attempt_counter} -eq ${max_attempts} ];then
                   echo "Failed to connect to endpoint. Will attempt to redeploy sample app."
-                  success=1
+                  deployment_failed=1
                   break
                 fi
           
@@ -102,12 +98,20 @@ jobs:
           
             # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
             # resources created from terraform and try again.
-            if [ $success -eq 1 ]; then
+            if [ $deployment_failed -eq 1 ]; then
               echo "Destroying terraform"
               terraform destroy -auto-approve \
                 -var="test_id=${{ env.TESTING_ID }}" 
           
               retry_counter=$(($retry_counter+1))
+            else
+              # If deployment succeeded, then exit the loop
+              break
+            fi
+          
+            if [ $retry_counter -eq $max_retry ]; then
+              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
+              exit 1
             fi
           done
 

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -63,8 +63,10 @@ jobs:
           success=1 
           while [ $success -eq 1 ]; do
             if [ $retry_counter -ge $max_retry ]; then
+              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
               exit 1
             fi
+            echo "Attempt $retry_counter"
             success=0
             terraform apply -auto-approve \
               -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
@@ -73,6 +75,10 @@ jobs:
               -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
               -var="cw_agent_rpm=${{ env.APP_SIGNALS_CW_AGENT_RPM }}" \
               -var="adot_jar=${{ env.APP_SIGNALS_ADOT_JAR }}" || success=$?
+          
+            if [ $success -eq 1 ]; then
+              echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
+            fi
           
             # If the success is still 0, then the terraform deployment succeeded and now try to connect to the endpoint.
             # Attempts to connect will be made for up to 10 minutes
@@ -83,7 +89,7 @@ jobs:
               max_attempts=60
               until $(curl --output /dev/null --silent --head --fail $(echo "$sample_app_endpoint" | tr -d '"')); do
                 if [ ${attempt_counter} -eq ${max_attempts} ];then
-                  echo "Max attempts reached"
+                  echo "Failed to connect to endpoint. Will attempt to redeploy sample app."
                   success=1
                   break
                 fi
@@ -97,6 +103,7 @@ jobs:
             # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
             # resources created from terraform and try again.
             if [ $success -eq 1 ]; then
+              echo "Destroying terraform"
               terraform destroy -auto-approve \
                 -var="test_id=${{ env.TESTING_ID }}" 
           

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -274,4 +274,4 @@ jobs:
           --name service-account-${{ env.TESTING_ID }} \
           --namespace ${{ env.SAMPLE_APP_NAMESPACE }} \
           --cluster ${{ inputs.test-cluster-name }} \
-          --region ${{ env.AWS_DEFAULT_REGION }} \
+          --region ${{ env.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
Issue #, if available:
The EC2 Canary occasionally fails due to transitivity issues. Some of the recurring errors are `Max attempts reached` in the [Step](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7082260691/job/19272772682) : `Wait for Endpoint to Come Online` and the [Step](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7115409391/job/19371495221): `Timeout while waiting for state to become running`. This occurs due to the endpoint and the ec2 instances sometime taking longer than expected to become ready.

Description of changes:
- Change the endpoint wait time from 5 minutes to 10 minutes.
- Add a retry mechanism such that if either the terraform deployment or the endpoint connection fails, then destroy the terraform deployment and try again. This will ensure that the endpoint is deleted and recreated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
