### PR TITLE
Add different endpoints for GRPC and HTTP protocal

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java
@@ -137,19 +137,25 @@ public class AwsAppSignalsCustomizerProvider implements AutoConfigurationCustomi
           OtlpConfigUtil.getOtlpProtocol(OtlpConfigUtil.DATA_TYPE_METRICS, configProps);
       logger.log(Level.FINE, String.format("AppSignals export protocol: %s", protocol));
 
-      String appSignalsEndpoint =
-          configProps.getString(
-              "otel.aws.app.signals.exporter.endpoint",
-              configProps.getString("otel.aws.smp.exporter.endpoint", "http://localhost:4315"));
-      logger.log(Level.FINE, String.format("AppSignals export endpoint: %s", appSignalsEndpoint));
-
+      String appSignalsEndpoint;
       if (protocol.equals(OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF)) {
+        appSignalsEndpoint =
+            configProps.getString(
+                "otel.aws.app.signals.exporter.endpoint",
+                configProps.getString(
+                    "otel.aws.smp.exporter.endpoint", "http://localhost:4316/v1/metrics"));
+        logger.log(Level.FINE, String.format("AppSignals export endpoint: %s", appSignalsEndpoint));
         return OtlpHttpMetricExporter.builder()
             .setEndpoint(appSignalsEndpoint)
             .setDefaultAggregationSelector(this::getAggregation)
             .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
             .build();
       } else if (protocol.equals(OtlpConfigUtil.PROTOCOL_GRPC)) {
+        appSignalsEndpoint =
+            configProps.getString(
+                "otel.aws.app.signals.exporter.endpoint",
+                configProps.getString("otel.aws.smp.exporter.endpoint", "http://localhost:4315"));
+        logger.log(Level.FINE, String.format("AppSignals export endpoint: %s", appSignalsEndpoint));
         return OtlpGrpcMetricExporter.builder()
             .setEndpoint(appSignalsEndpoint)
             .setDefaultAggregationSelector(this::getAggregation)


### PR DESCRIPTION
*Issue #, if available:*
Updating Java Instrumentation to match parity with the Python Instrumentation. Update code based on this [change](https://github.com/aws-observability/aws-otel-python-instrumentation/commit/2301739fa32386b110197da28f1ce7fe9e4bbe86). 

The python instrumentation has strict dependencies on the python version for `grpc`, so `opentelemetry-exporter-otlp-proto-grpc` is only installed if explicitly called by the user. Such issues are not present in the Java instrumentation, so will leave the build configuration as it is. 

Only changes to be made are to update the endpoints for HTTP and grpc protocol

*Description of changes:*
HTTP and grpc protocol will have different endpoints. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
