### PR TITLE
Rename AppSignals configs with backward compatibility

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/base/ContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/base/ContractTestBase.java
@@ -78,11 +78,11 @@ public abstract class ContractTestBase {
           .waitingFor(getApplicationWaitCondition())
           .withEnv("JAVA_TOOL_OPTIONS", "-javaagent:/opentelemetry-javaagent-all.jar")
           .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "100") // 100 ms
-          .withEnv("OTEL_SMP_ENABLED", "true")
+          .withEnv("OTEL_AWS_APP_SIGNALS_ENABLED", "true")
           .withEnv("OTEL_METRICS_EXPORTER", "none")
           .withEnv("OTEL_BSP_SCHEDULE_DELAY", "0") // Don't wait to export spans to the collector
           .withEnv(
-              "OTEL_AWS_SMP_EXPORTER_ENDPOINT",
+              "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT",
               "http://" + COLLECTOR_HOSTNAME + ":" + COLLECTOR_PORT)
           .withEnv(
               "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -63,7 +63,8 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
   }
 
   private boolean isSmpEnabled(ConfigProperties configProps) {
-    return configProps.getBoolean("otel.smp.enabled", false);
+    return configProps.getBoolean(
+        "otel.aws.app.signals.enabled", configProps.getBoolean("otel.smp.enabled", false));
   }
 
   private Sampler customizeSampler(Sampler sampler, ConfigProperties configProps) {
@@ -79,7 +80,8 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
       logger.info("Span Metrics Processor enabled");
       String smpEndpoint =
           configProps.getString(
-              "otel.aws.smp.exporter.endpoint", "http://cloudwatch-agent.amazon-cloudwatch:4317");
+              "otel.aws.app.signals.exporter.endpoint",
+              configProps.getString("otel.aws.smp.exporter.endpoint", "http://localhost:4315"));
       Duration exportInterval =
           configProps.getDuration("otel.metric.export.interval", DEFAULT_METRIC_EXPORT_INTERVAL);
       logger.log(Level.FINE, String.format("Span Metrics endpoint: %s", smpEndpoint));

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -48,8 +48,9 @@ import java.util.logging.Logger;
  *   <li>Add AwsMetricAttributesSpanExporter to add more attributes to all spans.
  * </ul>
  *
- * <p>You can control when these customizations are applied using the property otel.smp.enabled or
- * the environment variable OTEL_SMP_ENABLED. This flag is enabled by default.
+ * <p>You can control when these customizations are applied using the property
+ * otel.aws.app.signals.enabled or the environment variable OTEL_AWS_APP_SIGNALS_ENABLED. This flag
+ * is disabled by default.
  */
 public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomizerProvider {
   private static final Duration DEFAULT_METRIC_EXPORT_INTERVAL = Duration.ofMinutes(1);


### PR DESCRIPTION
*Description of changes:*
SMP is just a component of Application Signals, so it makes sense that we appropriately name the config that controls the Application Signals.

Also, `http://cloudwatch-agent.amazon-cloudwatch:4317` as default exporter endpoint doesn't really work since it points to CW pod in EKS environment. Plus `4317` is also wrong as we have switched to `4315` for AppSignals.

*Testing*
Tested without and with updating the environment variables in contract tests to ensure the change is backward compatible.
- Test run with SMP config: https://github.com/srprash/aws-otel-java-instrumentation/actions/runs/7836933969/job/21386408375?pr=1
- Test run with AppSignal config: https://github.com/srprash/aws-otel-java-instrumentation/actions/runs/7837485201/job/21387233082?pr=1 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
