### PR TITLE
Add API Key in workflow for dependency checks

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -46,6 +46,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: ":javaagent:dependencyCheckAnalyze"
+          env:
+            NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Upload report
         if: ${{ always() }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Add API Key in workflow for dependency checks that could fix - [Error updating the NVD Data; the NVD returned a 403 or 404 error](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7536638526/job/20514345862#step:4:196)

Reference - https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7536638526/job/20514345862#step:4:198


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
