### PR TITLE
E2E Testing: Fix EKS test candidate image override

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -88,10 +88,6 @@ jobs:
         working-directory: testing/terraform/eks
         run: aws s3 cp ${{ env.ENABLEMENT_SCRIPT_S3_BUCKET }} . && unzip -j onboarding.zip
 
-      - name: Change ADOT image if main-build
-        if: inputs.caller-workflow-name == 'main-build'
-        run: "sed -i 's#image:.*#image: ${{ inputs.appsignals-adot-image-name }}#g' instrumentation.yaml"
-
       - name: Remove log group deletion command
         if: always()
         working-directory: testing/terraform/eks
@@ -139,6 +135,15 @@ jobs:
               ${{ inputs.test-cluster-name }} \
               ${{ env.AWS_DEFAULT_REGION }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}
+          
+              # If the workflow provides a specific ADOT image to test, patch the deployment and restart CW agent related pods
+              if [ ${{ inputs.appsignals-adot-image-name }} != "" ]; then
+                kubectl patch deploy -namazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+                -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/0", "value": "--auto-instrumentation-java-image=${{ inputs.appsignals-adot-image-name }}"}]'
+          
+                kubectl delete pods --all -n amazon-cloudwatch
+                kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+              fi
           
               kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
               kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}


### PR DESCRIPTION
This change checks if there is an adot image passed to the workflow and patches the App Signals deployment to update the image and restarts the cloudwatch pods. We check for input instead of a specific workflow, allowing any workflow to call this and run the e2e test.

Note: It is a limitation of EKS addon that we cannot set the artifact version before enabling pulse because the enablement script refers to a specific version of the addon we cannot change/create a new one for. As such, we need to apply the change for the ADOT image after enabling app signals, then restart the relevant pods.

Tested in private repo:
Test showing failure when using a non application signals image: [run](https://github.com/aws-observability/aws-apm-java-instrumentation/actions/runs/7201809370)
- `public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.30.0`

Test showing pass for no input: [run](https://github.com/aws-observability/aws-apm-java-instrumentation/actions/runs/7212987747)
Test showing pass for app signals as input: [run](https://github.com/aws-observability/aws-apm-java-instrumentation/actions/runs/7213496367)
- `public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.31.1`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
