### PR TITLE
Use input rather than secret in composite action

### DIFF
--- a/.github/actions/cpUtility-testing/action.yml
+++ b/.github/actions/cpUtility-testing/action.yml
@@ -16,6 +16,10 @@ inputs:
   adot-java-version:
     required: true
     description: "ADOT Java Version"
+  snapshot-ecr-role:
+    require: true
+    description: "IAM Role used for pushing to snapshot ecr"
+
 
 runs:
   using: "composite"
@@ -29,7 +33,7 @@ runs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
+        role-to-assume: ${{ inputs.snapshot-ecr-role }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Login to private staging ecr

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -126,6 +126,7 @@ jobs:
           image_uri_with_tag: ${{ steps.imageOutput.outputs.stagingImage }}
           image_registry: ${{ steps.imageOutput.outputs.stagingRegistry }}
           adot-java-version: ${{ steps.getADOTJavaVersion.outputs.adot_java_version }}
+          snapshot-ecr-role: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
 
       - name: Upload to GitHub Actions
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -78,6 +78,7 @@ jobs:
           image_uri_with_tag: ${{ steps.imageOutput.outputs.rcImage }}
           image_registry: ${{ steps.imageOutput.outputs.imageRegistry }}
           adot-java-version: ${{ steps.getADOTJavaVersion.outputs.adot_java_version }}
+          snapshot-ecr-role: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
 
       - name: Upload to GitHub Actions
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
*Description of changes:* Composite actions do not have access to secrets. They must be passed in as inputs. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
