### PR TITLE
update the remote target for eks e2e validations

### DIFF
--- a/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
@@ -113,7 +113,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Latency
@@ -136,7 +136,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -253,7 +253,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -276,7 +276,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -393,7 +393,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -416,4 +416,4 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name

--- a/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
+++ b/testing/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
@@ -44,7 +44,7 @@
             "aws_local_operation": "^GET /aws-sdk-call$",
             "aws_remote_service": "^AWS\\.SDK\\.S3$",
             "aws_remote_operation": "GetBucketLocation",
-            "aws_remote_target": "e2e-test-bucket-name"
+            "aws_remote_target": "::s3:::e2e-test-bucket-name"
           },
           "metadata": {
             "default": {


### PR DESCRIPTION
Follow up from the https://github.com/aws-observability/aws-otel-java-instrumentation/pull/757 where EKS E2E test templates were missed out.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
