### PR TITLE
Support AppSignals metrics transport protocol configuration

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -84,7 +84,8 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
       logger.info("AWS AppSignals enabled");
       Duration exportInterval =
           configProps.getDuration("otel.metric.export.interval", DEFAULT_METRIC_EXPORT_INTERVAL);
-      logger.log(Level.FINE, String.format("AppSignals Metrics export interval: %s", exportInterval));
+      logger.log(
+          Level.FINE, String.format("AppSignals Metrics export interval: %s", exportInterval));
       // Cap export interval to 60 seconds. This is currently required for metrics-trace correlation
       // to work correctly.
       if (exportInterval.compareTo(DEFAULT_METRIC_EXPORT_INTERVAL) > 0) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -81,10 +81,10 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
   private SdkTracerProviderBuilder customizeTracerProviderBuilder(
       SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties configProps) {
     if (isAppSignalsEnabled(configProps)) {
-      logger.info("Span Metrics Processor enabled");
+      logger.info("AWS AppSignals enabled");
       Duration exportInterval =
           configProps.getDuration("otel.metric.export.interval", DEFAULT_METRIC_EXPORT_INTERVAL);
-      logger.log(Level.FINE, String.format("Span Metrics export interval: %s", exportInterval));
+      logger.log(Level.FINE, String.format("AppSignals Metrics export interval: %s", exportInterval));
       // Cap export interval to 60 seconds. This is currently required for metrics-trace correlation
       // to work correctly.
       if (exportInterval.compareTo(DEFAULT_METRIC_EXPORT_INTERVAL) > 0) {
@@ -108,7 +108,7 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
               .setResource(ResourceHolder.getResource())
               .registerMetricReader(metricReader)
               .build();
-      // Construct and set span metrics processor
+      // Construct and set AppSignals metrics processor
       SpanProcessor spanMetricsProcessor =
           AwsSpanMetricsProcessorBuilder.create(meterProvider, ResourceHolder.getResource())
               .build();
@@ -134,13 +134,13 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
     public MetricExporter createExporter(ConfigProperties configProps) {
       String protocol =
           OtlpConfigUtil.getOtlpProtocol(OtlpConfigUtil.DATA_TYPE_METRICS, configProps);
-      logger.log(Level.FINE, String.format("AppSignals protocol: %s", protocol));
+      logger.log(Level.FINE, String.format("AppSignals export protocol: %s", protocol));
 
       String appSignalsEndpoint =
           configProps.getString(
               "otel.aws.app.signals.exporter.endpoint",
               configProps.getString("otel.aws.smp.exporter.endpoint", "http://localhost:4315"));
-      logger.log(Level.FINE, String.format("AppSignals endpoint: %s", appSignalsEndpoint));
+      logger.log(Level.FINE, String.format("AppSignals export endpoint: %s", appSignalsEndpoint));
 
       if (protocol.equals(OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF)) {
         return OtlpHttpMetricExporter.builder()
@@ -155,7 +155,7 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
             .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
             .build();
       }
-      throw new ConfigurationException("Unsupported AppSignals protocol: " + protocol);
+      throw new ConfigurationException("Unsupported AppSignals export protocol: " + protocol);
     }
 
     private Aggregation getAggregation(InstrumentType instrumentType) {


### PR DESCRIPTION
*Issue #, if available:*
The SMP exporter for AppSignals metrics only support grpc transport protocol

*Description of changes:*

SMP exporter transport protocol is configurable, follows OTel environment variables priority:
1. OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
2. OTEL_EXPORTER_OTLP_PROTOCOL

For example, 
customer can use grpc for traces and http/protobuf for AppSignals metrics:
```
OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
```

or use http/protobuf for both traces and AppSignals metrics:
```
OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
```

*Testing:*
Build ADOT javaagent in local, launch OTel collector and turn on port 4315 for grpc, 4316 for http.
Then run a SpringBoot Application instrumented by ADOT javaagent, with different combination of OTel configurations
```
10055* OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10057* OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10059* OTEL_EXPORTER_OTLP_PROTOCOL=http/json OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:ws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10061* OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10062* OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10067* OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10069* OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10071* OTEL_EXPORTER_OTLP_PROTOCOL=http/json OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10073* OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10075* OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10078* OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10079* OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10080* OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10082* OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10084* OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10085* OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10087* OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
10115* OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315 OTEL_METRICS_EXPORTER=none OTEL_SMP_ENABLED=true OTEL_AWS_SMP_EXPORTER_ENDPOINT=http://localhost:4315 java -javaagent:aws-opentelemetry-agent-1.32.0-SNAPSHOT.jar -jar ./build/libs/spring-boot-0.0.1-SNAPSHOT.jar Application
```

Both traces and AppSignals metrics are able to be received by OTel Collector.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
