### PR TITLE
Switch to using sonatype token user name and password

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -94,8 +94,8 @@ jobs:
         with:
           arguments: build integrationTests snapshot --stacktrace -PenableCoverage=true -PlocalDocker=true
         env:
-          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
+          PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -50,8 +50,8 @@ jobs:
         with:
           arguments: build --stacktrace -PenableCoverage=true -PtestUpstreamSnapshots=true
         env:
-          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
+          PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -140,8 +140,8 @@ jobs:
         with:
           arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
         env:
-          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
+          PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
           GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -109,8 +109,8 @@ jobs:
         with:
           arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
         env:
-          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
+          PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
           GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,16 +81,16 @@ is`v1.2.3-RC$`, where `$` denotes a release candidate version, e.g. `v1.2.3-RC1`
 
 The following credentials are required for publishing (and automatically set in CI):
 
-* `PUBLISH_USERNAME` and `PUBLISH_PASSWORD`: Sonatype credentials for publishing.
+* `PUBLISH_TOKEN_USERNAME` and `PUBLISH_TOKEN_PASSWORD`: Sonatype credentials for publishing.
 
 ## Releasing from the local setup
 
 Releasing from the local setup can be done providing the previously mentioned four credential values, i.e.
-`PUBLISH_USERNAME`, `PUBLISH_PASSWORD`
+`PUBLISH_TOKEN_USERNAME`, `PUBLISH_TOKEN_PASSWORD`
 
 ```sh
-export PUBLISH_USERNAME=my_sonatype_user
-export PUBLISH_PASSWORD=my_sonatype_key
+export PUBLISH_TOKEN_USERNAME=my_sonatype_user
+export PUBLISH_TOKEN_PASSWORD=my_sonatype_key
 export RELEASE_VERSION=2.4.5 # Set version you want to release
 ./gradlew build final -Prelease.version=${RELEASE_VERSION}
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,8 @@ nexusPublishing {
     sonatype {
       nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
       snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
-      username.set(System.getenv("PUBLISH_USERNAME"))
-      password.set(System.getenv("PUBLISH_PASSWORD"))
+      username.set(System.getenv("PUBLISH_TOKEN_USERNAME"))
+      password.set(System.getenv("PUBLISH_TOKEN_PASSWORD"))
     }
   }
 }


### PR DESCRIPTION
Utilizes tokens created in NXRM rather than standard usernames and passwords. 

Secrets have already been added to the repository

https://central.sonatype.org/publish/generate-token/



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
