### PR TITLE
Change terraform to use minimal ami

### DIFF
--- a/testing/terraform/ec2/main.tf
+++ b/testing/terraform/ec2/main.tf
@@ -89,10 +89,8 @@ resource "null_resource" "main_service_setup" {
 
   provisioner "remote-exec" {
     inline = [
-      # Install wget
-      "yes | sudo yum install wget",
-      # Install Java 11
-      "sudo yum install java-11-amazon-corretto -y",
+      # Install Java 11 and wget
+      "sudo yum install wget java-11-amazon-corretto -y",
 
       # Copy in CW Agent configuration
       "agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'",
@@ -152,10 +150,8 @@ resource "null_resource" "remote_service_setup" {
 
   provisioner "remote-exec" {
     inline = [
-      # Install wget
-      "yes | sudo yum install wget",
-      # Install Java 11
-      "sudo yum install java-11-amazon-corretto -y",
+      # Install Java 11 and wget
+      "sudo yum install wget java-11-amazon-corretto -y",
 
       # Copy in CW Agent configuration
       "agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'",

--- a/testing/terraform/ec2/main.tf
+++ b/testing/terraform/ec2/main.tf
@@ -27,8 +27,16 @@ locals {
 }
 
 data "aws_ami" "ami" {
-  executable_users = ["self"]
+  owners = ["amazon"]
   most_recent      = true
+  filter {
+    name   = "name"
+    values = ["al20*-ami-minimal-*-x86_64"]
+  }
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
   filter {
     name   = "architecture"
     values = ["x86_64"]
@@ -81,8 +89,10 @@ resource "null_resource" "main_service_setup" {
 
   provisioner "remote-exec" {
     inline = [
-      # Install Java 11 and tmux
-      "yes | sudo amazon-linux-extras install java-openjdk11",
+      # Install wget
+      "yes | sudo yum install wget",
+      # Install Java 11
+      "sudo yum install java-11-amazon-corretto -y",
 
       # Copy in CW Agent configuration
       "agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'",
@@ -142,8 +152,10 @@ resource "null_resource" "remote_service_setup" {
 
   provisioner "remote-exec" {
     inline = [
-      # Install Java 11 and tmux
-      "yes | sudo amazon-linux-extras install java-openjdk11",
+      # Install wget
+      "yes | sudo yum install wget",
+      # Install Java 11
+      "sudo yum install java-11-amazon-corretto -y",
 
       # Copy in CW Agent configuration
       "agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'",


### PR DESCRIPTION
*Issue #, if available:*
A new AMI available to the public that was matching our filter conditions for EC2 Terraform came pre-installed with Java 8. This caused dependency issues with the sample app which uses Java 11 used for E2E testing and caused the canary to fail. 

*Description of changes:*
Added additional filter conditions for the EC2 AMIs to look for minimal images. Also updated the instances to install `java-11-amazon-coretto`

Test run:
us-east-1: https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/7495423753
us-east-2: https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/7495550565
eu-west-1: https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/7495547623
ap-norhteast-1: https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/7495545124
ap-southeast-2: https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/7495438492

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
