### PR TITLE
[v1.31.1] [Cherry-pick 651] Change dependency config in awsagentprovider

### DIFF
--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   // AWS Resource Detectors
   implementation("io.opentelemetry.contrib:opentelemetry-aws-resources")
   // Export configuration
-  implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+  compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")


### PR DESCRIPTION
*Issue #, if available:*
fixed https://github.com/aws-observability/aws-otel-java-instrumentation/issues/648, https://github.com/aws-observability/aws-otel-java-instrumentation/issues/644 in v1.31.x.

*Description of changes:*
In this PR, we changed the dependency configuration of `io.opentelemetry:opentelemetry-exporter-otlp` from `implementation` to `compileOnly`.

The high cardinality issue was caused by introducing this dependency as `implementation` which causes classpath conflict during the runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.