### PR TITLE
Removing caching from codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,26 +36,15 @@ jobs:
         java-version: 17
         distribution: temurin
 
-    - name: Cache local Maven repository
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.m2/repository/io/opentelemetry/
-        key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
     - name: Publish patched dependencies to maven local
       uses: ./.github/actions/patch-dependencies
-      if: steps.cache-local-maven-repo.outputs.cache-hit != 'true'
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         gpg_password: ${{ secrets.GPG_PASSPHRASE }}
-        
-    - uses: gradle/wrapper-validation-action@v1
 
     - name: Manually build to avoid autobuild failures
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: build
+      run: |
+        ./gradlew build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
*Description of changes:*

Codeql requires non cached builds every time. See excerpt below from [codeql troubleshooting steps](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/no-source-code-seen-during-build). 

```
Your workflow is analyzing a compiled language (C, C++, C#, Go, or Java), but portions of your build are cached to improve performance (most likely to occur with build systems like Gradle or Bazel). Since CodeQL observes the activity of the compiler to understand the data flows in a repository, CodeQL requires a complete build to take place in order to perform analysis.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
