### PR TITLE
Reinsert aws default region env var

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
 
 env:
+  # The precense of this env var is required for use by terraform and AWS CLI commands
+  # It is not redundant
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} 
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   SAMPLE_APP_FRONTEND_SERVICE_JAR: "s3://aws-appsignals-sample-app/main-service.jar"
   SAMPLE_APP_REMOTE_SERVICE_JAR: "s3://aws-appsignals-sample-app/remote-service.jar"

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Set CW Agent RPM environment variable
         run: |
-          if [ ${{ inputs.aws-region }} == "us-east-1" ]; then
+          if [ ${{ env.AWS_DEFAULT_REGION }} == "us-east-1" ]; then
             echo APP_SIGNALS_CW_AGENT_RPM="https://amazoncloudwatch-agent-us-east-1.s3.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm" >> $GITHUB_ENV
           else
-            echo APP_SIGNALS_CW_AGENT_RPM="https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm" >> $GITHUB_ENV
+            echo APP_SIGNALS_CW_AGENT_RPM="https://amazoncloudwatch-agent-${{ env.AWS_DEFAULT_REGION }}.s3.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm" >> $GITHUB_ENV
           fi
           
 
@@ -56,7 +56,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.E2E_TEST_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v3
@@ -79,7 +79,7 @@ jobs:
             echo "Attempt $retry_counter"
             deployment_failed=0
             terraform apply -auto-approve \
-              -var="aws_region=${{ inputs.aws-region }}" \
+              -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
               -var="sample_app_jar=${{ env.SAMPLE_APP_FRONTEND_SERVICE_JAR }}" \
               -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
@@ -173,7 +173,7 @@ jobs:
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
@@ -190,7 +190,7 @@ jobs:
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
@@ -207,7 +207,7 @@ jobs:
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
@@ -225,13 +225,13 @@ jobs:
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
             --value 0.0 \
-            --region ${{ inputs.aws-region }}
+            --region ${{ env.AWS_DEFAULT_REGION }}
           else
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
             --value 1.0 \
-            --region ${{ inputs.aws-region }}
+            --region ${{ env.AWS_DEFAULT_REGION }}
           fi
 
 

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -48,13 +48,13 @@ jobs:
           distribution: temurin
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ inputs.aws-region }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ env.AWS_DEFAULT_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.E2E_TEST_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       # local directory to store the kubernetes config
       - name: Create kubeconfig directory
@@ -64,7 +64,7 @@ jobs:
         run: echo KUBECONFIG="${{ github.workspace }}/.kube/config" >> $GITHUB_ENV
 
       - name: Set up kubeconfig
-        run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}
+        run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Install eksctl
         run: |
@@ -82,7 +82,7 @@ jobs:
           --cluster ${{ inputs.test-cluster-name }} \
           --role-name eks-s3-access-${{ env.TESTING_ID }} \
           --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess \
-          --region ${{ inputs.aws-region }} \
+          --region ${{ env.AWS_DEFAULT_REGION }} \
           --approve
 
       - name: Set up terraform
@@ -120,7 +120,7 @@ jobs:
             deployment_failed=0
             terraform apply -auto-approve \
               -var="test_id=${{ env.TESTING_ID }}" \
-              -var="aws_region=${{ inputs.aws-region }}" \
+              -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
               -var="kube_directory_path=${{ github.workspace }}/.kube" \
               -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
               -var="eks_cluster_context_name=$(kubectl config current-context)" \
@@ -140,7 +140,7 @@ jobs:
               echo "Installing app signals to the sample app"
               ./enable-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
-              ${{ inputs.aws-region }} \
+              ${{ env.AWS_DEFAULT_REGION }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}
           
               # If the workflow provides a specific ADOT image to test, patch the deployment and restart CW agent related pods
@@ -178,16 +178,16 @@ jobs:
               echo "Cleaning up App Signal"
               ./clean-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
-              ${{ inputs.aws-region }} \
+              ${{ env.AWS_DEFAULT_REGION }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}
           
               # Running clean-app-signal.sh removes the current cluster from the config. Update the cluster again for subsequent runs.
-              aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}
+              aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.AWS_DEFAULT_REGION }}
 
               echo "Destroying terraform"
               terraform destroy -auto-approve \
                 -var="test_id=${{ env.TESTING_ID }}" \
-                -var="aws_region=${{ inputs.aws-region }}" \
+                -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
                 -var="kube_directory_path=${{ github.workspace }}/.kube" \
                 -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
                 -var="test_namespace=${{ env.SAMPLE_APP_NAMESPACE }}" \
