### PR TITLE
Update RemoteTarget Value on E2E EC2 Test

### DIFF
--- a/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-metric.mustache
@@ -95,7 +95,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Latency
@@ -115,7 +115,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -214,7 +214,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -234,7 +234,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -333,7 +333,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -353,6 +353,6 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 

--- a/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
@@ -42,7 +42,7 @@
             "aws_local_operation": "^GET /aws-sdk-call$",
             "aws_remote_service": "^AWS\\.SDK\\.S3$",
             "aws_remote_operation": "^GetBucketLocation$",
-            "aws_remote_target": "^e2e-test-bucket-name$"
+            "aws_remote_target": "^::s3:::e2e-test-bucket-name$"
           },
           "metadata": {
             "default": {


### PR DESCRIPTION
*Issue #, if available:*
The e2e test in main-build is currently failing due to outdated remote target value for aws-sdk-call

*Description of changes:*
Update the remote target value to ::s3:::e2e-test-bucket-name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
