### PR TITLE
[E2E] Update patch command to let ADOT image update

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Patch the ADOT image and restart CloudWatch pods
         run: |
           kubectl patch deploy -namazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-          -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/0", "value": "--auto-instrumentation-java-image=${{ inputs.appsignals-adot-image-name }}"}]'
+          -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/1", "value": "--auto-instrumentation-java-image=${{ inputs.appsignals-adot-image-name }}"}]'
           kubectl delete pods --all -n amazon-cloudwatch
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
 


### PR DESCRIPTION
Based on changes introduced by this PR in the operator repo: https://github.com/aws/amazon-cloudwatch-agent-operator/pull/85

Validated [here](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8638684079) (note: this workflow failed as it is a WIP but the [ADOT image logging step](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8638684079) shows it has changed)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
