### PR TITLE
Updated generateRemoteService to parse HTTP_URL as last resort

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -253,9 +253,9 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * </ul>
    *
    * if the selected attributes are still producing the UnknownRemoteService or
-   * UnknownRemoteOperation, `net.peer.name`, `net.peer.port`, `net.peer.sock.addr` and
-   * `net.peer.sock.port` will be used to derive the RemoteService. And `http.method` and `http.url`
-   * will be used to derive the RemoteOperation.
+   * UnknownRemoteOperation, `net.peer.name`, `net.peer.port`, `net.peer.sock.addr`,
+   * `net.peer.sock.port` and `http.url` will be used to derive the RemoteService. And `http.method`
+   * and `http.url` will be used to derive the RemoteOperation.
    */
   private static void setRemoteServiceAndOperation(SpanData span, AttributesBuilder builder) {
     String remoteService = UNKNOWN_REMOTE_SERVICE;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -339,6 +339,19 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         Long port = span.getAttributes().get(NET_SOCK_PEER_PORT);
         remoteService += ":" + port;
       }
+    } else if (isKeyPresent(span, HTTP_URL)) {
+      String httpUrl = span.getAttributes().get(HTTP_URL);
+      try {
+        URL url = new URL(httpUrl);
+        if (!url.getHost().isEmpty()) {
+          remoteService = url.getHost();
+          if (url.getPort() != -1) {
+            remoteService += ":" + url.getPort();
+          }
+        }
+      } catch (MalformedURLException e) {
+        logger.log(Level.FINEST, "invalid http.url attribute: ", httpUrl);
+      }
     } else {
       logUnknownAttribute(AWS_REMOTE_SERVICE, span);
     }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -499,14 +499,31 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(NET_SOCK_PEER_ADDR, null);
     mockAttribute(NET_SOCK_PEER_PORT, null);
 
-    // Validate behavior of Remote Operation from HttpTarget - with 1st api part, then remove it
+    // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates that RemoteService
+    // is extracted from HttpUrl.
     mockAttribute(HTTP_URL, "http://www.example.com/payment/123");
-    validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, "/payment");
+    validateExpectedRemoteAttributes("www.example.com", "/payment");
     mockAttribute(HTTP_URL, null);
 
-    // Validate behavior of Remote Operation from HttpTarget - without 1st api part, then remove it
+    // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates that RemoteService
+    // is extracted from HttpUrl.
     mockAttribute(HTTP_URL, "http://www.example.com");
-    validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, "/");
+    validateExpectedRemoteAttributes("www.example.com", "/");
+    mockAttribute(HTTP_URL, null);
+
+    // Validate behavior of Remote Service from HttpUrl
+    mockAttribute(HTTP_URL, "http://192.168.1.1:8000");
+    validateExpectedRemoteAttributes("192.168.1.1:8000", "/");
+    mockAttribute(HTTP_URL, null);
+
+    // Validate behavior of Remote Service from HttpUrl
+    mockAttribute(HTTP_URL, "");
+    validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, UNKNOWN_REMOTE_OPERATION);
+    mockAttribute(HTTP_URL, null);
+
+    // Validate behavior of Remote Service from HttpUrl
+    mockAttribute(HTTP_URL, null);
+    validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, UNKNOWN_REMOTE_OPERATION);
     mockAttribute(HTTP_URL, null);
 
     // Validate behavior of Remote Operation from HttpTarget - invalid url, then remove it

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -499,13 +499,15 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(NET_SOCK_PEER_ADDR, null);
     mockAttribute(NET_SOCK_PEER_PORT, null);
 
-    // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates that RemoteService
+    // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates
+    // that RemoteService
     // is extracted from HttpUrl.
     mockAttribute(HTTP_URL, "http://www.example.com/payment/123");
     validateExpectedRemoteAttributes("www.example.com", "/payment");
     mockAttribute(HTTP_URL, null);
 
-    // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates that RemoteService
+    // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates
+    // that RemoteService
     // is extracted from HttpUrl.
     mockAttribute(HTTP_URL, "http://www.example.com");
     validateExpectedRemoteAttributes("www.example.com", "/");

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -500,15 +500,13 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(NET_SOCK_PEER_PORT, null);
 
     // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates
-    // that RemoteService
-    // is extracted from HttpUrl.
+    // that RemoteService is extracted from HttpUrl.
     mockAttribute(HTTP_URL, "http://www.example.com/payment/123");
     validateExpectedRemoteAttributes("www.example.com", "/payment");
     mockAttribute(HTTP_URL, null);
 
     // Validate behavior of Remote Operation from HttpTarget - with 1st api part. Also validates
-    // that RemoteService
-    // is extracted from HttpUrl.
+    // that RemoteService is extracted from HttpUrl.
     mockAttribute(HTTP_URL, "http://www.example.com");
     validateExpectedRemoteAttributes("www.example.com", "/");
     mockAttribute(HTTP_URL, null);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -517,6 +517,11 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(HTTP_URL, null);
 
     // Validate behavior of Remote Service from HttpUrl
+    mockAttribute(HTTP_URL, "http://192.168.1.1");
+    validateExpectedRemoteAttributes("192.168.1.1", "/");
+    mockAttribute(HTTP_URL, null);
+
+    // Validate behavior of Remote Service from HttpUrl
     mockAttribute(HTTP_URL, "");
     validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, UNKNOWN_REMOTE_OPERATION);
     mockAttribute(HTTP_URL, null);


### PR DESCRIPTION
*Description of changes:*
Updated generateRemoteService to parse HTTP_URL as last resort in case NET_PEER_NAME or NET_SOCK_PEER_ADDR are not present as attributes. If HTTP_URL is present, this will attempt to parse it and if it fails, it defaults to UNKNOWN_REMOTE_SERVICE.

Tested by updating the unit tests and verifying the expected behavior. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
