### PR TITLE
Change App Signals Directory for E2E EKS Testing

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -240,6 +240,7 @@ jobs:
       - name: Clean Up App Signals
         if: always()
         continue-on-error: true
+        working-directory: testing/terraform/eks
         run: |
           ./clean-app-signals.sh \
           ${{ inputs.test-cluster-name }} \


### PR DESCRIPTION
*Issue #, if available:*
The App Signals download directory was changed to testing/terraform/eks in this PR: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/634
Need to run ./clean-app-signals.sh in the correct directory else the E2E EKS canary will fail to cleanup properly: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7203256881

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
