### PR TITLE
Build before publishing in e2e operator tests

### DIFF
--- a/.github/workflows/e2e-tests-with-operator.yml
+++ b/.github/workflows/e2e-tests-with-operator.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build and push Sample-Apps without Auto-Instrumentation Agent
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jibBuildWithoutAgent
+          arguments: build jibBuildWithoutAgent
         env:
           COMMIT_HASH: ${{ inputs.image_tag }}
 

--- a/.github/workflows/e2e-tests-with-operator.yml
+++ b/.github/workflows/e2e-tests-with-operator.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build and push Sample-Apps without Auto-Instrumentation Agent
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build jibBuildWithoutAgent
+          arguments: jibBuildWithoutAgent
         env:
           COMMIT_HASH: ${{ inputs.image_tag }}
 

--- a/sample-apps/spark/build.gradle.kts
+++ b/sample-apps/spark/build.gradle.kts
@@ -51,6 +51,7 @@ tasks {
     dependsOn(":otelagent:jibDockerBuild")
   }
   register<BuildImageTask>("jibBuildWithoutAgent") {
+    dependsOn(":sample-apps:spark:build")
     val j = JibExtension(project)
     j.configureImages(
       "eclipse-temurin:17",


### PR DESCRIPTION
*Issue #, if available:*
 
*Description of changes:* Add dependency to build spark sample app to `jibBuildWithoutAgent`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
