### PR TITLE
[v1.31.1] [Cherry-pick 646] E2E Testing: Add concurrency tag to test in main build and nightly build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -452,6 +452,9 @@ jobs:
           VALIDATOR_COMMAND: -c spark-otel-trace-metric-validation.yml --endpoint http://app:4567 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}
 
   e2e-test:
+    concurrency:
+      group: e2e-adot-test
+      cancel-in-progress: false
     needs: build
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -98,6 +98,9 @@ jobs:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar
 
+    concurrency:
+      group: e2e-adot-test
+      cancel-in-progress: false
   publish-build-status:
     needs: [build]
     if: ${{ always() }}


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Cherry-pick https://github.com/aws-observability/aws-otel-java-instrumentation/pull/646 to v1.31.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
