### PR TITLE
Add app signals contract test for postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ atlassian-ide-plugin.xml
 
 # rust
 tools/cp-utility/target
+
+# lsp
+**/.project
+**/.classpath
+**/.settings
+**/bin

--- a/appsignals-tests/contract-tests/build.gradle.kts
+++ b/appsignals-tests/contract-tests/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   testImplementation(kotlin("test"))
   implementation(project(":appsignals-tests:images:grpc:grpc-base"))
   testImplementation("org.testcontainers:kafka:1.19.3")
+  testImplementation("org.testcontainers:postgresql:1.19.3")
 }
 
 project.evaluationDependsOn(":otelagent")

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
@@ -103,11 +103,16 @@ public class JdbcH2Test extends ContractTestBase {
   @Override
   protected Map<String, String> getApplicationExtraEnvironmentVariables() {
     return Map.of(
-        "DB_URL", String.format("jdbc:h2:mem:%s", DB_NAME),
-        "DB_DRIVER", "org.h2.Driver",
-        "DB_USERNAME", DB_USER,
-        "DB_PASSWORD", DB_PASSWORD,
-        "DB_PLATFORM", "org.hibernate.dialect.H2Dialect");
+        "DB_URL",
+        String.format("jdbc:h2:mem:%s", DB_NAME),
+        "DB_DRIVER",
+        "org.h2.Driver",
+        "DB_USERNAME",
+        DB_USER,
+        "DB_PASSWORD",
+        DB_PASSWORD,
+        "DB_PLATFORM",
+        "org.hibernate.dialect.H2Dialect");
   }
 
   protected void assertAwsSpanAttributes(

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.appsignals.test.jdbc;
+
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.opentelemetry.appsignals.test.base.ContractTestBase;
+import software.amazon.opentelemetry.appsignals.test.utils.AppSignalsConstants;
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeMetric;
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
+import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class JdbcH2Test extends ContractTestBase {
+
+  private static final String DB_SYSTEM = "h2";
+  private static final String DB_NAME = "testdb";
+  private static final String DB_USER = "sa";
+  private static final String DB_PASSWORD = "password";
+  private static final String DB_OPERATION = "SELECT";
+
+  @Test
+  public void testSuccess() {
+    var path = "success";
+    var method = "GET";
+    var otelStatusCode = "STATUS_CODE_UNSET";
+    var dbSqlTable = "employee";
+    var response = appClient.get(path).aggregate().join();
+    assertThat(response.status().isSuccess()).isTrue();
+
+    var traces = mockCollectorClient.getTraces();
+    assertAwsSpanAttributes(traces, method, path);
+    assertSemanticConventionsSpanAttributes(traces, otelStatusCode, dbSqlTable);
+
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.LATENCY_METRIC,
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC));
+    assertMetricAttributes(metrics, method, path, AppSignalsConstants.LATENCY_METRIC, 5000.0);
+    assertMetricAttributes(metrics, method, path, AppSignalsConstants.ERROR_METRIC, 0.0);
+    assertMetricAttributes(metrics, method, path, AppSignalsConstants.FAULT_METRIC, 0.0);
+  }
+
+  @Test
+  public void testFault() {
+    var path = "fault";
+    var method = "GET";
+    var otelStatusCode = "STATUS_CODE_ERROR";
+    var dbSqlTable = "userrr";
+    var response = appClient.get(path).aggregate().join();
+    assertThat(response.status().isServerError()).isTrue();
+
+    var traces = mockCollectorClient.getTraces();
+    assertAwsSpanAttributes(traces, method, path);
+    assertSemanticConventionsSpanAttributes(traces, otelStatusCode, dbSqlTable);
+
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.LATENCY_METRIC,
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC));
+    assertMetricAttributes(metrics, method, path, AppSignalsConstants.LATENCY_METRIC, 5000.0);
+    assertMetricAttributes(metrics, method, path, AppSignalsConstants.ERROR_METRIC, 0.0);
+    assertMetricAttributes(metrics, method, path, AppSignalsConstants.FAULT_METRIC, 1.0);
+  }
+
+  @Override
+  protected String getApplicationImageName() {
+    return "aws-appsignals-tests-jdbc-app";
+  }
+
+  @Override
+  protected String getApplicationWaitPattern() {
+    return ".*Application Ready.*";
+  }
+
+  @Override
+  protected Map<String, String> getApplicationExtraEnvironmentVariables() {
+    return Map.of(
+        "DB_URL", String.format("jdbc:h2:mem:%s", DB_NAME),
+        "DB_DRIVER", "org.h2.Driver",
+        "DB_USERNAME", DB_USER,
+        "DB_PASSWORD", DB_PASSWORD,
+        "DB_PLATFORM", "org.hibernate.dialect.H2Dialect");
+  }
+
+  protected void assertAwsSpanAttributes(
+      List<ResourceScopeSpan> resourceScopeSpans, String method, String path) {
+    assertThat(resourceScopeSpans)
+        .satisfiesOnlyOnce(
+            rss -> {
+              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+              var attributesList = rss.getSpan().getAttributesList();
+              assertAwsAttributes(attributesList, method, path);
+            });
+  }
+
+  protected void assertAwsAttributes(
+      List<KeyValue> attributesList, String method, String endpoint) {
+    assertThat(attributesList)
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(String.format("%s /%s", method, endpoint));
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(getApplicationOtelServiceName());
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_SYSTEM);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_OPERATION);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo("CLIENT");
+            });
+  }
+
+  protected void assertSemanticConventionsSpanAttributes(
+      List<ResourceScopeSpan> resourceScopeSpans, String otelStatusCode, String dbSqlTable) {
+    assertThat(resourceScopeSpans)
+        .satisfiesOnlyOnce(
+            rss -> {
+              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+              assertThat(rss.getSpan().getName())
+                  .isEqualTo(String.format("%s %s.%s", DB_OPERATION, DB_NAME, dbSqlTable));
+              assertThat(rss.getSpan().getStatus().getCode().equals(otelStatusCode));
+              var attributesList = rss.getSpan().getAttributesList();
+              assertSemanticConventionsAttributes(attributesList, dbSqlTable);
+            });
+  }
+
+  protected void assertSemanticConventionsAttributes(
+      List<KeyValue> attributesList, String dbSqlTable) {
+    assertThat(attributesList)
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_ID);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_NAME);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey())
+                  .isEqualTo(SemanticConventionsConstants.DB_CONNECTION_STRING);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(String.format("%s:mem:", DB_SYSTEM));
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_NAME);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_NAME);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SQL_TABLE);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSqlTable);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_STATEMENT);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(
+                      String.format("%s count(*) from %s", DB_OPERATION.toLowerCase(), dbSqlTable));
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_USER);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_USER);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_OPERATION);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_OPERATION);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SYSTEM);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_SYSTEM);
+            });
+  }
+
+  protected void assertMetricAttributes(
+      List<ResourceScopeMetric> resourceScopeMetrics,
+      String method,
+      String path,
+      String metricName,
+      Double expectedSum) {
+    assertThat(resourceScopeMetrics)
+        .anySatisfy(
+            metric -> {
+              assertThat(metric.getMetric().getName()).isEqualTo(metricName);
+              List<ExponentialHistogramDataPoint> dpList =
+                  metric.getMetric().getExponentialHistogram().getDataPointsList();
+              assertThat(dpList)
+                  .satisfiesOnlyOnce(
+                      dp -> {
+                        List<KeyValue> attributesList = dp.getAttributesList();
+                        assertThat(attributesList).isNotNull();
+                        assertThat(attributesList)
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo("CLIENT");
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(String.format("%s /%s", method, path));
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(getApplicationOtelServiceName());
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(DB_SYSTEM);
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(DB_OPERATION);
+                                });
+
+                        if (expectedSum != null) {
+                          double actualSum = dp.getSum();
+                          switch (metricName) {
+                            case AppSignalsConstants.LATENCY_METRIC:
+                              assertThat(actualSum).isStrictlyBetween(0.0, expectedSum);
+                              break;
+                            default:
+                              assertThat(actualSum).isEqualTo(expectedSum);
+                          }
+                        }
+                      });
+            });
+  }
+}

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcPostgresTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcPostgresTest.java
@@ -119,11 +119,16 @@ public class JdbcPostgresTest extends ContractTestBase {
   @Override
   protected Map<String, String> getApplicationExtraEnvironmentVariables() {
     return Map.of(
-        "DB_URL", String.format("jdbc:postgresql://%s:5432/%s", NETWORK_ALIAS, DB_NAME),
-        "DB_DRIVER", "org.postgresql.Driver",
-        "DB_USERNAME", DB_USER,
-        "DB_PASSWORD", DB_PASSWORD,
-        "DB_PLATFORM", "org.hibernate.dialect.PostgreSQLDialect");
+        "DB_URL",
+        String.format("jdbc:postgresql://%s:5432/%s", NETWORK_ALIAS, DB_NAME),
+        "DB_DRIVER",
+        "org.postgresql.Driver",
+        "DB_USERNAME",
+        DB_USER,
+        "DB_PASSWORD",
+        DB_PASSWORD,
+        "DB_PLATFORM",
+        "org.hibernate.dialect.PostgreSQLDialect");
   }
 
   @Override

