### PR TITLE
Restore Cache in AppSignals e2e Tests Workflow

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -214,6 +214,14 @@ jobs:
           kubectl get pods -n amazon-cloudwatch --output json | \
           jq '.items[0].status.containerStatuses[0].imageID'
 
+      # cache local patch outputs
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/**/opentelemetry-java-*.patch') }}
+
       - name: Get the sample app endpoint
         run: echo "APP_ENDPOINT=$(terraform output sample_app_endpoint)" >> $GITHUB_ENV
         working-directory: testing/terraform/eks


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Restore cache in AppSignals e2e to resolve [this](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7266704488/job/19799965604#step:19:83) build failure.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
