### PR TITLE
E2E Testing: Add concurrency tag to test in main build and nightly build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -457,6 +457,9 @@ jobs:
           VALIDATOR_COMMAND: -c spark-otel-trace-metric-validation.yml --endpoint http://app:4567 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}
 
   e2e-test:
+    concurrency:
+      group: e2e-adot-test
+      cancel-in-progress: false
     needs: build
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -108,6 +108,9 @@ jobs:
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar
 
   e2e-test:
+    concurrency:
+      group: e2e-adot-test
+      cancel-in-progress: false
     needs: build
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit


### PR DESCRIPTION
Adding concurrency tag to test in main build and nightly build without having conflicting jobs occurring at the same time. This way, the e2e-adot-test cluster will not be used by two jobs at the same time


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
