### PR TITLE
Update Release Testing with Latest Update

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -23,7 +23,6 @@ env:
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   SAMPLE_APP_FRONTEND_SERVICE_JAR: ${{ secrets.APP_SIGNALS_E2E_FE_SA_JAR }}
   SAMPLE_APP_REMOTE_SERVICE_JAR: ${{ secrets.APP_SIGNALS_E2E_RE_SA_JAR }}
-  APP_SIGNALS_ADOT_JAR: "https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
   GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-us-east-1.s3.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"
   GET_ADOT_JAR_COMMAND: "aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar"
   METRIC_NAMESPACE: AppSignals
@@ -37,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws-observability/aws-application-signals-test-framework
-          ref: main
+          ref: adot-pending-release
 
       - name: Generate testing id
         run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
@@ -125,7 +124,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
-          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
@@ -142,7 +141,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
-          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
@@ -159,7 +158,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
-          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws-observability/aws-application-signals-test-framework
-          ref: main
+          ref: adot-pending-release
 
       - name: Download enablement script
         uses: actions/checkout@v4
@@ -134,7 +134,8 @@ jobs:
           kubectl patch deploy -namazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
           -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/1", "value": "--auto-instrumentation-java-image=${{ inputs.appsignals-adot-image-name }}"}]'
           kubectl delete pods --all -n amazon-cloudwatch
-          kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+          sleep 5
+          kubectl wait --for=condition=Ready pod --request-timeout '5m' --all -n amazon-cloudwatch
 
       - name: Restart the app pods
         run: kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
@@ -205,7 +206,7 @@ jobs:
           --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 
       - name: Call endpoints and validate generated metrics
@@ -223,7 +224,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 
       - name: Call endpoints and validate generated traces
@@ -240,7 +241,7 @@ jobs:
           --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 
       - name: Publish metric on test result


### PR DESCRIPTION
*Issue #, if available:*
The Enablement E2E tests are failing during main-build. There are currently three issues:
- Parameter in the validators was changed and invalid now.
- The framework repository is not yet updated to reflect the new ADOT changes
- EKS sample app pods does not start properly. Suspect the secrets to the ECR containing sample app images are pointintg to the wrong address. 

*Description of changes:*
- Update the request-body parameter with the query string parameter based on changes from this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/commit/22d1f72a6468935217f9c1d868672a1de3cf17b5)
- Retrieve validation resources from the [framework](https://github.com/aws-observability/aws-application-signals-test-framework) repository `adot-pending-release` branch instead of the `main` branch
- Re-updated the secrets `APP_SIGNALS_E2E_FE_SA_IMG` and `APP_SIGNALS_E2E_RE_SA_IMG`
- Added a 5 second sleep after ADOT is patched since the `kubectl wait` command exits immediately and doesn't seem to wait if the pods are not up yet. 

*Test run:*
- https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/9036399926
- https://github.com/harrryr/aws-otel-java-instrumentation/actions/runs/9036816462

*Note:* Check if the main-build test passes successfully after this PR is merged

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
