### PR TITLE
Download Enablement Script from Github Repo Instead of S3

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -40,6 +40,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download enablement script
+        uses: actions/checkout@v4
+        with:
+          repository: aws-observability/application-signals-demo
+          ref: main
+          path: enablement-script
+          sparse-checkout: |
+            scripts/eks/appsignals/enable-app-signals.sh
+            scripts/eks/appsignals/clean-app-signals.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Remove log group deletion command
+        if: always()
+        working-directory: enablement-script/scripts/eks/appsignals
+        run: |
+          delete_log_group="aws logs delete-log-group --log-group-name '${{ env.LOG_GROUP_NAME }}' --region \$REGION"
+          sed -i "s#$delete_log_group##g" clean-app-signals.sh
+
       - name: Generate testing id
         run: echo TESTING_ID="${{ env.AWS_DEFAULT_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
@@ -83,21 +101,6 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Download enablement scripts from repository
-        working-directory: testing/terraform/eks
-        run: |
-          curl -O https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/enable-app-signals.sh
-          curl -O https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/clean-app-signals.sh
-          chmod 755 ./enable-app-signals.sh
-          chmod 755 ./clean-app-signals.sh
-
-      - name: Remove log group deletion command
-        if: always()
-        working-directory: testing/terraform/eks
-        run: |
-          delete_log_group="aws logs delete-log-group --log-group-name '${{ env.LOG_GROUP_NAME }}' --region \$REGION"
-          sed -i "s#$delete_log_group##g" clean-app-signals.sh
-
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-sample-app
         working-directory: testing/terraform/eks
@@ -134,7 +137,7 @@ jobs:
             # after installing App Signals. Attempts to connect will be made for up to 10 minutes
             if [ $deployment_failed -eq 0 ]; then
               echo "Installing app signals to the sample app"
-              ./enable-app-signals.sh \
+              ${GITHUB_WORKSPACE}/enablement-script/scripts/eks/appsignals/enable-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
               ${{ env.AWS_DEFAULT_REGION }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}
@@ -296,7 +299,7 @@ jobs:
       - name: Clean Up App Signals
         if: always()
         continue-on-error: true
-        working-directory: testing/terraform/eks
+        working-directory: enablement-script/scripts/eks/appsignals
         run: |
           ./clean-app-signals.sh \
           ${{ inputs.test-cluster-name }} \

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -83,14 +83,13 @@ jobs:
         with:
           terraform_wrapper: false
 
-      # Enable App Signals on the test cluster
-      - name: Pull and unzip enablement script from S3
+      - name: Download enablement scripts from repository
         working-directory: testing/terraform/eks
-        run: aws s3 cp ${{ env.ENABLEMENT_SCRIPT_S3_BUCKET }} . && unzip -j onboarding.zip
-
-      - name: Change ADOT image if main-build
-        if: inputs.caller-workflow-name == 'main-build'
-        run: "sed -i 's#image:.*#image: ${{ inputs.appsignals-adot-image-name }}#g' instrumentation.yaml"
+        run: |
+          curl -O https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/enable-app-signals.sh
+          curl -O https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/clean-app-signals.sh
+          chmod 755 ./enable-app-signals.sh
+          chmod 755 ./clean-app-signals.sh
 
       - name: Remove log group deletion command
         if: always()


### PR DESCRIPTION
*Issue #, if available:*
The latest scripts for App Signals Enablement are now located in this [repo](https://github.com/aws-observability/application-signals-demo). 

*Description of changes:*
Replace the code downloading the enablement scripts from the S3 Bucket and download the scripts directly from the github repository instead. 

Also remove the `change ADOT image if main-build` step, outdated code. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
