### PR TITLE
reorder codeql init

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: java
+
     - uses: actions/setup-java@v4
       with:
         java-version: 17
@@ -43,12 +49,6 @@ jobs:
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         gpg_password: ${{ secrets.GPG_PASSPHRASE }}
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: java
         
     - uses: gradle/wrapper-validation-action@v1
 


### PR DESCRIPTION
*Description of changes:*
`
Encountered a fatal error while running "/opt/hostedtoolcache/CodeQL/2.15.5/x64/codeql/codeql database finalize --finalize-dataset --threads=4 --ram=14567 /home/runner/work/_temp/codeql_databases/java". Exit code was 32 and last log line was: CodeQL detected code written in Java/Kotlin and Java/Kotlin but could not process any of it. Review our troubleshooting guide at https://gh.io/troubleshooting-code-scanning/no-source-code-seen-during-build . See the logs for more details.
`


To address error we are reordering codeql initialization action to happen before patch build. 
https://github.com/orgs/community/discussions/68044#discussioncomment-7101451

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
