### PR TITLE
Add tests for Metric Rollup Addition of [RemoteService, RemoteTarget, ...]

### DIFF
--- a/testing/validator/src/main/java/com/amazon/aoc/helpers/CWMetricHelper.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/helpers/CWMetricHelper.java
@@ -15,11 +15,6 @@
 
 package com.amazon.aoc.helpers;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.amazon.aoc.callers.ICaller;
 import com.amazon.aoc.fileconfigs.FileConfig;
 import com.amazon.aoc.models.Context;
@@ -28,6 +23,10 @@ import com.amazonaws.services.cloudwatch.model.Metric;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /** helper class for getting expected metrics from templates. */
 public class CWMetricHelper {

--- a/testing/validator/src/main/java/com/amazon/aoc/helpers/CWMetricHelper.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/helpers/CWMetricHelper.java
@@ -15,6 +15,11 @@
 
 package com.amazon.aoc.helpers;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.amazon.aoc.callers.ICaller;
 import com.amazon.aoc.fileconfigs.FileConfig;
 import com.amazon.aoc.models.Context;
@@ -23,10 +28,6 @@ import com.amazonaws.services.cloudwatch.model.Metric;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /** helper class for getting expected metrics from templates. */
 public class CWMetricHelper {

--- a/testing/validator/src/main/java/com/amazon/aoc/services/CloudWatchService.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/services/CloudWatchService.java
@@ -17,9 +17,6 @@ package com.amazon.aoc.services;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import java.util.Date;
-import java.util.List;
-
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.cloudwatch.model.*;
@@ -31,7 +28,8 @@ import com.amazonaws.services.logs.model.FilteredLogEvent;
 import com.amazonaws.services.logs.model.GetLogEventsRequest;
 import com.amazonaws.services.logs.model.GetLogEventsResult;
 import com.amazonaws.services.logs.model.OutputLogEvent;
-
+import java.util.Date;
+import java.util.List;
 import kotlin.Pair;
 import lombok.extern.log4j.Log4j2;
 
@@ -68,11 +66,15 @@ public class CloudWatchService {
   public List<Metric> listMetrics(
       final String namespace,
       final String metricName,
-      final List<Pair<String,String>> dimensionList) {
+      final List<Pair<String, String>> dimensionList) {
     final List<DimensionFilter> dimensionFilters =
-        dimensionList.stream().map(
-          dimension -> new DimensionFilter().withName(dimension.getFirst()).withValue(dimension.getSecond())
-        ).collect(toImmutableList());
+        dimensionList.stream()
+            .map(
+                dimension ->
+                    new DimensionFilter()
+                        .withName(dimension.getFirst())
+                        .withValue(dimension.getSecond()))
+            .collect(toImmutableList());
     final ListMetricsRequest listMetricsRequest =
         new ListMetricsRequest()
             .withNamespace(namespace)

--- a/testing/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -15,16 +15,6 @@
 
 package com.amazon.aoc.validators;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-
 import com.amazon.aoc.callers.ICaller;
 import com.amazon.aoc.exception.BaseException;
 import com.amazon.aoc.exception.ExceptionCode;
@@ -38,7 +28,15 @@ import com.amazon.aoc.services.CloudWatchService;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.Metric;
 import com.google.common.collect.Lists;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import kotlin.Pair;
 import lombok.extern.log4j.Log4j2;
 
@@ -109,24 +107,24 @@ public class CWMetricValidator implements IValidator {
           List<Metric> actualMetricList = Lists.newArrayList();
 
           // Add sets of dimesion filters to use for each query to CloudWatch
-          List<List<Pair<String,String>>> dimensionLists = Lists.newArrayList();
+          List<List<Pair<String, String>>> dimensionLists = Lists.newArrayList();
           for (String serviceName : serviceNames) {
-            dimensionLists.add(Arrays.asList(new Pair<>(CloudWatchService.SERVICE_DIMENSION, serviceName)));
+            dimensionLists.add(
+                Arrays.asList(new Pair<>(CloudWatchService.SERVICE_DIMENSION, serviceName)));
           }
           for (String remoteServiceName : remoteServiceNames) {
-            dimensionLists.add(Arrays.asList(new Pair<>(CloudWatchService.REMOTE_SERVICE_DIMENSION, remoteServiceName)));
+            dimensionLists.add(
+                Arrays.asList(
+                    new Pair<>(CloudWatchService.REMOTE_SERVICE_DIMENSION, remoteServiceName)));
           }
-          dimensionLists.add(Arrays.asList(
-            new Pair<>(CloudWatchService.REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3"),
-            new Pair<>(CloudWatchService.REMOTE_TARGET_DIMENSION, "e2e-test-bucket-name"))
-          );
+          dimensionLists.add(
+              Arrays.asList(
+                  new Pair<>(CloudWatchService.REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3"),
+                  new Pair<>(CloudWatchService.REMOTE_TARGET_DIMENSION, "e2e-test-bucket-name")));
 
           // Populate actualMetricList with each set of dimension filters
-          for (List<Pair<String,String>> dimensionList : dimensionLists) {
-            addMetrics(
-              dimensionList,
-              expectedMetricList,
-              actualMetricList);
+          for (List<Pair<String, String>> dimensionList : dimensionLists) {
+            addMetrics(dimensionList, expectedMetricList, actualMetricList);
           }
 
           // remove the skip dimensions
@@ -147,13 +145,12 @@ public class CWMetricValidator implements IValidator {
   }
 
   private void addMetrics(
-      List<Pair<String,String>> dimensionList,
+      List<Pair<String, String>> dimensionList,
       List<Metric> expectedMetricList,
       List<Metric> actualMetricList)
       throws Exception {
     actualMetricList.addAll(
-        this.listMetricFromCloudWatch(
-            cloudWatchService, expectedMetricList, dimensionList));
+        this.listMetricFromCloudWatch(cloudWatchService, expectedMetricList, dimensionList));
   }
 
   /**
@@ -206,7 +203,7 @@ public class CWMetricValidator implements IValidator {
   private List<Metric> listMetricFromCloudWatch(
       CloudWatchService cloudWatchService,
       List<Metric> expectedMetricList,
-      List<Pair<String,String>> dimensionList)
+      List<Pair<String, String>> dimensionList)
       throws IOException {
     // put namespace into the map key, so that we can use it to search metric
     HashMap<String, String> metricNameMap = new HashMap<>();
@@ -218,8 +215,7 @@ public class CWMetricValidator implements IValidator {
     List<Metric> result = new ArrayList<>();
     for (String metricName : metricNameMap.keySet()) {
       result.addAll(
-          cloudWatchService.listMetrics(
-              metricNameMap.get(metricName), metricName, dimensionList));
+          cloudWatchService.listMetrics(metricNameMap.get(metricName), metricName, dimensionList));
     }
     return result;
   }

--- a/testing/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/testing/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -89,6 +89,7 @@ public class CWMetricValidator implements IValidator {
           .getDimensions()
           .removeIf((dimension) -> skippedDimensionNameList.contains(dimension.getName()));
     }
+
     // get metric from cloudwatch
     RetryHelper.retry(
         maxRetryCount,

--- a/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-metric.mustache
@@ -118,6 +118,34 @@
       value: e2e-test-bucket-name
 
 -
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.Environment
+      value: EC2
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
   metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
@@ -237,6 +265,34 @@
       value: e2e-test-bucket-name
 
 -
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.Environment
+      value: EC2
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
   metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
@@ -355,4 +411,31 @@
       name: RemoteTarget
       value: e2e-test-bucket-name
 
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.Environment
+      value: EC2
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
 

--- a/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
@@ -139,6 +139,37 @@
       value: e2e-test-bucket-name
 
 -
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
   metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
@@ -279,6 +310,37 @@
       value: e2e-test-bucket-name
 
 -
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
   metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
@@ -411,6 +473,37 @@
     -
       name: RemoteOperation
       value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.EKS.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
     -
       name: RemoteService
       value: AWS.SDK.S3

--- a/testing/validator/src/test/java/com/amazon/aoc/validators/CWMetricValidatorTest.java
+++ b/testing/validator/src/test/java/com/amazon/aoc/validators/CWMetricValidatorTest.java
@@ -21,14 +21,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
-
 import com.amazon.aoc.callers.HttpCaller;
 import com.amazon.aoc.exception.BaseException;
 import com.amazon.aoc.fileconfigs.LocalPathExpectedTemplate;
@@ -38,9 +30,13 @@ import com.amazon.aoc.models.SampleAppResponse;
 import com.amazon.aoc.models.ValidationConfig;
 import com.amazon.aoc.services.CloudWatchService;
 import com.amazonaws.services.cloudwatch.model.Metric;
-
+import java.util.Arrays;
+import java.util.List;
 import kotlin.Pair;
-
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 /**
  * This class covers the tests for CWMetricValidator. Tests are not run for Windows, due to file
@@ -50,7 +46,7 @@ import kotlin.Pair;
 public class CWMetricValidatorTest {
   private CWMetricHelper cwMetricHelper = new CWMetricHelper();
   private static final String SERVICE_DIMENSION = "Service";
-  private static final String REMOTE_SERVICE_DIMENSION= "RemoteService";
+  private static final String REMOTE_SERVICE_DIMENSION = "RemoteService";
   private static final String REMOTE_TARGET_DIMENSION = "RemoteTarget";
   private static final String TEMPLATE_ROOT =
       "file://" + System.getProperty("user.dir") + "/src/test/test-resources/";
@@ -130,7 +126,8 @@ public class CWMetricValidatorTest {
     List<Metric> remoteMetricsWithRemoteApp = Lists.newArrayList();
     List<Metric> remoteMetricsWithAmazon = getTestMetrics("endToEnd_remoteMetricsWithAmazon");
     List<Metric> remoteMetricsWithAwsSdk = getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
-    List<Metric> remoteMetricsWithAwsSdkWithTarget = getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
+    List<Metric> remoteMetricsWithAwsSdkWithTarget =
+        getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
 
     CloudWatchService cloudWatchService =
         mockCloudWatchService(
@@ -191,25 +188,43 @@ public class CWMetricValidatorTest {
       List<Metric> remoteMetricsWithS3Target) {
     CloudWatchService cloudWatchService = mock(CloudWatchService.class);
     Lists.newArrayList();
-    when(cloudWatchService.listMetrics(any(), any(), eq(Arrays.asList(new Pair<String,String>(SERVICE_DIMENSION, SERVICE_NAME)))))
+    when(cloudWatchService.listMetrics(
+            any(),
+            any(),
+            eq(Arrays.asList(new Pair<String, String>(SERVICE_DIMENSION, SERVICE_NAME)))))
         .thenReturn(localServiceMetrics);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(Arrays.asList(new Pair<String,String>(SERVICE_DIMENSION, REMOTE_SERVICE_NAME)))))
+            any(),
+            any(),
+            eq(Arrays.asList(new Pair<String, String>(SERVICE_DIMENSION, REMOTE_SERVICE_NAME)))))
         .thenReturn(remoteServiceMetrics);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(Arrays.asList(new Pair<String,String>(REMOTE_SERVICE_DIMENSION, REMOTE_SERVICE_DEPLOYMENT_NAME)))))
+            any(),
+            any(),
+            eq(
+                Arrays.asList(
+                    new Pair<String, String>(
+                        REMOTE_SERVICE_DIMENSION, REMOTE_SERVICE_DEPLOYMENT_NAME)))))
         .thenReturn(remoteMetricsWithRemoteApp);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(Arrays.asList(new Pair<String,String>(REMOTE_SERVICE_DIMENSION, "www.amazon.com")))))
+            any(),
+            any(),
+            eq(
+                Arrays.asList(
+                    new Pair<String, String>(REMOTE_SERVICE_DIMENSION, "www.amazon.com")))))
         .thenReturn(remoteMetricsWithAmazon);
     when(cloudWatchService.listMetrics(
-      any(), any(), eq(Arrays.asList(new Pair<String,String>(REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3")))))
+            any(),
+            any(),
+            eq(Arrays.asList(new Pair<String, String>(REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3")))))
         .thenReturn(remoteMetricsWithAwsSdk);
-        when(cloudWatchService.listMetrics(
-      any(), any(), eq(Arrays.asList(
-          new Pair<String,String>(REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3"),
-          new Pair<String,String>(REMOTE_TARGET_DIMENSION, "e2e-test-bucket-name")
-        ))))
+    when(cloudWatchService.listMetrics(
+            any(),
+            any(),
+            eq(
+                Arrays.asList(
+                    new Pair<String, String>(REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3"),
+                    new Pair<String, String>(REMOTE_TARGET_DIMENSION, "e2e-test-bucket-name")))))
         .thenReturn(remoteMetricsWithS3Target);
     return cloudWatchService;
   }

--- a/testing/validator/src/test/java/com/amazon/aoc/validators/CWMetricValidatorTest.java
+++ b/testing/validator/src/test/java/com/amazon/aoc/validators/CWMetricValidatorTest.java
@@ -21,6 +21,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
 import com.amazon.aoc.callers.HttpCaller;
 import com.amazon.aoc.exception.BaseException;
 import com.amazon.aoc.fileconfigs.LocalPathExpectedTemplate;
@@ -30,11 +38,9 @@ import com.amazon.aoc.models.SampleAppResponse;
 import com.amazon.aoc.models.ValidationConfig;
 import com.amazon.aoc.services.CloudWatchService;
 import com.amazonaws.services.cloudwatch.model.Metric;
-import java.util.List;
-import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
+
+import kotlin.Pair;
+
 
 /**
  * This class covers the tests for CWMetricValidator. Tests are not run for Windows, due to file
@@ -44,11 +50,13 @@ import org.junit.jupiter.api.condition.DisabledIf;
 public class CWMetricValidatorTest {
   private CWMetricHelper cwMetricHelper = new CWMetricHelper();
   private static final String SERVICE_DIMENSION = "Service";
-  private static final String REMOTE_SERVICE_DIMENSION = "RemoteService";
+  private static final String REMOTE_SERVICE_DIMENSION= "RemoteService";
+  private static final String REMOTE_TARGET_DIMENSION = "RemoteTarget";
   private static final String TEMPLATE_ROOT =
       "file://" + System.getProperty("user.dir") + "/src/test/test-resources/";
   private static final String SERVICE_NAME = "serviceName";
   private static final String REMOTE_SERVICE_NAME = "remoteServiceName";
+  private static final String REMOTE_TARGET_NAME = "remoteTargetName";
   private static final String REMOTE_SERVICE_DEPLOYMENT_NAME = "remoteServiceDeploymentName";
 
   private Context context;
@@ -90,13 +98,14 @@ public class CWMetricValidatorTest {
   @Test
   public void testValidateEndToEnd_Success() throws Exception {
     ValidationConfig validationConfig =
-        initValidationConfig(TEMPLATE_ROOT + "endToEnd_expectedMetrics.mustache");
+        initValidationConfig(TEMPLATE_ROOT + "endToEnd_expectedMetrics.mustache ");
 
     List<Metric> localServiceMetrics = getTestMetrics("endToEnd_localMetricsWithService");
     List<Metric> remoteServiceMetrics = getTestMetrics("endToEnd_remoteMetricsWithService");
     List<Metric> remoteMetricsWithRemoteApp = getTestMetrics("endToEnd_remoteMetricsWithRemoteApp");
     List<Metric> remoteMetricsWithAmazon = getTestMetrics("endToEnd_remoteMetricsWithAmazon");
     List<Metric> remoteMetricsWithAwsSdk = getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
+    List<Metric> remoteMetricsWithS3Target = getTestMetrics("endToEnd_remoteMetricsWithS3Target");
 
     CloudWatchService cloudWatchService =
         mockCloudWatchService(
@@ -104,7 +113,8 @@ public class CWMetricValidatorTest {
             remoteServiceMetrics,
             remoteMetricsWithRemoteApp,
             remoteMetricsWithAmazon,
-            remoteMetricsWithAwsSdk);
+            remoteMetricsWithAwsSdk,
+            remoteMetricsWithS3Target);
 
     validate(validationConfig, cloudWatchService);
   }
@@ -120,6 +130,7 @@ public class CWMetricValidatorTest {
     List<Metric> remoteMetricsWithRemoteApp = Lists.newArrayList();
     List<Metric> remoteMetricsWithAmazon = getTestMetrics("endToEnd_remoteMetricsWithAmazon");
     List<Metric> remoteMetricsWithAwsSdk = getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
+    List<Metric> remoteMetricsWithAwsSdkWithTarget = getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
 
     CloudWatchService cloudWatchService =
         mockCloudWatchService(
@@ -127,7 +138,8 @@ public class CWMetricValidatorTest {
             remoteServiceMetrics,
             remoteMetricsWithRemoteApp,
             remoteMetricsWithAmazon,
-            remoteMetricsWithAwsSdk);
+            remoteMetricsWithAwsSdk,
+            remoteMetricsWithAwsSdkWithTarget);
 
     try {
       validate(validationConfig, cloudWatchService);
@@ -175,22 +187,30 @@ public class CWMetricValidatorTest {
       List<Metric> remoteServiceMetrics,
       List<Metric> remoteMetricsWithRemoteApp,
       List<Metric> remoteMetricsWithAmazon,
-      List<Metric> remoteMetricsWithAwsSdk) {
+      List<Metric> remoteMetricsWithAwsSdk,
+      List<Metric> remoteMetricsWithS3Target) {
     CloudWatchService cloudWatchService = mock(CloudWatchService.class);
-    when(cloudWatchService.listMetrics(any(), any(), eq(SERVICE_DIMENSION), eq(SERVICE_NAME)))
+    Lists.newArrayList();
+    when(cloudWatchService.listMetrics(any(), any(), eq(Arrays.asList(new Pair<String,String>(SERVICE_DIMENSION, SERVICE_NAME)))))
         .thenReturn(localServiceMetrics);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(SERVICE_DIMENSION), eq(REMOTE_SERVICE_NAME)))
+            any(), any(), eq(Arrays.asList(new Pair<String,String>(SERVICE_DIMENSION, REMOTE_SERVICE_NAME)))))
         .thenReturn(remoteServiceMetrics);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(REMOTE_SERVICE_DIMENSION), eq(REMOTE_SERVICE_DEPLOYMENT_NAME)))
+            any(), any(), eq(Arrays.asList(new Pair<String,String>(REMOTE_SERVICE_DIMENSION, REMOTE_SERVICE_DEPLOYMENT_NAME)))))
         .thenReturn(remoteMetricsWithRemoteApp);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(REMOTE_SERVICE_DIMENSION), eq("www.amazon.com")))
+            any(), any(), eq(Arrays.asList(new Pair<String,String>(REMOTE_SERVICE_DIMENSION, "www.amazon.com")))))
         .thenReturn(remoteMetricsWithAmazon);
     when(cloudWatchService.listMetrics(
-            any(), any(), eq(REMOTE_SERVICE_DIMENSION), eq("AWS.SDK.S3")))
+      any(), any(), eq(Arrays.asList(new Pair<String,String>(REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3")))))
         .thenReturn(remoteMetricsWithAwsSdk);
+        when(cloudWatchService.listMetrics(
+      any(), any(), eq(Arrays.asList(
+          new Pair<String,String>(REMOTE_SERVICE_DIMENSION, "AWS.SDK.S3"),
+          new Pair<String,String>(REMOTE_TARGET_DIMENSION, "e2e-test-bucket-name")
+        ))))
+        .thenReturn(remoteMetricsWithS3Target);
     return cloudWatchService;
   }
 
@@ -212,7 +232,7 @@ public class CWMetricValidatorTest {
     CloudWatchService cloudWatchService = mock(CloudWatchService.class);
 
     // mock listMetrics
-    when(cloudWatchService.listMetrics(any(), any(), any(), any())).thenReturn(metrics);
+    when(cloudWatchService.listMetrics(any(), any(), any())).thenReturn(metrics);
 
     // start validation
     validate(validationConfig, cloudWatchService);

--- a/testing/validator/src/test/test-resources/endToEnd_expectedMetrics.mustache
+++ b/testing/validator/src/test/test-resources/endToEnd_expectedMetrics.mustache
@@ -85,3 +85,13 @@
     -
       name: RemoteService
       value: remoteServiceDeploymentName
+-
+  metricName: metricName
+  namespace: metricNamespace
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name

--- a/testing/validator/src/test/test-resources/endToEnd_remoteMetricsWithS3Target.mustache
+++ b/testing/validator/src/test/test-resources/endToEnd_remoteMetricsWithS3Target.mustache
@@ -1,0 +1,10 @@
+-
+  metricName: metricName
+  namespace: metricNamespace
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: e2e-test-bucket-name


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-cloudwatch-agent/pull/1010
Recently the following metric rollups were added to 2 AppSignal Configuration files. Tests need to be added for them
  - `[RemoteService, RemoteTarget]`
  - `[HostedIn.<Attributes>, Service, RemoteService, RemoteTarget]`

*Description of changes:*
Add tests for new metric rollups

*Testing done:*
EKS in IAD: https://github.com/jj22ee/amazon-cloudwatch-agent/actions/runs/7659009903/job/20873170967
EC2 in IAD: https://github.com/jj22ee/amazon-cloudwatch-agent/actions/runs/7659098851/job/20873465899

`./gradlew testing:validator:test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