@@ -257,7 +257,7 @@ jobs:
         run: ./gradlew testing:validator:run --args='-c eks/log-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
@@ -274,7 +274,7 @@ jobs:
         run: ./gradlew testing:validator:run --args='-c eks/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
@@ -292,7 +292,7 @@ jobs:
         run: ./gradlew testing:validator:run --args='-c eks/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.APP_ENDPOINT }}
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
@@ -311,13 +311,13 @@ jobs:
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
             --value 0.0 \
-            --region ${{ inputs.aws-region }}
+            --region ${{ env.AWS_DEFAULT_REGION }}
           else
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
             --value 1.0 \
-            --region ${{ inputs.aws-region }}
+            --region ${{ env.AWS_DEFAULT_REGION }}
           fi
 
       # Clean up Procedures
@@ -329,7 +329,7 @@ jobs:
         run: |
           ./clean-app-signals.sh \
           ${{ inputs.test-cluster-name }} \
-          ${{ inputs.aws-region }} \
+          ${{ env.AWS_DEFAULT_REGION }} \
           ${{ env.SAMPLE_APP_NAMESPACE }}
 
       # This step also deletes lingering resources from previous test runs
@@ -346,7 +346,7 @@ jobs:
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}" \
-            -var="aws_region=${{ inputs.aws-region }}" \
+            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
             -var="kube_directory_path=${{ github.workspace }}/.kube" \
             -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
             -var="test_namespace=${{ env.SAMPLE_APP_NAMESPACE }}" \
@@ -361,4 +361,4 @@ jobs:
           --name service-account-${{ env.TESTING_ID }} \
           --namespace ${{ env.SAMPLE_APP_NAMESPACE }} \
           --cluster ${{ inputs.test-cluster-name }} \
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -23,6 +23,9 @@ permissions:
   contents: read
 
 env:
+  # The precense of this env var is required for use by terraform and AWS CLI commands
+  # It is not redundant
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} 
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   ENABLEMENT_SCRIPT_S3_BUCKET: ${{ secrets.APP_SIGNALS_E2E_ENABLEMENT_SCRIPT }}
   SAMPLE_APP_NAMESPACE: sample-app-namespace

--- a/.github/workflows/e2e-tests-app-with-java-agent.yml
+++ b/.github/workflows/e2e-tests-app-with-java-agent.yml
@@ -16,6 +16,10 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  # The precense of this env var is required. It is not redundant
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} 
+  
 jobs:
   build_Images_For_Testing_Sample_App_With_Java_Agent:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests-app-with-java-agent.yml
+++ b/.github/workflows/e2e-tests-app-with-java-agent.yml
@@ -57,7 +57,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Log in to AWS ECR
         uses: docker/login-action@v3
@@ -89,7 +89,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Log in to AWS ECR
         uses: docker/login-action@v3
         with:
@@ -120,7 +120,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Log in to AWS ECR
         uses: docker/login-action@v3
         with:
@@ -151,7 +151,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Log in to AWS ECR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/e2e-tests-with-operator.yml
+++ b/.github/workflows/e2e-tests-with-operator.yml
@@ -22,6 +22,8 @@ env:
   TESTING_FRAMEWORK_REPO: aws-observability/aws-otel-test-framework
   NUM_BATCHES: 2
   DDB_TABLE_NAME: BatchTestCache
+  # The precense of this env var is required. It is not redundant
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }} 
 
 permissions:
   id-token: write

--- a/.github/workflows/e2e-tests-with-operator.yml
+++ b/.github/workflows/e2e-tests-with-operator.yml
@@ -63,7 +63,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Log in to AWS ECR
         uses: docker/login-action@v3

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -138,7 +138,7 @@ jobs:
     outputs:
       aws_default_region: ${{ steps.default_region_output.outputs.aws_default_region }}
     steps:
-    - name: Set default region output
+      - name: Set default region output
         id: default_region_output
         run: |
             echo "aws_default_region=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,7 +53,6 @@ jobs:
       staging-image: ${{ steps.imageOutput.outputs.stagingImage }}
       staging_registry: ${{ steps.imageOutput.outputs.stagingRegistry }}
       staging_repository: ${{ steps.imageOutput.outputs.stagingRepository }}
