### PR TITLE
Handle multi-line strings in patch action. 

### DIFF
--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -28,11 +28,20 @@ runs:
         INPUT_PASSWORD: ${{ inputs.gpg_password }}
       shell: bash
       run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         if [[ ! -z "$INPUT_KEY" ]]; then
-          echo "GPG_PRIVATE_KEY=$INPUT_KEY" >> $GITHUB_ENV
+          {
+            echo "GPG_PRIVATE_KEY<<$EOF"
+            echo "$INPUT_KEY"
+            echo "$EOF"
+          } >> "$GITHUB_ENV"
         fi
         if [[ ! -z "$INPUT_PASSWORD" ]]; then
-          echo "GPG_PASSWORD=$INPUT_PASSWORD" >> $GITHUB_ENV
+          {
+            echo "GPG_PASSWORD<<$EOF"
+            echo "$INPUT_PASSWORD"
+            echo "$EOF"
+          } >> "$GITHUB_ENV"
         fi
 
     - name: check patches


### PR DESCRIPTION
*Issue #, if available:* Handle key and secret being multi-line strings using official [docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings). Use randomization suggested [here](https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully) to avoid EOF conflicts. 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
