### PR TITLE
Adding support for ISO regions

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
@@ -331,17 +331,14 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String target,
       String spanKind) {
 
-    var assertions =
-        assertThat(attributesList)
-            .satisfiesOnlyOnce(
-                assertAttribute(AppSignalsConstants.AWS_LOCAL_OPERATION, localOperation))
+    assertThat(attributesList)
+            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_LOCAL_OPERATION, localOperation))
             .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_LOCAL_SERVICE, localService))
             .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_OPERATION, operation))
             .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_SERVICE, service))
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_SPAN_KIND, spanKind));
-    if (target != null) {
-      assertions.satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_TARGET, target));
-    }
+            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_SPAN_KIND, spanKind))
+            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_TARGET, target));
+
   }
 
   private void assertSqsConsumerAwsAttributes(List<KeyValue> attributesList, String operation) {
@@ -1059,8 +1056,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "GET /sqs/publishqueue/:queuename";
-    // SendMessage does not capture aws.queue.name
-    String target = null;
+    String target = "::sqs:::some-queue";
 
     assertSpanProducerAttributes(
         traces,
@@ -1122,8 +1118,8 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "InternalOperation";
-    // ReceiveMessage does not capture aws.queue.name
-    String target = null;
+    String target = "::sqs:::some-queue";
+
     // Consumer traces for SQS behave like a Server span (they create the local aws service
     // attributes), but have RPC attributes like a client span.
     assertSpanConsumerAttributes(
@@ -1171,8 +1167,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "GET /sqs/error";
-    // SendMessage does not capture aws.queue.name
-    String target = null;
+    String target = "::sqs:::some-queue";
 
     assertSpanProducerAttributes(
         traces,
@@ -1230,8 +1225,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "GET /sqs/fault";
-    // SendMessage does not capture aws.queue.name
-    String target = null;
+    String target = "::sqs:::some-queue";
 
     assertSpanProducerAttributes(
         traces,

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
@@ -332,13 +332,12 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String spanKind) {
 
     assertThat(attributesList)
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_LOCAL_OPERATION, localOperation))
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_LOCAL_SERVICE, localService))
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_OPERATION, operation))
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_SERVICE, service))
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_SPAN_KIND, spanKind))
-            .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_TARGET, target));
-
+        .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_LOCAL_OPERATION, localOperation))
+        .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_LOCAL_SERVICE, localService))
+        .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_OPERATION, operation))
+        .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_SERVICE, service))
+        .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_SPAN_KIND, spanKind))
+        .satisfiesOnlyOnce(assertAttribute(AppSignalsConstants.AWS_REMOTE_TARGET, target));
   }
 
   private void assertSqsConsumerAwsAttributes(List<KeyValue> attributesList, String operation) {

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
@@ -1055,7 +1055,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "GET /sqs/publishqueue/:queuename";
-    String target = "::sqs:::some-queue";
+    String target = "::sqs::000000000000:some-queue";
 
     assertSpanProducerAttributes(
         traces,
@@ -1117,7 +1117,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "InternalOperation";
-    String target = "::sqs:::some-queue";
+    String target = "::sqs::000000000000:some-queue";
 
     // Consumer traces for SQS behave like a Server span (they create the local aws service
     // attributes), but have RPC attributes like a client span.
@@ -1166,7 +1166,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "GET /sqs/error";
-    String target = "::sqs:::some-queue";
+    String target = "::sqs::000000000000:some-queue";
 
     assertSpanProducerAttributes(
         traces,
@@ -1224,7 +1224,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
 
     var localService = getApplicationOtelServiceName();
     var localOperation = "GET /sqs/fault";
-    String target = "::sqs:::some-queue";
+    String target = "::sqs::000000000000:some-queue";
 
     assertSpanProducerAttributes(
         traces,

--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
   // Export configuration
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
 
+  implementation("software.amazon.awssdk:regions:2.24.4")
+
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("io.opentelemetry:opentelemetry-extension-aws")

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -659,12 +659,26 @@ class AwsMetricAttributeGeneratorTest {
   public void testClientSpanSqsInvalidOrEmptyUrls() {
     testSqsUrl(null, null);
     testSqsUrl("", null);
+    testSqsUrl("https://sqs.invalidRegion.amazonaws.com/123412341234/Q_Name-5", null);
     testSqsUrl("invalidUrl", null);
     testSqsUrl("https://www.amazon.com", null);
     testSqsUrl("https://sqs.us-east-1.amazonaws.com/123412341234/.", null);
     testSqsUrl("https://sqs.us-east-1.amazonaws.com/12/Queue", null);
-    testSqsUrl("https://sqs.us-east-1.amazonaws.com/A/A", null);
+    testSqsUrl("https://sqs.us-east-1.amazonaws.com/AAAAAAAAAAAA/A", null);
     testSqsUrl("https://sqs.us-east-1.amazonaws.com/123412341234/A/ThisShouldNotBeHere", null);
+  }
+
+  @Test
+  public void testClientSpanSqsIsoUrls() {
+    testSqsUrl(
+            "https://sqs.us-iso-east-1.amazonaws.com/112233445566/ThisQueue",
+            "arn:aws-iso:sqs:us-iso-east-1:112233445566:ThisQueue");
+    testSqsUrl(
+            "https://sqs.us-iso-west-1.amazonaws.com/112233445566/ThatQueue",
+            "arn:aws-iso:sqs:us-iso-west-1:112233445566:ThatQueue");
+    testSqsUrl(
+            "https://sqs.us-isob-east-1.amazonaws.com/123412341234/ThisQueue",
+            "arn:aws-iso-b:sqs:us-isob-east-1:123412341234:ThisQueue");
   }
 
   private void testSqsUrl(String sqsUrl, String expectedRemoteTarget) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -671,14 +671,14 @@ class AwsMetricAttributeGeneratorTest {
   @Test
   public void testClientSpanSqsIsoUrls() {
     testSqsUrl(
-            "https://sqs.us-iso-east-1.amazonaws.com/112233445566/ThisQueue",
-            "arn:aws-iso:sqs:us-iso-east-1:112233445566:ThisQueue");
+        "https://sqs.us-iso-east-1.amazonaws.com/112233445566/ThisQueue",
+        "arn:aws-iso:sqs:us-iso-east-1:112233445566:ThisQueue");
     testSqsUrl(
-            "https://sqs.us-iso-west-1.amazonaws.com/112233445566/ThatQueue",
-            "arn:aws-iso:sqs:us-iso-west-1:112233445566:ThatQueue");
+        "https://sqs.us-iso-west-1.amazonaws.com/112233445566/ThatQueue",
+        "arn:aws-iso:sqs:us-iso-west-1:112233445566:ThatQueue");
     testSqsUrl(
-            "https://sqs.us-isob-east-1.amazonaws.com/123412341234/ThisQueue",
-            "arn:aws-iso-b:sqs:us-isob-east-1:123412341234:ThisQueue");
+        "https://sqs.us-isob-east-1.amazonaws.com/123412341234/ThisQueue",
+        "arn:aws-iso-b:sqs:us-isob-east-1:123412341234:ThisQueue");
   }
 
   private void testSqsUrl(String sqsUrl, String expectedRemoteTarget) {


### PR DESCRIPTION
*Description of changes:*
Adding support for ISO regions in the remote target for SQS.
Added additional validation for region and account id.
Fixed some tests. The testing logic that already existed was busted because if the target compared to was null it didn't validate it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