-      aws_default_region: ${{ steps.default_region_output.outputs.aws_default_region }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -134,7 +133,12 @@ jobs:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar
 
-      - name: Set default region output
+  default-region-output:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_default_region: ${{ steps.default_region_output.outputs.aws_default_region }}
+    steps:
+    - name: Set default region output
         id: default_region_output
         run: |
             echo "aws_default_region=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_OUTPUT
@@ -157,11 +161,11 @@ jobs:
     concurrency:
       group: e2e-adot-agent-operator-test
       cancel-in-progress: false
-    needs: [ build, create-test-ref ]
+    needs: [ build, create-test-ref, default-region-output ]
     uses: ./.github/workflows/e2e-tests-with-operator.yml
     secrets: inherit
     with:
-      aws-region: ${{ needs.build.outputs.aws_default_region }}
+      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
       image_tag: ${{ needs.build.outputs.java_agent_tag }}
       image_uri: ${{ needs.build.outputs.staging_registry }}/${{ needs.build.outputs.staging_repository }}
       test_ref: ${{ needs.create-test-ref.outputs.testRef }}
@@ -169,11 +173,11 @@ jobs:
 
   # E2E tests where SampleApp has Java Agent
   e2e-test:
-    needs: build
+    needs: [build, default-region-output]
     uses: ./.github/workflows/e2e-tests-app-with-java-agent.yml
     secrets: inherit
     with:
-      aws-region: ${{ needs.build.outputs.aws_default_region }}
+      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
       image_tag: ${{ github.sha }}
       caller-workflow-name: 'main-build'
 
@@ -224,11 +228,11 @@ jobs:
     concurrency:
       group: e2e-adot-test
       cancel-in-progress: false
-    needs: build
+    needs: [build, default-region-output]
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit
     with:
-      aws-region: ${{ needs.build.outputs.aws_default_region }}
+      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
       test-cluster-name: "e2e-adot-test"
       appsignals-adot-image-name: ${{ needs.build.outputs.staging-image }}
       caller-workflow-name: 'main-build'

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -21,7 +21,6 @@ jobs:
       release-candidate-image: ${{ steps.imageOutput.outputs.rcImage }}
       image_registry: ${{ steps.imageOutput.outputs.imageRegistry }}
       image_name: ${{ steps.imageOutput.outputs.imageName }}
-      aws_default_region: ${{ steps.default_region_output.outputs.aws_default_region }}
 
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +86,12 @@ jobs:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar
 
-      - name: Set default region output
+  default-region-output:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_default_region: ${{ steps.default_region_output.outputs.aws_default_region }}
+    steps:
+    - name: Set default region output
         id: default_region_output
         run: |
             echo "aws_default_region=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_OUTPUT
@@ -96,11 +100,11 @@ jobs:
     concurrency:
       group: e2e-adot-agent-operator-test
       cancel-in-progress: false
-    needs: build
+    needs: [build, default-region-output]
     uses: ./.github/workflows/e2e-tests-with-operator.yml
     secrets: inherit
     with:
-      aws-region: ${{ needs.build.outputs.aws_default_region }}
+      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
       image_tag: ${{ needs.build.outputs.time_stamp_tag }}
       image_uri: ${{ needs.build.outputs.image_registry }}/${{ needs.build.outputs.image_name }}
       test_ref: 'terraform'
@@ -144,11 +148,11 @@ jobs:
     concurrency:
       group: e2e-adot-test
       cancel-in-progress: false
-    needs: build
+    needs: [build,default-region-output]
     uses: ./.github/workflows/appsignals-e2e-eks-test.yml
     secrets: inherit
     with:
-      aws-region: ${{ needs.build.outputs.aws_default_region }}
+      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
       test-cluster-name: "e2e-adot-test"
       appsignals-adot-image-name: ${{ needs.build.outputs.release-candidate-image }}
       caller-workflow-name: 'nightly-upstream-snapshot-build'

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -91,7 +91,7 @@ jobs:
     outputs:
       aws_default_region: ${{ steps.default_region_output.outputs.aws_default_region }}
     steps:
-    - name: Set default region output
+      - name: Set default region output
         id: default_region_output
         run: |
             echo "aws_default_region=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
*Description of changes:* Revert the changes to `AWS_DEFAULT_REGION` env var that were made #703. The presence of the env var is required for some steps inside the workflows. This is not redundant and is required to be present in the env. 

This PR also moves the setting of the default region output to an explicit job. Previously it was done at the end of the build step. This caused `us-west-2` to be output because the composite `cpUtility` test action overrode that default value. Using an explicit job here will ensure that `us-east-1` value is used as the output every time. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
