### PR TITLE
Provide aws-region for the e2e test in worklow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -464,6 +464,7 @@ jobs:
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit
     with:
+      aws-region: us-east-1
       test-cluster-name: "e2e-adot-test"
       appsignals-adot-image-name: ${{ needs.build.outputs.staging-image-name }}
       caller-workflow-name: 'main-build'

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -115,6 +115,7 @@ jobs:
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit
     with:
+      aws-region: us-east-1
       test-cluster-name: "e2e-adot-test"
       appsignals-adot-image-name: ${{ needs.build.outputs.release-candidate-image }}
       caller-workflow-name: 'nightly-upstream-snapshot-build'


### PR DESCRIPTION
Current [workflows are failing](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7176507664) and are not valid. Provide `aws-region` for the e2e test in worklow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
