### PR TITLE
Run contract tests with no cache

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Build snapshot with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: contractTests -PlocalDocker=true
+          arguments: contractTests -PlocalDocker=true --no-build-cache
 
   # AppSignals specific e2e tests
   appsignals-e2e-eks-test:


### PR DESCRIPTION
*Description of changes:*

Currently contract tests are [cached](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/7701804938/job/20989223389#step:9:4554) on main-build, this pr changes to run on no cache

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
