### PR TITLE
Removing patch dependencies scope restriction to release branch only

### DIFF
--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -13,9 +13,6 @@ inputs:
     default: "false"
     required: false
     description: "If the workflow should run tests of the dependencies. Anything different than false will evaluate to true"
-  branch:
-    required: true
-    description: "The branch where this patches are being applied e.g.: release/v1.21.x"
   gpg_private_key:
     description: "The gpg key used to sign the artifacts"
     required: true
@@ -27,19 +24,19 @@ runs:
   steps:
     - name: check patches
       run: |
-        if [[ -f .github/patches/${{ inputs.branch }}/opentelemetry-java.patch ]]; then
+        if [[ -f .github/patches/opentelemetry-java.patch ]]; then
           echo 'patch_otel_java=true' >> $GITHUB_ENV
         fi
-        if [[ -f .github/patches/${{ inputs.branch }}/opentelemetry-java-instrumentation.patch ]]; then
+        if [[ -f .github/patches/opentelemetry-java-instrumentation.patch ]]; then
             echo 'patch_otel_java_instrumentation=true' >> $GITHUB_ENV
         fi
-        if [[ -f .github/patches/${{ inputs.branch }}/opentelemetry-java-contrib.patch ]]; then
+        if [[ -f .github/patches/opentelemetry-java-contrib.patch ]]; then
             echo 'patch_otel_java_contrib=true' >> $GITHUB_ENV
         fi
       shell: bash
 
     - name: Clone and patch repositories
-      run: .github/scripts/patch.sh "${{ inputs.branch }}"
+      run: .github/scripts/patch.sh
       if: ${{ env.patch_otel_java == 'true' ||
               env.patch_otel_java_instrumentation == 'true' ||
               env.patch_otel_java_contrib == 'true' }}

--- a/.github/scripts/patch.sh
+++ b/.github/scripts/patch.sh
@@ -2,10 +2,7 @@
 # Enable debug mode, fail on any command that fail in this script and fail on unset variables
 set -x -e -u
 
-# This parameter will help find the patches to be applied
-BRANCH=$1
-
-# .github/patches/$BRANCH/versions.sh should define all the versions of the dependencies that we are going to patch
+# .github/patches/versions.sh should define all the versions of the dependencies that we are going to patch
 # This is used so that we can properly clone the upstream repositories.
 # This file should define the following variables:
 # OTEL_JAVA_VERSION. Tag of the opentelemetry-java repository to use. E.g.: JAVA_OTEL_JAVA_VERSION=v1.21.0
@@ -13,18 +10,18 @@ BRANCH=$1
 # OTEL_JAVA_CONTRIB_VERSION. Tag of the opentelemetry-java-contrib repository. E.g.: OTEL_JAVA_CONTRIB_VERSION=v1.21.0
 # This script will fail if a variable that is supposed to exist is referenced.
 
-if [[ ! -f .github/patches/${BRANCH}/versions ]]; then
+if [[ ! -f .github/patches/versions ]]; then
   echo "No versions file found. Skipping patching"
   exit 0
 fi
 
-source .github/patches/${BRANCH}/versions
+source .github/patches/versions
 
 git config --global user.email "adot-patch-workflow@github.com"
 git config --global user.name "ADOT Patch workflow"
 
 
-OTEL_JAVA_PATCH=".github/patches/${BRANCH}/opentelemetry-java.patch"
+OTEL_JAVA_PATCH=".github/patches/opentelemetry-java.patch"
 if [[ -f "$OTEL_JAVA_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java.git
   cd opentelemetry-java
@@ -37,7 +34,7 @@ else
 fi
 
 
-OTEL_JAVA_CONTRIB_PATCH=".github/patches/${BRANCH}/opentelemetry-java-contrib.patch"
+OTEL_JAVA_CONTRIB_PATCH=".github/patches/opentelemetry-java-contrib.patch"
 if [[ -f "$OTEL_JAVA_CONTRIB_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-contrib.git
   cd opentelemetry-java-contrib
@@ -50,7 +47,7 @@ else
 fi
 
 
-OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patches/${BRANCH}/opentelemetry-java-instrumentation.patch"
+OTEL_JAVA_INSTRUMENTATION_PATCH=".github/patches/opentelemetry-java-instrumentation.patch"
 if [[ -f "$OTEL_JAVA_INSTRUMENTATION_PATCH" ]]; then
   git clone https://github.com/open-telemetry/opentelemetry-java-instrumentation.git
   cd opentelemetry-java-instrumentation

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -25,7 +25,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref_name, 'release/v') }}
+    if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -48,7 +48,6 @@ jobs:
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"
-          branch: ${{ github.ref_name }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -72,13 +71,12 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/**/opentelemetry-java-*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java-*.patch') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ startsWith(github.ref_name, 'release/v') }}
+        if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
         with:
-          branch: ${{ github.ref_name }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -339,7 +337,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/**/opentelemetry-java-*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java-*.patch') }}
 
       - uses: gradle/wrapper-validation-action@v1
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -25,7 +25,6 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -75,7 +74,6 @@ jobs:
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java-*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
@@ -335,7 +335,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java-*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
       - uses: gradle/wrapper-validation-action@v1
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,7 +11,6 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +75,6 @@ jobs:
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java-*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,7 +11,7 @@ jobs:
   testpatch:
     name: Test patches applied to dependencies
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.event.pull_request.base.ref, 'release/v') }}
+    if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +37,6 @@ jobs:
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"
-          branch: ${{ github.event.pull_request.base.ref }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -67,11 +66,18 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
+        # cache local patch outputs
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java-*.patch') }}
+
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
-        if: ${{ startsWith(github.event.pull_request.base.ref, 'release/v') }}
+        if: ${{ hashFiles('.github/patches/opentelemetry-java-*.patch') != ''}}
         with:
-          branch: ${{ github.event.pull_request.base.ref }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x]  Includes maven cache in prbuild to make subsequent pr builds faster.
- [x]  Updates patch workflows and scripts so that they are not scoped to only release branches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
