### PR TITLE
make grpc protocal to be default

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -34,6 +34,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,6 +58,7 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
       Logger.getLogger(AwsAppSignalsCustomizerProvider.class.getName());
 
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    grpcProtocolByDefault(autoConfiguration);
     autoConfiguration.addSamplerCustomizer(this::customizeSampler);
     autoConfiguration.addTracerProviderCustomizer(this::customizeTracerProviderBuilder);
     autoConfiguration.addSpanExporterCustomizer(this::customizeSpanExporter);
@@ -134,5 +136,18 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
     }
 
     return spanExporter;
+  }
+
+  private void grpcProtocolByDefault(AutoConfigurationCustomizer autoConfiguration) {
+    if (System.getProperty("otel.exporter.otlp.protocol") == null
+        && System.getenv("OTEL_EXPORTER_OTLP_PROTOCOL") == null) {
+      autoConfiguration.addPropertiesSupplier(
+          () ->
+              new HashMap<String, String>() {
+                {
+                  put("otel.exporter.otlp.protocol", "grpc");
+                }
+              });
+    }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
OpenTelemetry java 2.0 introduces a breaking change that the default OTLP protocol has been changed from `grpc` to `http/protobuf` in order to align with specification. It does not impact ADOT users since ADOT Collector configurations [turn on both grpc and http ports for otlp receiver](https://github.com/aws-observability/aws-otel-collector/tree/main/config). But today AppSignals has to stick on grpc because: 
1. SMP exporter is grpc metrics exporter;
2. In [AppSignals enablement public document](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals-Enable-Other.html), we ask EC2 and ECS users set the endpoints to be a grpc endpoint, which is [port 4315 hardcoded in CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent/blob/50775938eaae3dbf8f9214815f098983558c935c/translator/translate/otel/receiver/otlp/appsignals_config.yaml).

So, in order to avoid any impact on users who are already onboarded AppSignals, we want to override the default protocol from the SDK side to be gRPC. 

*Description of changes:*

The default otlp protocol in Opentelemetry java 1.0 is `grpc`, in OpenTelemetry java 2.0 becomes `http/protobuf`. 
This change makes sure if user does not manually set otlp protocol, we still use `grpc` as default in 2.0. 

*Testing:*

This change is manually verified in local by:
* Launch an OpenTelemetry Collector, respectively disable grpc and http protocol in receiver.
* Launch a SpringBoot application with ADOT javaagent, verify 3 different cases:
  * Set environment variable OTEL_EXPORTER_OTLP_PROTOCOL to http/protobuf
  * Set environment variable OTEL_EXPORTER_OTLP_PROTOCOL to grpc
  * Not set environment variable OTEL_EXPORTER_OTLP_PROTOCOL

Command example,
```
OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:./aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
