### PR TITLE
Add support on Database RemoteResourceType and RemoteResourceIdentifier

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -15,6 +15,9 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
+import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_OPERATION;
@@ -217,5 +220,12 @@ final class AwsSpanProcessingUtil {
       }
     }
     return operation;
+  }
+
+  // Check if the current Span adheres to database semantic conventions
+  static boolean isDBSpan(SpanData span) {
+    return isKeyPresent(span, DB_SYSTEM)
+        || isKeyPresent(span, DB_OPERATION)
+        || isKeyPresent(span, DB_STATEMENT);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
If we detect the span is a [Database span](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md) (by the existence of the `db.system`, `db.operation`, or `db.statement` attributes, except in the case of a [AWS SDK span](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/cloud-providers/aws-sdk.md), like DynamoDB SDK calls), we will provide a `RemoteResourceType` and `RemoteResourceIdentifier` as follows:

1. If an address attribute is present, and if a port attribute and/or db.name attribute is optionally present
    1. RemoteResourceType = DB::Connection
    2. RemoteResourceIdentifier = [db.name|]? {**address**} [|{**port**}]?
        1. If any attribute contains | or ^ , they will be replaced with ^| or ^^ , respectively 
2. If address is not present, neither RemoteResourceType nor RemoteResourceIdentifier will be provided.
#### Note:
* {**address**} attribute is retrieved in priority order:
   - server.address
   - network.peer.address
   - server.socket.address
   - db.connection_string#getHost 

* {**port**}] attribute is retrieved in priority order:
   - server.port
   - network.peer.port
   - server.socket.port
   - db.connection_string#getPort 

#### Example
```
RemoteService=mysql
RemoteOperation=SELECT
RemoteResourceType=DB::Connection
RemoteResourceIdentifier=petclicnic|[apm-test.cluster-cnrw3s3ddo7n.us-east-1.rds.amazonaws.com](http://apm-test.cluster-cnrw3s3ddo7n.us-east-1.rds.amazonaws.com/)|3306
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
