### PR TITLE
Contract test the new DB resource type and identifier attributes

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
@@ -32,12 +32,12 @@ public class JdbcH2Test extends JdbcContractTestBase {
 
   @Test
   public void testSuccess() {
-    assertSuccess(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
+    assertSuccess(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING, null, null);
   }
 
   @Test
   public void testFault() {
-    assertFault(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
+    assertFault(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING, null, null);
   }
 
   @Override

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
@@ -38,6 +38,8 @@ public class JdbcMySQLTest extends JdbcContractTestBase {
   private static final String DB_URL = String.format("jdbc:%s/%s", DB_CONNECTION_STRING, DB_NAME);
   private static final String DB_DRIVER = "com.mysql.cj.jdbc.Driver";
   private static final String DB_PLATFORM = "org.hibernate.dialect.MySQL8Dialect";
+  private static final String MYSQL_IDENTIFIER =
+      String.format("%s|%s|%s", DB_NAME, NETWORK_ALIAS, MySQLContainer.MYSQL_PORT);
 
   private MySQLContainer<?> mySQLContainer;
 
@@ -48,12 +50,26 @@ public class JdbcMySQLTest extends JdbcContractTestBase {
 
   @Test
   public void testSuccess() {
-    assertSuccess(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
+    assertSuccess(
+        DB_SYSTEM,
+        DB_OPERATION,
+        DB_USER,
+        DB_NAME,
+        DB_CONNECTION_STRING,
+        DB_RESOURCE_TYPE,
+        MYSQL_IDENTIFIER);
   }
 
   @Test
   public void testFault() {
-    assertFault(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
+    assertFault(
+        DB_SYSTEM,
+        DB_OPERATION,
+        DB_USER,
+        DB_NAME,
+        DB_CONNECTION_STRING,
+        DB_RESOURCE_TYPE,
+        MYSQL_IDENTIFIER);
   }
 
   @Override

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcPostgresTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcPostgresTest.java
@@ -37,6 +37,8 @@ public class JdbcPostgresTest extends JdbcContractTestBase {
   private static final String DB_URL = String.format("jdbc:%s/%s", DB_CONNECTION_STRING, DB_NAME);
   private static final String DB_DRIVER = "org.postgresql.Driver";
   private static final String DB_PLATFORM = "org.hibernate.dialect.PostgreSQLDialect";
+  private static final String POSTGRES_IDENTIFIER =
+      String.format("%s|%s|%s", DB_NAME, NETWORK_ALIAS, PostgreSQLContainer.POSTGRESQL_PORT);
 
   private PostgreSQLContainer<?> postgreSqlContainer;
 
@@ -48,12 +50,26 @@ public class JdbcPostgresTest extends JdbcContractTestBase {
 
   @Test
   public void testSuccess() {
-    assertSuccess(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
+    assertSuccess(
+        DB_SYSTEM,
+        DB_OPERATION,
+        DB_USER,
+        DB_NAME,
+        DB_CONNECTION_STRING,
+        DB_RESOURCE_TYPE,
+        POSTGRES_IDENTIFIER);
   }
 
   @Test
   public void testFault() {
-    assertFault(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING);
+    assertFault(
+        DB_SYSTEM,
+        DB_OPERATION,
+        DB_USER,
+        DB_NAME,
+        DB_CONNECTION_STRING,
+        DB_RESOURCE_TYPE,
+        POSTGRES_IDENTIFIER);
   }
 
   @Override


### PR DESCRIPTION
*Issue #, if available:*
Update the contract test to cover the new DB resource attributes `AWS_REMOTE_RESOURCE_TYPE` and `AWS_REMOTE_RESOURCE_IDENTIFIER` for JDBC calls

*Description of changes:*
 * For Mem DB, the new DB resource attributes are not expected to be generated
 * For MySql and Postgresql, the expected format of 
   * AWS_REMOTE_RESOURCE_TYPE = "DB:Connectoin"
   * AWS_REMOTE_RESOURCE_IDENTIFIER = "db_name|db_server|db_port"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
