### PR TITLE
limit histogram buckets to 100 as per EMF

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -72,14 +72,12 @@ public class AwsApplicationSignalsCustomizerProvider
       "otel.aws.application.signals.exporter.endpoint";
 
   // Histograms must only be exported with no more than 100 buckets per EMF specifications. Per OTEL
-  // documentation,
+  // specification, max total buckets = max_size*2+1; *2 is because of positive and negative
+  // buckets, +1 because of the zero bucket. Negatives are not a concern for Application Signals
+  // use-case, which only measures latency, so max_size of 99 gives total buckets of 100. MaxScale
+  // is being set as the default value as per the OTEL spec.
+  // OTEL Specification:
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation
-  // max total buckets = max_size*2+1; *2 is because of positive and negative buckets, +1 because of
-  // the zero
-  // bucket. Negatives are not a concern for Application Signals use-case, which only measures
-  // latency, so max_size
-  // of 99 gives total buckets of 100.
-  // MaxScale is being set as the default value as per the OTEL spec.
   private static final int MAX_HISTOGRAM_BUCKETS = 99;
   private static final int MAX_HISTOGRAM_SCALE = 20;
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -156,7 +156,7 @@ public class AwsApplicationSignalsCustomizerProvider
     return spanExporter;
   }
 
-  protected enum ApplicationSignalsExporterProvider {
+  private enum ApplicationSignalsExporterProvider {
     INSTANCE;
 
     public MetricExporter createExporter(ConfigProperties configProps) {


### PR DESCRIPTION
### Issue
Per [AWS EMF specifications](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_target), metric histograms (numeric arrays) may contain no more than 100 values. Exceeding this results in invalid metric records. For the short term, we have decided that we will simply limit the number of histogram buckets to 100, to avoid this issue.

### Testing
Did an end-to-end testing by setting up a simple application that will produce spans (and thus metrics) with varying latencies between 0-1000 ms. Instrumented the application with ADOT Java agent first without this change and then with the change. Generated traffic of 600 req/min and observed EMF log records in the CW logs.

#### Case 1: Without any change
- Observed 83 buckets. 

```json
{
    "HostedIn.Environment": "ec2",
    "OTelLib": "AwsSpanMetricsProcessor",
    "Operation": "GET /latency",
    "Service": "latencyTest_defaultBucket_600R",
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "AppSignals",
                "Dimensions": [
                    [
                        "HostedIn.Environment",
                        "Operation",
                        "Service"
                    ],
                    [
                        "HostedIn.Environment",
                        "Service"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "Latency",
                        "Unit": "Milliseconds"
                    },
                    {
                        "Name": "Error"
                    },
                    {
                        "Name": "Fault"
                    }
                ]
            }
        ],
        "Timestamp": 1718037122611
    },
    "aws.span.kind": "LOCAL_ROOT",
    "Error": {
        "Values": [
            0
        ],
        "Counts": [
            456
        ],
        "Max": 0,
        "Min": 0,
        "Count": 456,
        "Sum": 0
    },
    "Fault": {
        "Values": [
            0
        ],
        "Counts": [
            456
        ],
        "Max": 0,
        "Min": 0,
        "Count": 456,
        "Sum": 0
    },
    "Latency": {
        "Values": [
            2.8910397083125865,
            3.438044990880718,
            5.302190203175782,
            8.53912606037064,
            9.311982999037598,
            10.154789466897915,
            14.361040987130473,
            18.623965998075164,
            23.12831766650057,
            24.152295770779325,
            25.221609258857356,
            26.338265299653248,
            28.72208197426089,
            31.321652491176906,
            32.70838051883833,
            40.61915786759152,
            48.304591541558565,
            50.44321851771462,
            55.0087198540911,
            59.987434364903216,
            65.41676103767654,
            74.4958639923004,
            77.79407766643769,
            84.83504325081192,
            88.5910114979186,
            92.51327066600194,
            100.88643703542905,
            110.017439708182,
            114.88832789704315,
            119.97486872980622,
            125.28660996470717,
            130.83352207535285,
            136.62601696592927,
            142.67496751500295,
            148.99172798460052,
            155.5881553328751,
            162.47663147036548,
            169.67008650162353,
            177.18202299583686,
            185.02654133200355,
            201.77287407085777,
            210.70612239722487,
            220.0348794163636,
            229.7766557940859,
            239.949737459612,
            250.57321992941388,
            261.66704415070524,
            273.252033931858,
            285.3499350300054,
            297.98345596920046,
            311.1763106657497,
            324.9532629407304,
            339.3401730032465,
            354.3640459916731,
            370.0530826640064,
            386.4367323324664,
            403.5457481417148,
            421.41224479444895,
            440.0697588327264,
            459.553311588171,
            479.89947491922317,
            501.14643985882685,
            523.3340883014096,
            546.5040678637151,
            570.6998700600097,
            595.9669119383999,
            622.3526213314983,
            649.9065258814596,
            678.6803460064917,
            708.7280919833449,
            740.1061653280116,
            772.8734646649315,
            807.0914962834281,
            842.8244895888965,
            880.1395176654513,
            919.1066231763405,
            959.7989498384446,
            1002.292879717652,
            1093.0081357274282,
            1191.9338238767978,
            1244.7052426629944,
            1299.813051762917,
            1357.360692012981
        ],
        "Counts": [
            1,
            2,
            1,
            1,
            1,
            1,
            1,
            1,
            1,
            1,
            2,
            1,
            1,
            2,
            1,
            1,
            1,
            1,
            1,
            3,
            2,
            1,
            1,
            2,
            1,
            1,
            1,
            4,
            4,
            4,
            4,
            1,
            4,
            2,
            5,
            5,
            4,
            4,
            4,
            3,
            3,
            3,
            4,
            1,
            6,
            7,
            6,
            5,
            6,
            6,
            6,
            5,
            8,
            6,
            9,
            2,
            6,
            10,
            7,
            8,
            8,
            18,
            13,
            12,
            12,
            15,
            14,
            13,
            13,
            15,
            16,
            12,
            20,
            17,
            13,
            14,
            17,
            11,
            1,
            1,
            1,
            1,
            1
        ],
        "Max": 1331.997124,
        "Min": 2.929554,
        "Count": 454,
        "Sum": 233980.8038119999
    }
}
```

#### Case 2: Max bucket limited to 11 (10+1). **NOTE:** Although we want to test the limit of 100, since I couldn't get buckets in that range I am testing the limit of 10 to verify that setting the limit actually works.
- Observed 10 histogram buckets

```json
{
    "HostedIn.Environment": "ec2",
    "OTelLib": "AwsSpanMetricsProcessor",
    "Operation": "GET /latency",
    "Service": "latencyTest_limitedbuckets_10_600R",
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "AppSignals",
                "Dimensions": [
                    [
                        "HostedIn.Environment",
                        "Operation",
                        "Service"
                    ],
                    [
                        "HostedIn.Environment",
                        "Service"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "Error"
                    },
                    {
                        "Name": "Fault"
                    },
                    {
                        "Name": "Latency",
                        "Unit": "Milliseconds"
                    }
                ]
            }
        ],
        "Timestamp": 1718037291793
    },
    "aws.span.kind": "LOCAL_ROOT",
    "Error": {
        "Values": [
            0
        ],
        "Counts": [
            470
        ],
        "Max": 0,
        "Min": 0,
        "Count": 470,
        "Sum": 0
    },
    "Fault": {
        "Values": [
            0
        ],
        "Counts": [
            470
        ],
        "Max": 0,
        "Min": 0,
        "Count": 470,
        "Sum": 0
    },
    "Latency": {
        "Values": [
            3,
            6,
            12,
            24,
            48,
            96,
            192,
            384,
            768,
            1536
        ],
        "Counts": [
            3,
            3,
            6,
            9,
            15,
            32,
            68,
            111,
            214,
            9
        ],
        "Max": 1433.775923,
        "Min": 2.043554,
        "Count": 470,
        "Sum": 230359.94839499998
    }
}
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
