### PR TITLE
Update settings.gradle.kts to remove outdate code

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -75,12 +75,6 @@ jobs:
         uses: ./.github/actions/patch-dependencies
         if: ${{ matrix.os != 'windows-latest' }} # Skip patch on windows as it is not possible to build opentelemetry-java on windows
 
-      - name: Dry Run Validator
-        uses: gradle/gradle-build-action@v3
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        with:
-          arguments: testing:validator:build
-
       - name: Build with Gradle with Integration tests
         uses: gradle/gradle-build-action@v3
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,9 +69,3 @@ include("appsignals-tests:images:grpc:grpc-client")
 include("appsignals-tests:images:jdbc")
 include("appsignals-tests:images:kafka:kafka-producers")
 include("appsignals-tests:images:kafka:kafka-consumers")
-
-
-// End to end tests
-include(":testing:validator")
-include(":testing:sample-apps:springboot")
-include(":testing:sample-apps:springboot-remote-service")


### PR DESCRIPTION
*Issue #, if available:*
The e2e-operator-test is currently failing in main-build. We suspect it may be due to trying to compile non-existent directories during compilation. 

*Description of changes:*
Removed Enablement E2E test directories from settings.gradle.kts which was removed in this [PR](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/770)

Also removed the dry run validator step in PR build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
