### PR TITLE
Adding Application Signals Contract Test for MySQL

### DIFF
--- a/appsignals-tests/contract-tests/build.gradle.kts
+++ b/appsignals-tests/contract-tests/build.gradle.kts
@@ -58,6 +58,8 @@ dependencies {
   implementation(project(":appsignals-tests:images:grpc:grpc-base"))
   testImplementation("org.testcontainers:kafka:1.19.3")
   testImplementation("org.testcontainers:postgresql:1.19.3")
+  testImplementation("org.testcontainers:mysql:1.19.8")
+  testImplementation("com.mysql:mysql-connector-j:8.4.0")
 }
 
 project.evaluationDependsOn(":otelagent")

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
-import io.opentelemetry.proto.trace.v1.Status.StatusCode;
 import java.util.List;
 import java.util.Set;
 import software.amazon.opentelemetry.appsignals.test.base.ContractTestBase;
@@ -98,7 +97,7 @@ public class JdbcContractTestBase extends ContractTestBase {
 
   protected void assertSemanticConventionsSpanAttributes(
       List<ResourceScopeSpan> resourceScopeSpans,
-      StatusCode otelStatusCode,
+      String otelStatusCode,
       String dbSqlTable,
       String dbSystem,
       String dbOperation,
@@ -111,7 +110,7 @@ public class JdbcContractTestBase extends ContractTestBase {
               assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
               assertThat(rss.getSpan().getName())
                   .isEqualTo(String.format("%s %s.%s", dbOperation, dbName, dbSqlTable));
-              assertThat(rss.getSpan().getStatus().getCode()).isEqualTo(otelStatusCode);
+              assertThat(rss.getSpan().getStatus().getCode().toString()).isEqualTo(otelStatusCode);
               var attributesList = rss.getSpan().getAttributesList();
               assertSemanticConventionsAttributes(
                   attributesList, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
@@ -249,7 +248,7 @@ public class JdbcContractTestBase extends ContractTestBase {
       String dbSystem, String dbOperation, String dbUser, String dbName, String jdbcUrl) {
     var path = "success";
     var method = "GET";
-    var otelStatusCode = StatusCode.STATUS_CODE_UNSET;
+    var otelStatusCode = "STATUS_CODE_UNSET";
     var dbSqlTable = "employee";
 
     var response = appClient.get(path).aggregate().join();
@@ -278,7 +277,7 @@ public class JdbcContractTestBase extends ContractTestBase {
       String dbSystem, String dbOperation, String dbUser, String dbName, String jdbcUrl) {
     var path = "fault";
     var method = "GET";
-    var otelStatusCode = StatusCode.STATUS_CODE_ERROR;
+    var otelStatusCode = "STATUS_CODE_ERROR";
     var dbSqlTable = "userrr";
     var response = appClient.get(path).aggregate().join();
     assertThat(response.status().isServerError()).isTrue();

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.appsignals.test.jdbc;
+
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
+import io.opentelemetry.proto.trace.v1.Status.StatusCode;
+import java.util.List;
+import java.util.Set;
+import software.amazon.opentelemetry.appsignals.test.base.ContractTestBase;
+import software.amazon.opentelemetry.appsignals.test.utils.AppSignalsConstants;
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeMetric;
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
+import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
+
+public class JdbcContractTestBase extends ContractTestBase {
+  protected static final String DB_NAME = "testdb";
+  protected static final String DB_USER = "sa";
+  protected static final String DB_PASSWORD = "password";
+  protected static final String DB_OPERATION = "SELECT";
+
+  @Override
+  protected String getApplicationImageName() {
+    return "aws-appsignals-tests-jdbc-app";
+  }
+
+  @Override
+  protected String getApplicationWaitPattern() {
+    return ".*Application Ready.*";
+  }
+
+  protected void assertAwsSpanAttributes(
+      List<ResourceScopeSpan> resourceScopeSpans,
+      String method,
+      String path,
+      String dbSystem,
+      String dbOperation) {
+    assertThat(resourceScopeSpans)
+        .satisfiesOnlyOnce(
+            rss -> {
+              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+              var attributesList = rss.getSpan().getAttributesList();
+              assertAwsAttributes(attributesList, method, path, dbSystem, dbOperation);
+            });
+  }
+
+  protected void assertAwsAttributes(
+      List<KeyValue> attributesList,
+      String method,
+      String endpoint,
+      String dbSystem,
+      String dbOperation) {
+    assertThat(attributesList)
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(String.format("%s /%s", method, endpoint));
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(getApplicationOtelServiceName());
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSystem);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbOperation);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo("CLIENT");
+            });
+  }
+
+  protected void assertSemanticConventionsSpanAttributes(
+      List<ResourceScopeSpan> resourceScopeSpans,
+      StatusCode otelStatusCode,
+      String dbSqlTable,
+      String dbSystem,
+      String dbOperation,
+      String dbUser,
+      String dbName,
+      String jdbcUrl) {
+    assertThat(resourceScopeSpans)
+        .satisfiesOnlyOnce(
+            rss -> {
+              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+              assertThat(rss.getSpan().getName())
+                  .isEqualTo(String.format("%s %s.%s", dbOperation, dbName, dbSqlTable));
+              assertThat(rss.getSpan().getStatus().getCode()).isEqualTo(otelStatusCode);
+              var attributesList = rss.getSpan().getAttributesList();
+              assertSemanticConventionsAttributes(
+                  attributesList, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
+            });
+  }
+
+  protected void assertSemanticConventionsAttributes(
+      List<KeyValue> attributesList,
+      String dbSqlTable,
+      String dbSystem,
+      String dbOperation,
+      String dbUser,
+      String dbName,
+      String jdbcUrl) {
+    assertThat(attributesList)
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_ID);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_NAME);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey())
+                  .isEqualTo(SemanticConventionsConstants.DB_CONNECTION_STRING);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(jdbcUrl);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_NAME);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbName);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SQL_TABLE);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSqlTable);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_STATEMENT);
+              assertThat(attribute.getValue().getStringValue())
+                  .isEqualTo(
+                      String.format("%s count(*) from %s", dbOperation.toLowerCase(), dbSqlTable));
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_USER);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbUser);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_OPERATION);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbOperation);
+            })
+        .satisfiesOnlyOnce(
+            attribute -> {
+              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SYSTEM);
+              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSystem);
+            });
+  }
+
+  protected void assertMetricAttributes(
+      List<ResourceScopeMetric> resourceScopeMetrics,
+      String method,
+      String path,
+      String metricName,
+      Double expectedSum,
+      String dbSystem,
+      String dbOperation) {
+    assertThat(resourceScopeMetrics)
+        .anySatisfy(
+            metric -> {
+              assertThat(metric.getMetric().getName()).isEqualTo(metricName);
+              List<ExponentialHistogramDataPoint> dpList =
+                  metric.getMetric().getExponentialHistogram().getDataPointsList();
+              assertThat(dpList)
+                  .satisfiesOnlyOnce(
+                      dp -> {
+                        List<KeyValue> attributesList = dp.getAttributesList();
+                        assertThat(attributesList).isNotNull();
+                        assertThat(attributesList)
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo("CLIENT");
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(String.format("%s /%s", method, path));
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(getApplicationOtelServiceName());
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(dbSystem);
+                                })
+                            .satisfiesOnlyOnce(
+                                attribute -> {
+                                  assertThat(attribute.getKey())
+                                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
+                                  assertThat(attribute.getValue().getStringValue())
+                                      .isEqualTo(dbOperation);
+                                });
+
+                        if (expectedSum != null) {
+                          double actualSum = dp.getSum();
+                          switch (metricName) {
+                            case AppSignalsConstants.LATENCY_METRIC:
+                              assertThat(actualSum).isStrictlyBetween(0.0, expectedSum);
+                              break;
+                            default:
+                              assertThat(actualSum).isEqualTo(expectedSum);
+                          }
+                        }
+                      });
+            });
+  }
+
+  protected void assertSuccess(
+      String dbSystem, String dbOperation, String dbUser, String dbName, String jdbcUrl) {
+    var path = "success";
+    var method = "GET";
+    var otelStatusCode = StatusCode.STATUS_CODE_UNSET;
+    var dbSqlTable = "employee";
+
+    var response = appClient.get(path).aggregate().join();
+    assertThat(response.status().isSuccess()).isTrue();
+
+    var traces = mockCollectorClient.getTraces();
+    assertAwsSpanAttributes(traces, method, path, dbSystem, dbOperation);
+    assertSemanticConventionsSpanAttributes(
+        traces, otelStatusCode, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
+
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.LATENCY_METRIC,
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC));
+    assertMetricAttributes(
+        metrics, method, path, AppSignalsConstants.LATENCY_METRIC, 5000.0, dbSystem, dbOperation);
+    assertMetricAttributes(
+        metrics, method, path, AppSignalsConstants.ERROR_METRIC, 0.0, dbSystem, dbOperation);
+    assertMetricAttributes(
+        metrics, method, path, AppSignalsConstants.FAULT_METRIC, 0.0, dbSystem, dbOperation);
+  }
+
+  protected void assertFault(
+      String dbSystem, String dbOperation, String dbUser, String dbName, String jdbcUrl) {
+    var path = "fault";
+    var method = "GET";
+    var otelStatusCode = StatusCode.STATUS_CODE_ERROR;
+    var dbSqlTable = "userrr";
+    var response = appClient.get(path).aggregate().join();
+    assertThat(response.status().isServerError()).isTrue();
+
+    var traces = mockCollectorClient.getTraces();
+    assertAwsSpanAttributes(traces, method, path, dbSystem, dbOperation);
+    assertSemanticConventionsSpanAttributes(
+        traces, otelStatusCode, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
+
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.LATENCY_METRIC,
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC));
+    assertMetricAttributes(
+        metrics, method, path, AppSignalsConstants.LATENCY_METRIC, 5000.0, dbSystem, dbOperation);
+    assertMetricAttributes(
+        metrics, method, path, AppSignalsConstants.ERROR_METRIC, 0.0, dbSystem, dbOperation);
+    assertMetricAttributes(
+        metrics, method, path, AppSignalsConstants.FAULT_METRIC, 1.0, dbSystem, dbOperation);
+  }
+}

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
@@ -15,280 +15,38 @@
 
 package software.amazon.opentelemetry.appsignals.test.jdbc;
 