--- a/appsignals-tests/images/jdbc/build.gradle.kts
+++ b/appsignals-tests/images/jdbc/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-jdbc:3.1.4")
   implementation("com.h2database:h2:2.2.224")
   implementation("org.slf4j:slf4j-simple")
+  implementation("org.postgresql:postgresql:42.2.0")
 }
 
 // not publishing images to hubs in this configuration - local build only through jibDockerBuild

--- a/appsignals-tests/images/jdbc/src/main/java/software/amazon/opentelemetry/AppController.java
+++ b/appsignals-tests/images/jdbc/src/main/java/software/amazon/opentelemetry/AppController.java
@@ -58,7 +58,7 @@ public class AppController {
   @GetMapping("/fault")
   @ResponseBody
   public ResponseEntity<String> failure() {
-    int count = jdbcTemplate.queryForObject("select count(*) from user", Integer.class);
+    int count = jdbcTemplate.queryForObject("select count(*) from userrr", Integer.class);
     return ResponseEntity.ok().body("success");
   }
 

--- a/appsignals-tests/images/jdbc/src/main/resources/application.properties
+++ b/appsignals-tests/images/jdbc/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.datasource.url=${DB_URL}
+spring.datasource.driverClassName=${DB_DRIVER}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.jpa.database-platform=${DB_PLATFORM}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding PostgreSQL contract tests for app signals to ensure that customer experience doesn't break with any change.

The new contract test follows the same structure as the current [JDBC test](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JDBC.java#L36) and asserts on the same fields of the spans and attributes.

To reuse the [same app](https://github.com/aws-observability/aws-otel-java-instrumentation/tree/main/appsignals-tests/images/jdbc/src/main) as the current test, added the following environment variables which are changed by each test:
- DB_URL
- DB_DRIVER
- DB_USERNAME
- DB_PASSWORD
- DB_PLATFORM

This will allow us to easily write tests for other kinds of databases in the future.

**Notes**
Had to change the fault query in the app because the previous query is valid in PostgresSQL. This change won't have any impact with `H2` database because it is still an invalid query.
From:
```
select count(*) from user
```
To:
```
select count(*) from userrr
```

**Contract tests running successfully**
```
$ JAVA_HOME=/home/tdm/java17/amazon-corretto-17.0.11.9.1-linux-x64 ./gradlew :appsignals-tests:contract-tests:contractTests

> Configure project :awsagentprovider
Inferred project: aws-otel-java-instrumentation, version: 1.33.0-SNAPSHOT

> Task :appsignals-tests:images:http-servers:tomcat:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-tomcat...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.tests.images.httpservers.tomcat.Main]
Executing tasks:
[==============================] 99.3% complete
> loading to Docker daemon


> Task :appsignals-tests:images:http-servers:netty-server:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-netty-server...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.NettyServer]

Built image to Docker daemon as aws-appsignals-tests-http-server-netty-server
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:apache-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-apache-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-apache-http-client-app
Executing tasks:

Built image to Docker daemon as aws-appsignals-tests-http-server-tomcat
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:kafka:kafka-producers:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-kafka-kafka-producers...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-kafka-kafka-producers

A new version of jib-gradle-plugin (3.4.2) is available (currently using 3.4.0). Update your build configuration to use the latest features and fixes!
https://github.com/GoogleContainerTools/jib/blob/master/jib-gradle-plugin/CHANGELOG.md

Please see https://github.com/GoogleContainerTools/jib/blob/master/docs/privacy.md for info on disabling this update check.

Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:native-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-native-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[==============================] 99.1% complete
> loading to Docker daemon


> Task :appsignals-tests:images:kafka:kafka-consumers:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-kafka-kafka-consumers...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, App]

Built image to Docker daemon as aws-appsignals-tests-kafka-kafka-consumers
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-servers:spring-mvc:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-spring-mvc...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.tests.images.httpservers.springmvc.Application]

Built image to Docker daemon as aws-appsignals-tests-http-server-spring-mvc
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:netty-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-netty-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.NettyClient]

Built image to Docker daemon as aws-appsignals-tests-netty-http-client-app
Executing tasks:

Built image to Docker daemon as aws-appsignals-tests-native-http-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:mock-collector:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-mock-collector...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.test.images.mockcollector.Main]

Built image to Docker daemon as aws-appsignals-mock-collector
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:grpc:grpc-client:jibDockerBuild

Containerizing application to Docker daemon as grpc-client...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, software.amazon.opentelemetry.Main]

Built image to Docker daemon as grpc-client
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:aws-sdk:aws-sdk-v1:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-aws-sdk-v1...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[============================= ] 97.5% complete
> loading to Docker daemon


> Task :appsignals-tests:images:aws-sdk:aws-sdk-v2:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-aws-sdk-v2...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-aws-sdk-v2
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:grpc:grpc-server:jibDockerBuild

Containerizing application to Docker daemon as grpc-server...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, software.amazon.opentelemetry.EchoerServer]

Built image to Docker daemon as grpc-server
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:jdbc:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-jdbc-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.Application]

Built image to Docker daemon as aws-appsignals-tests-jdbc-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:spring-mvc-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-spring-mvc-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.Application]

Built image to Docker daemon as aws-appsignals-tests-spring-mvc-client-app
Executing tasks:

Built image to Docker daemon as aws-appsignals-tests-aws-sdk-v1
Executing tasks:
[==============================] 100.0% complete


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 13m 9s
56 actionable tasks: 19 executed, 37 up-to-date
````


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
