### PR TITLE
prefix `AWS.SDK` to the RemoteService from AWS SDK v1 spans

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/v1/AwsSdkV1Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/v1/AwsSdkV1Test.java
@@ -59,22 +59,22 @@ public class AwsSdkV1Test extends AwsSdkBaseTest {
 
   @Override
   protected String getS3ServiceName() {
-    return "Amazon S3";
+    return "AWS.SDK.Amazon S3";
   }
 
   @Override
   protected String getDynamoDbServiceName() {
-    return "AmazonDynamoDBv2";
+    return "AWS.SDK.AmazonDynamoDBv2";
   }
 
   @Override
   protected String getSqsServiceName() {
-    return "AmazonSQS";
+    return "AWS.SDK.AmazonSQS";
   }
 
   @Override
   protected String getKinesisServiceName() {
-    return "AmazonKinesis";
+    return "AWS.SDK.AmazonKinesis";
   }
 
   protected String getS3RpcServiceName() {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -216,10 +216,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   // add `AWS.SDK.` as prefix to indicate the metrics resulted from current span is from AWS SDK
   private static String normalizeServiceName(SpanData span, String serviceName) {
     if (AwsSpanProcessingUtil.isAwsSDKSpan(span)) {
-      String scopeName = span.getInstrumentationScopeInfo().getName();
-      if (scopeName.contains("aws-sdk-2.")) {
-        return "AWS.SDK." + serviceName;
-      }
+      return "AWS.SDK." + serviceName;
     }
     return serviceName;
   }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -969,7 +969,7 @@ class AwsMetricAttributeGeneratorTest {
 
     Attributes actualAttributes =
         GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
-    assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo("Amazon S3");
+    assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo("AWS.SDK.Amazon S3");
   }
 
   @Test


### PR DESCRIPTION
A follow up on this PR, where we left out the AWS SDK v1 instrumentation.
https://github.com/aws-observability/aws-apm-java-instrumentation/pull/160

Now with this change, for any version of AWS SDK client, we will be prefixing `AWS.SDK.` to the `RemoteService` attribute for the generated AppSignals metrics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