-import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import software.amazon.opentelemetry.appsignals.test.base.ContractTestBase;
-import software.amazon.opentelemetry.appsignals.test.utils.AppSignalsConstants;
-import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeMetric;
-import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
-import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
 
 @Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class JdbcH2Test extends ContractTestBase {
+public class JdbcH2Test extends JdbcContractTestBase {
 
   private static final String DB_SYSTEM = "h2";
-  private static final String DB_NAME = "testdb";
-  private static final String DB_USER = "sa";
-  private static final String DB_PASSWORD = "password";
-  private static final String DB_OPERATION = "SELECT";
+  private static final String DB_CONNECTION_STRING = String.format("%s:mem:", DB_SYSTEM);
+  private static final String DB_URL = String.format("jdbc:%s%s", DB_CONNECTION_STRING, DB_NAME);
+  private static final String DB_DRIVER = "org.h2.Driver";
+  private static final String DB_PLATFORM = "org.hibernate.dialect.H2Dialect";
 
   @Test
   public void testSuccess() {
-    var path = "success";
-    var method = "GET";
-    var otelStatusCode = "STATUS_CODE_UNSET";
-    var dbSqlTable = "employee";
-    var response = appClient.get(path).aggregate().join();
-    assertThat(response.status().isSuccess()).isTrue();
-
-    var traces = mockCollectorClient.getTraces();
-    assertAwsSpanAttributes(traces, method, path);
-    assertSemanticConventionsSpanAttributes(traces, otelStatusCode, dbSqlTable);
-
-    var metrics =
-        mockCollectorClient.getMetrics(
-            Set.of(
-                AppSignalsConstants.LATENCY_METRIC,
-                AppSignalsConstants.ERROR_METRIC,
-                AppSignalsConstants.FAULT_METRIC));
-    assertMetricAttributes(metrics, method, path, AppSignalsConstants.LATENCY_METRIC, 5000.0);
-    assertMetricAttributes(metrics, method, path, AppSignalsConstants.ERROR_METRIC, 0.0);
-    assertMetricAttributes(metrics, method, path, AppSignalsConstants.FAULT_METRIC, 0.0);
+    assertSuccess(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
   }
 
   @Test
   public void testFault() {
-    var path = "fault";
-    var method = "GET";
-    var otelStatusCode = "STATUS_CODE_ERROR";
-    var dbSqlTable = "userrr";
-    var response = appClient.get(path).aggregate().join();
-    assertThat(response.status().isServerError()).isTrue();
-
-    var traces = mockCollectorClient.getTraces();
-    assertAwsSpanAttributes(traces, method, path);
-    assertSemanticConventionsSpanAttributes(traces, otelStatusCode, dbSqlTable);
-
-    var metrics =
-        mockCollectorClient.getMetrics(
-            Set.of(
-                AppSignalsConstants.LATENCY_METRIC,
-                AppSignalsConstants.ERROR_METRIC,
-                AppSignalsConstants.FAULT_METRIC));
-    assertMetricAttributes(metrics, method, path, AppSignalsConstants.LATENCY_METRIC, 5000.0);
-    assertMetricAttributes(metrics, method, path, AppSignalsConstants.ERROR_METRIC, 0.0);
-    assertMetricAttributes(metrics, method, path, AppSignalsConstants.FAULT_METRIC, 1.0);
-  }
-
-  @Override
-  protected String getApplicationImageName() {
-    return "aws-appsignals-tests-jdbc-app";
-  }
-
-  @Override
-  protected String getApplicationWaitPattern() {
-    return ".*Application Ready.*";
+    assertFault(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
   }
 
   @Override
   protected Map<String, String> getApplicationExtraEnvironmentVariables() {
     return Map.of(
-        "DB_URL",
-        String.format("jdbc:h2:mem:%s", DB_NAME),
-        "DB_DRIVER",
-        "org.h2.Driver",
-        "DB_USERNAME",
-        DB_USER,
-        "DB_PASSWORD",
-        DB_PASSWORD,
-        "DB_PLATFORM",
-        "org.hibernate.dialect.H2Dialect");
-  }
-
-  protected void assertAwsSpanAttributes(
-      List<ResourceScopeSpan> resourceScopeSpans, String method, String path) {
-    assertThat(resourceScopeSpans)
-        .satisfiesOnlyOnce(
-            rss -> {
-              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
-              var attributesList = rss.getSpan().getAttributesList();
-              assertAwsAttributes(attributesList, method, path);
-            });
-  }
-
-  protected void assertAwsAttributes(
-      List<KeyValue> attributesList, String method, String endpoint) {
-    assertThat(attributesList)
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
-              assertThat(attribute.getValue().getStringValue())
-                  .isEqualTo(String.format("%s /%s", method, endpoint));
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
-              assertThat(attribute.getValue().getStringValue())
-                  .isEqualTo(getApplicationOtelServiceName());
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_SYSTEM);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_OPERATION);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo("CLIENT");
-            });
-  }
-
-  protected void assertSemanticConventionsSpanAttributes(
-      List<ResourceScopeSpan> resourceScopeSpans, String otelStatusCode, String dbSqlTable) {
-    assertThat(resourceScopeSpans)
-        .satisfiesOnlyOnce(
-            rss -> {
-              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
-              assertThat(rss.getSpan().getName())
-                  .isEqualTo(String.format("%s %s.%s", DB_OPERATION, DB_NAME, dbSqlTable));
-              assertThat(rss.getSpan().getStatus().getCode().equals(otelStatusCode));
-              var attributesList = rss.getSpan().getAttributesList();
-              assertSemanticConventionsAttributes(attributesList, dbSqlTable);
-            });
-  }
-
-  protected void assertSemanticConventionsAttributes(
-      List<KeyValue> attributesList, String dbSqlTable) {
-    assertThat(attributesList)
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_ID);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_NAME);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey())
-                  .isEqualTo(SemanticConventionsConstants.DB_CONNECTION_STRING);
-              assertThat(attribute.getValue().getStringValue())
-                  .isEqualTo(String.format("%s:mem:", DB_SYSTEM));
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_NAME);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_NAME);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SQL_TABLE);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSqlTable);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_STATEMENT);
-              assertThat(attribute.getValue().getStringValue())
-                  .isEqualTo(
-                      String.format("%s count(*) from %s", DB_OPERATION.toLowerCase(), dbSqlTable));
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_USER);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_USER);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_OPERATION);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_OPERATION);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SYSTEM);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(DB_SYSTEM);
-            });
-  }
-
-  protected void assertMetricAttributes(
-      List<ResourceScopeMetric> resourceScopeMetrics,
-      String method,
-      String path,
-      String metricName,
-      Double expectedSum) {
-    assertThat(resourceScopeMetrics)
-        .anySatisfy(
-            metric -> {
-              assertThat(metric.getMetric().getName()).isEqualTo(metricName);
-              List<ExponentialHistogramDataPoint> dpList =
-                  metric.getMetric().getExponentialHistogram().getDataPointsList();
-              assertThat(dpList)
-                  .satisfiesOnlyOnce(
-                      dp -> {
-                        List<KeyValue> attributesList = dp.getAttributesList();
-                        assertThat(attributesList).isNotNull();
-                        assertThat(attributesList)
-                            .satisfiesOnlyOnce(
-                                attribute -> {
-                                  assertThat(attribute.getKey())
-                                      .isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
-                                  assertThat(attribute.getValue().getStringValue())
-                                      .isEqualTo("CLIENT");
-                                })
-                            .satisfiesOnlyOnce(
-                                attribute -> {
-                                  assertThat(attribute.getKey())
-                                      .isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
-                                  assertThat(attribute.getValue().getStringValue())
-                                      .isEqualTo(String.format("%s /%s", method, path));
-                                })
-                            .satisfiesOnlyOnce(
-                                attribute -> {
-                                  assertThat(attribute.getKey())
-                                      .isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
-                                  assertThat(attribute.getValue().getStringValue())
-                                      .isEqualTo(getApplicationOtelServiceName());
-                                })
-                            .satisfiesOnlyOnce(
-                                attribute -> {
-                                  assertThat(attribute.getKey())
-                                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
-                                  assertThat(attribute.getValue().getStringValue())
-                                      .isEqualTo(DB_SYSTEM);
-                                })
-                            .satisfiesOnlyOnce(
-                                attribute -> {
-                                  assertThat(attribute.getKey())
-                                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
-                                  assertThat(attribute.getValue().getStringValue())
-                                      .isEqualTo(DB_OPERATION);
-                                });
-
-                        if (expectedSum != null) {
-                          double actualSum = dp.getSum();
-                          switch (metricName) {
-                            case AppSignalsConstants.LATENCY_METRIC:
-                              assertThat(actualSum).isStrictlyBetween(0.0, expectedSum);
-                              break;
-                            default:
-                              assertThat(actualSum).isEqualTo(expectedSum);
-                          }
-                        }
-                      });
-            });
+        "DB_URL", DB_URL,
+        "DB_DRIVER", DB_DRIVER,
+        "DB_USERNAME", DB_USER,
+        "DB_PASSWORD", DB_PASSWORD,
+        "DB_PLATFORM", DB_PLATFORM);
   }
 }

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
@@ -20,30 +20,30 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startable;
 
 @Testcontainers(disabledWithoutDocker = true)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class JdbcPostgresTest extends JdbcContractTestBase {
+@TestInstance(Lifecycle.PER_CLASS)
+public class JdbcMySQLTest extends JdbcContractTestBase {
 
-  private static final String NETWORK_ALIAS = "postgres";
-  private static final String DB_SYSTEM = "postgresql";
+  private static final String NETWORK_ALIAS = "mysql";
+  private static final String DB_SYSTEM = "mysql";
   private static final String DB_CONNECTION_STRING =
-      String.format("%s://%s:%s", DB_SYSTEM, NETWORK_ALIAS, PostgreSQLContainer.POSTGRESQL_PORT);
+      String.format("%s://%s:%s", DB_SYSTEM, NETWORK_ALIAS, MySQLContainer.MYSQL_PORT);
   private static final String DB_URL = String.format("jdbc:%s/%s", DB_CONNECTION_STRING, DB_NAME);
-  private static final String DB_DRIVER = "org.postgresql.Driver";
-  private static final String DB_PLATFORM = "org.hibernate.dialect.PostgreSQLDialect";
+  private static final String DB_DRIVER = "com.mysql.cj.jdbc.Driver";
+  private static final String DB_PLATFORM = "org.hibernate.dialect.MySQL8Dialect";
 
-  private PostgreSQLContainer<?> postgreSqlContainer;
+  private MySQLContainer<?> mySQLContainer;
 
   @AfterEach
   public void afterEach() {
-    // dependent containers are not stopped between tests, only the application container.
-    postgreSqlContainer.stop();
+    mySQLContainer.stop();
   }
 
   @Test
@@ -68,8 +68,8 @@ public class JdbcPostgresTest extends JdbcContractTestBase {
 
   @Override
   protected List<Startable> getApplicationDependsOnContainers() {
-    this.postgreSqlContainer =
-        new PostgreSQLContainer<>("postgres:16.3")
+    mySQLContainer =
+        new MySQLContainer<>("mysql:8.4")
             .withImagePullPolicy(PullPolicy.alwaysPull())
             .withUsername(DB_USER)
             .withPassword(DB_PASSWORD)
@@ -78,6 +78,6 @@ public class JdbcPostgresTest extends JdbcContractTestBase {
             .withNetwork(network)
             .waitingFor(
                 Wait.forLogMessage(".*database system is ready to accept connections.*", 1));
-    return List.of(postgreSqlContainer);
+    return List.of(mySQLContainer);
   }
 }

--- a/appsignals-tests/images/jdbc/build.gradle.kts
+++ b/appsignals-tests/images/jdbc/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   implementation("com.h2database:h2:2.2.224")
   implementation("org.slf4j:slf4j-simple")
   implementation("org.postgresql:postgresql:42.2.0")
+  implementation("com.mysql:mysql-connector-j:8.4.0")
 }
 
 // not publishing images to hubs in this configuration - local build only through jibDockerBuild

--- a/appsignals-tests/images/jdbc/src/main/java/software/amazon/opentelemetry/AppController.java
+++ b/appsignals-tests/images/jdbc/src/main/java/software/amazon/opentelemetry/AppController.java
@@ -41,7 +41,7 @@ public class AppController {
 
   @EventListener(ApplicationReadyEvent.class)
   public void prepareDB() {
-    jdbcTemplate.execute("create table employee (id int, name varchar)");
+    jdbcTemplate.execute("create table employee (id int, name varchar(255))");
     jdbcTemplate.execute("insert into employee (id, name) values (1, 'A')");
     logger.info("Application Ready");
   }


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Adding MySQL contract tests for Application Signals to ensure customer experience won't break by any change.

As agreed in PR https://github.com/aws-observability/aws-otel-java-instrumentation/pull/806, we are refactoring JDBC related contracts to move them into a common base class. So adding a new JDBC related test like MySQL one is easy now.

This change also updated the create table sql statement as the existed one is invalid for MySQL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

### Spotless
```
➜  aws-otel-java-instrumentation git:(main) ./gradlew spotlessCheck

> Configure project :awsagentprovider
Inferred project: aws-otel-java-instrumentation, version: 1.33.0-SNAPSHOT

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1s
148 actionable tasks: 2 executed, 146 up-to-date
```

### Contract Tests
```
➜  aws-otel-java-instrumentation git:(main) ./gradlew :appsignals-tests:contract-tests:contractTests

> Configure project :awsagentprovider
Inferred project: aws-otel-java-instrumentation, version: 1.33.0-SNAPSHOT

> Task :appsignals-tests:images:http-clients:native-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-native-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[============================  ] 92.8% complete
> loading to Docker daemon


> Task :appsignals-tests:images:http-clients:netty-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-netty-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.NettyClient]

Built image to Docker daemon as aws-appsignals-tests-netty-http-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:jdbc:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-jdbc-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.Application]

Built image to Docker daemon as aws-appsignals-tests-jdbc-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:apache-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-apache-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[==============================] 98.9% complete
> loading to Docker daemon


> Task :appsignals-tests:images:grpc:grpc-client:jibDockerBuild

Containerizing application to Docker daemon as grpc-client...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, software.amazon.opentelemetry.Main]

Built image to Docker daemon as grpc-client
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:mock-collector:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-mock-collector...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.test.images.mockcollector.Main]

Built image to Docker daemon as aws-appsignals-mock-collector
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:aws-sdk:aws-sdk-v2:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-aws-sdk-v2...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[============================= ] 96.9% complete

Built image to Docker daemon as aws-appsignals-tests-apache-http-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:aws-sdk:aws-sdk-v1:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-aws-sdk-v1...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-aws-sdk-v1
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:grpc:grpc-server:jibDockerBuild

Containerizing application to Docker daemon as grpc-server...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, software.amazon.opentelemetry.EchoerServer]
Executing tasks:
[==============================] 98.3% complete

Built image to Docker daemon as aws-appsignals-tests-aws-sdk-v2
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:spring-mvc-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-spring-mvc-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.Application]
Executing tasks:
[==============================] 98.9% complete

Built image to Docker daemon as aws-appsignals-tests-native-http-client-app
Executing tasks:

Built image to Docker daemon as grpc-server
Executing tasks:

Built image to Docker daemon as aws-appsignals-tests-spring-mvc-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-servers:netty-server:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-netty-server...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.NettyServer]

Built image to Docker daemon as aws-appsignals-tests-http-server-netty-server
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-servers:spring-mvc:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-spring-mvc...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.tests.images.httpservers.springmvc.Application]
Executing tasks:
[==============================] 99.3% complete
> loading to Docker daemon


> Task :appsignals-tests:images:http-servers:tomcat:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-tomcat...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.tests.images.httpservers.tomcat.Main]

Built image to Docker daemon as aws-appsignals-tests-http-server-tomcat
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:kafka:kafka-consumers:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-kafka-kafka-consumers...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, App]
Executing tasks:
[============================= ] 97.4% complete

Built image to Docker daemon as aws-appsignals-tests-http-server-spring-mvc
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:kafka:kafka-producers:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-kafka-kafka-producers...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using credentials from Docker config (/Users/mingjs/.docker/config.json) for public.ecr.aws/docker/library/amazoncorretto:17-alpine
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[============================  ] 93.6% complete

Built image to Docker daemon as aws-appsignals-tests-kafka-kafka-consumers
Executing tasks:

Built image to Docker daemon as aws-appsignals-tests-kafka-kafka-producers
Executing tasks:
[==============================] 100.0% complete


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 17m 44s
56 actionable tasks: 16 executed, 40 up-to-date
```