### PR TITLE
adding contract-tests for successful 'CREATE DATABASE'

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/base/ContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/base/ContractTestBase.java
@@ -87,7 +87,7 @@ public abstract class ContractTestBase {
           .withEnv(
               "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
               "http://" + COLLECTOR_HOSTNAME + ":" + COLLECTOR_PORT)
-          .withEnv("OTEL_RESOURCE_ATTRIBUTES", getApplicationOtelResourceAttributes())
+          .withEnv("OTEL_RESOURCE_ATTRIBUTES", getApplicationOtelResourceAttributes()).withReuse(true)
           .withEnv(getApplicationExtraEnvironmentVariables())
           .withNetworkAliases(getApplicationNetworkAliases().toArray(new String[0]));
 

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
@@ -15,25 +15,19 @@
 
 package software.amazon.opentelemetry.appsignals.test.jdbc;
 
-import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThat;
 
-import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
-import java.util.List;
 import java.util.Set;
 import software.amazon.opentelemetry.appsignals.test.base.ContractTestBase;
+import software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.DBOperation;
+import software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.JdbcOperationTester;
+import software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.JdbcOperationTesterProvider;
 import software.amazon.opentelemetry.appsignals.test.utils.AppSignalsConstants;
-import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeMetric;
-import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
-import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
 
-public class JdbcContractTestBase extends ContractTestBase {
+public abstract class JdbcContractTestBase extends ContractTestBase {
   protected static final String DB_NAME = "testdb";
-  protected static final String DB_USER = "sa";
+  protected static final String DB_USER = "root";
   protected static final String DB_PASSWORD = "password";
-  protected static final String DB_OPERATION = "SELECT";
   protected static final String DB_RESOURCE_TYPE = "DB::Connection";
 
   @Override
@@ -46,264 +40,27 @@ public class JdbcContractTestBase extends ContractTestBase {
     return ".*Application Ready.*";
   }
 
-  protected void assertAwsSpanAttributes(
-      List<ResourceScopeSpan> resourceScopeSpans,
-      String method,
-      String path,
-      String dbSystem,
-      String dbOperation,
-      String type,
-      String identifier) {
-    assertThat(resourceScopeSpans)
-        .satisfiesOnlyOnce(
-            rss -> {
-              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
-              var attributesList = rss.getSpan().getAttributesList();
-              assertAwsAttributes(
-                  attributesList, method, path, dbSystem, dbOperation, type, identifier);
-            });
-  }
-
-  protected void assertAwsAttributes(
-      List<KeyValue> attributesList,
-      String method,
-      String endpoint,
-      String dbSystem,
-      String dbOperation,
-      String type,
-      String identifier) {
-    var assertions =
-        assertThat(attributesList)
-            .satisfiesOnlyOnce(
-                attribute -> {
-                  assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
-                  assertThat(attribute.getValue().getStringValue())
-                      .isEqualTo(String.format("%s /%s", method, endpoint));
-                })
-            .satisfiesOnlyOnce(
-                attribute -> {
-                  assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
-                  assertThat(attribute.getValue().getStringValue())
-                      .isEqualTo(getApplicationOtelServiceName());
-                })
-            .satisfiesOnlyOnce(
-                attribute -> {
-                  assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
-                  assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSystem);
-                })
-            .satisfiesOnlyOnce(
-                attribute -> {
-                  assertThat(attribute.getKey())
-                      .isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
-                  assertThat(attribute.getValue().getStringValue()).isEqualTo(dbOperation);
-                })
-            .satisfiesOnlyOnce(
-                attribute -> {
-                  assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
-                  assertThat(attribute.getValue().getStringValue()).isEqualTo("CLIENT");
-                });
-    if (type != null && identifier != null) {
-      assertions.satisfiesOnlyOnce(
-          (attribute) -> {
-            assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_TYPE);
-            assertThat(attribute.getValue().getStringValue()).isEqualTo(type);
-          });
-      assertions.satisfiesOnlyOnce(
-          (attribute) -> {
-            assertThat(attribute.getKey())
-                .isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER);
-            assertThat(attribute.getValue().getStringValue()).isEqualTo(identifier);
-          });
-    }
-  }
-
-  protected void assertSemanticConventionsSpanAttributes(
-      List<ResourceScopeSpan> resourceScopeSpans,
-      String otelStatusCode,
-      String dbSqlTable,
-      String dbSystem,
-      String dbOperation,
-      String dbUser,
-      String dbName,
-      String jdbcUrl) {
-    assertThat(resourceScopeSpans)
-        .satisfiesOnlyOnce(
-            rss -> {
-              assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
-              assertThat(rss.getSpan().getName())
-                  .isEqualTo(String.format("%s %s.%s", dbOperation, dbName, dbSqlTable));
-              assertThat(rss.getSpan().getStatus().getCode().toString()).isEqualTo(otelStatusCode);
-              var attributesList = rss.getSpan().getAttributesList();
-              assertSemanticConventionsAttributes(
-                  attributesList, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
-            });
-  }
-
-  protected void assertSemanticConventionsAttributes(
-      List<KeyValue> attributesList,
-      String dbSqlTable,
-      String dbSystem,
-      String dbOperation,
-      String dbUser,
-      String dbName,
-      String jdbcUrl) {
-    assertThat(attributesList)
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_ID);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_NAME);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey())
-                  .isEqualTo(SemanticConventionsConstants.DB_CONNECTION_STRING);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(jdbcUrl);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_NAME);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbName);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SQL_TABLE);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSqlTable);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_STATEMENT);
-              assertThat(attribute.getValue().getStringValue())
-                  .isEqualTo(
-                      String.format("%s count(*) from %s", dbOperation.toLowerCase(), dbSqlTable));
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_USER);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbUser);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_OPERATION);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbOperation);
-            })
-        .satisfiesOnlyOnce(
-            attribute -> {
-              assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SYSTEM);
-              assertThat(attribute.getValue().getStringValue()).isEqualTo(dbSystem);
-            });
-  }
-
-  protected void assertMetricAttributes(
-      List<ResourceScopeMetric> resourceScopeMetrics,
-      String method,
-      String path,
-      String metricName,
-      Double expectedSum,
-      String dbSystem,
-      String dbOperation,
-      String type,
-      String identifier) {
-    assertThat(resourceScopeMetrics)
-        .anySatisfy(
-            metric -> {
-              assertThat(metric.getMetric().getName()).isEqualTo(metricName);
-              List<ExponentialHistogramDataPoint> dpList =
-                  metric.getMetric().getExponentialHistogram().getDataPointsList();
-              assertThat(dpList)
-                  .satisfiesOnlyOnce(
-                      dp -> {
-                        List<KeyValue> attributesList = dp.getAttributesList();
-                        assertThat(attributesList).isNotNull();
-                        var assertions =
-                            assertThat(attributesList)
-                                .satisfiesOnlyOnce(
-                                    attribute -> {
-                                      assertThat(attribute.getKey())
-                                          .isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
-                                      assertThat(attribute.getValue().getStringValue())
-                                          .isEqualTo("CLIENT");
-                                    })
-                                .satisfiesOnlyOnce(
-                                    attribute -> {
-                                      assertThat(attribute.getKey())
-                                          .isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
-                                      assertThat(attribute.getValue().getStringValue())
-                                          .isEqualTo(String.format("%s /%s", method, path));
-                                    })
-                                .satisfiesOnlyOnce(
-                                    attribute -> {
-                                      assertThat(attribute.getKey())
-                                          .isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
-                                      assertThat(attribute.getValue().getStringValue())
-                                          .isEqualTo(getApplicationOtelServiceName());
-                                    })
-                                .satisfiesOnlyOnce(
-                                    attribute -> {
-                                      assertThat(attribute.getKey())
-                                          .isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
-                                      assertThat(attribute.getValue().getStringValue())
-                                          .isEqualTo(dbSystem);
-                                    })
-                                .satisfiesOnlyOnce(
-                                    attribute -> {
-                                      assertThat(attribute.getKey())
-                                          .isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
-                                      assertThat(attribute.getValue().getStringValue())
-                                          .isEqualTo(dbOperation);
-                                    });
-                        if (type != null && identifier != null) {
-                          assertions.satisfiesOnlyOnce(
-                              (attribute) -> {
-                                assertThat(attribute.getKey())
-                                    .isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_TYPE);
-                                assertThat(attribute.getValue().getStringValue()).isEqualTo(type);
-                              });
-                          assertions.satisfiesOnlyOnce(
-                              (attribute) -> {
-                                assertThat(attribute.getKey())
-                                    .isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER);
-                                assertThat(attribute.getValue().getStringValue())
-                                    .isEqualTo(identifier);
-                              });
-                        }
-
-                        if (expectedSum != null) {
-                          double actualSum = dp.getSum();
-                          switch (metricName) {
-                            case AppSignalsConstants.LATENCY_METRIC:
-                              assertThat(actualSum).isStrictlyBetween(0.0, expectedSum);
-                              break;
-                            default:
-                              assertThat(actualSum).isEqualTo(expectedSum);
-                          }
-                        }
-                      });
-            });
-  }
-
   protected void assertSuccess(
       String dbSystem,
-      String dbOperation,
+      DBOperation dbOperation,
       String dbUser,
       String dbName,
       String jdbcUrl,
       String type,
       String identifier) {
-    var path = "success";
+    var path = "success/" + dbOperation.name();
     var method = "GET";
     var otelStatusCode = "STATUS_CODE_UNSET";
     var dbSqlTable = "employee";
-
+    var otelApplicationImageName = getApplicationOtelServiceName();
+    JdbcOperationTester operationTester = JdbcOperationTesterProvider.getOperationTester(dbOperation, dbSystem, dbUser, jdbcUrl,
+              dbName, dbSqlTable);
     var response = appClient.get(path).aggregate().join();
     assertThat(response.status().isSuccess()).isTrue();
 
     var traces = mockCollectorClient.getTraces();
-    assertAwsSpanAttributes(traces, method, path, dbSystem, dbOperation, type, identifier);
-    assertSemanticConventionsSpanAttributes(
-        traces, otelStatusCode, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
+    operationTester.assertAwsSpanAttributes(traces, method, path, type, identifier, otelApplicationImageName);
+    operationTester.assertSemanticConventionsSpanAttributes(traces, otelStatusCode);
 
     var metrics =
         mockCollectorClient.getMetrics(
@@ -311,57 +68,56 @@ public class JdbcContractTestBase extends ContractTestBase {
                 AppSignalsConstants.LATENCY_METRIC,
                 AppSignalsConstants.ERROR_METRIC,
                 AppSignalsConstants.FAULT_METRIC));
-    assertMetricAttributes(
+      operationTester.assertMetricAttributes(
         metrics,
         method,
         path,
         AppSignalsConstants.LATENCY_METRIC,
         5000.0,
-        dbSystem,
-        dbOperation,
         type,
-        identifier);
-    assertMetricAttributes(
+        identifier,
+        otelApplicationImageName);
+      operationTester.assertMetricAttributes(
         metrics,
         method,
         path,
         AppSignalsConstants.ERROR_METRIC,
         0.0,
-        dbSystem,
-        dbOperation,
         type,
-        identifier);
-    assertMetricAttributes(
+        identifier,
+        otelApplicationImageName);
+      operationTester.assertMetricAttributes(
         metrics,
         method,
         path,
         AppSignalsConstants.FAULT_METRIC,
         0.0,
-        dbSystem,
-        dbOperation,
         type,
-        identifier);
+        identifier,
+        otelApplicationImageName);
   }
 
   protected void assertFault(
       String dbSystem,
-      String dbOperation,
+      DBOperation dbOperation,
       String dbUser,
       String dbName,
       String jdbcUrl,
       String type,
       String identifier) {
-    var path = "fault";
+    var path = "fault/" + dbOperation;
     var method = "GET";
     var otelStatusCode = "STATUS_CODE_ERROR";
     var dbSqlTable = "userrr";
+    var otelApplicationImageName = getApplicationOtelServiceName();
+    JdbcOperationTester operationTester = JdbcOperationTesterProvider.getOperationTester(dbOperation, dbSystem, dbUser, jdbcUrl,
+              dbName, dbSqlTable);
     var response = appClient.get(path).aggregate().join();
     assertThat(response.status().isServerError()).isTrue();
 
     var traces = mockCollectorClient.getTraces();
-    assertAwsSpanAttributes(traces, method, path, dbSystem, dbOperation, type, identifier);
-    assertSemanticConventionsSpanAttributes(
-        traces, otelStatusCode, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);
+    operationTester.assertAwsSpanAttributes(traces, method, path, type, identifier, otelApplicationImageName);
+    operationTester.assertSemanticConventionsSpanAttributes(traces, otelStatusCode);
 
     var metrics =
         mockCollectorClient.getMetrics(
@@ -369,35 +125,32 @@ public class JdbcContractTestBase extends ContractTestBase {
                 AppSignalsConstants.LATENCY_METRIC,
                 AppSignalsConstants.ERROR_METRIC,
                 AppSignalsConstants.FAULT_METRIC));
-    assertMetricAttributes(
+    operationTester.assertMetricAttributes(
         metrics,
         method,
         path,
         AppSignalsConstants.LATENCY_METRIC,
         5000.0,
-        dbSystem,
-        dbOperation,
         type,
-        identifier);
-    assertMetricAttributes(
+        identifier,
+        otelApplicationImageName);
+    operationTester.assertMetricAttributes(
         metrics,
         method,
         path,
         AppSignalsConstants.ERROR_METRIC,
         0.0,
-        dbSystem,
-        dbOperation,
         type,
-        identifier);
-    assertMetricAttributes(
+        identifier,
+            otelApplicationImageName);
+    operationTester.assertMetricAttributes(
         metrics,
         method,
         path,
         AppSignalsConstants.FAULT_METRIC,
         1.0,
-        dbSystem,
-        dbOperation,
         type,
-        identifier);
+        identifier,
+        otelApplicationImageName);
   }
 }

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcH2Test.java
@@ -16,9 +16,14 @@
 package software.amazon.opentelemetry.appsignals.test.jdbc;
 
 import java.util.Map;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.DBOperation;
 
 @Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -32,12 +37,12 @@ public class JdbcH2Test extends JdbcContractTestBase {
 
   @Test
   public void testSuccess() {
-    assertSuccess(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING, null, null);
+    assertSuccess(DB_SYSTEM, DBOperation.SELECT, DB_USER, DB_NAME, DB_CONNECTION_STRING, null, null);
   }
 
   @Test
   public void testFault() {
-    assertFault(DB_SYSTEM, DB_OPERATION, DB_USER, DB_NAME, DB_CONNECTION_STRING, null, null);
+    assertFault(DB_SYSTEM, DBOperation.SELECT, DB_USER, DB_NAME, DB_CONNECTION_STRING, null, null);
   }
 
   @Override

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
@@ -17,15 +17,20 @@ package software.amazon.opentelemetry.appsignals.test.jdbc;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startable;
+import software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.DBOperation;
 
 @Testcontainers(disabledWithoutDocker = true)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -48,11 +53,16 @@ public class JdbcMySQLTest extends JdbcContractTestBase {
     mySQLContainer.stop();
   }
 
-  @Test
-  public void testSuccess() {
+    private static Stream<DBOperation> dbOperations() {
+        return Stream.of(DBOperation.SELECT, DBOperation.CREATE_DATABASE);
+    }
+
+  @ParameterizedTest
+  @MethodSource("dbOperations")
+  public void testSuccess(DBOperation operation) {
     assertSuccess(
         DB_SYSTEM,
-        DB_OPERATION,
+        operation,
         DB_USER,
         DB_NAME,
         DB_CONNECTION_STRING,
@@ -64,7 +74,7 @@ public class JdbcMySQLTest extends JdbcContractTestBase {
   public void testFault() {
     assertFault(
         DB_SYSTEM,
-        DB_OPERATION,
+        DBOperation.SELECT,
         DB_USER,
         DB_NAME,
         DB_CONNECTION_STRING,

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcPostgresTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcPostgresTest.java
@@ -17,14 +17,19 @@ package software.amazon.opentelemetry.appsignals.test.jdbc;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startable;
+import software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.DBOperation;
 
 @Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -48,11 +53,16 @@ public class JdbcPostgresTest extends JdbcContractTestBase {
     postgreSqlContainer.stop();
   }
 
-  @Test
-  public void testSuccess() {
+    private static Stream<DBOperation> dbOperations() {
+        return Stream.of(DBOperation.SELECT, DBOperation.CREATE_DATABASE);
+    }
+
+  @ParameterizedTest
+  @MethodSource("dbOperations")
+  public void testSuccess(DBOperation operation) {
     assertSuccess(
         DB_SYSTEM,
-        DB_OPERATION,
+        operation,
         DB_USER,
         DB_NAME,
         DB_CONNECTION_STRING,
@@ -64,7 +74,7 @@ public class JdbcPostgresTest extends JdbcContractTestBase {
   public void testFault() {
     assertFault(
         DB_SYSTEM,
-        DB_OPERATION,
+        DBOperation.SELECT,
         DB_USER,
         DB_NAME,
         DB_CONNECTION_STRING,

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/DBOperation.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/DBOperation.java
@@ -1,0 +1,24 @@
+package software.amazon.opentelemetry.appsignals.test.jdbc.operationtests;
+
+public enum DBOperation {
+    CREATE_DATABASE("CREATE DATABASE", "testdb2"),
+    SELECT("SELECT", "testdb")
+    ;
+
+    DBOperation(String value, String targetDB) {
+        this.value = value;
+        this.targetDB = targetDB;
+    }
+
+    private final String value;
+    private final String targetDB;
+
+    public String getTargetDB() {
+        return targetDB;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcCreateDatabaseOperationTester.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcCreateDatabaseOperationTester.java
@@ -1,0 +1,27 @@
+package software.amazon.opentelemetry.appsignals.test.jdbc.operationtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
+import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
+
+import static software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.DBOperation.CREATE_DATABASE;
+
+public class JdbcCreateDatabaseOperationTester extends JdbcOperationTester {
+
+    public JdbcCreateDatabaseOperationTester(String dbSystem, String dbUser, String jdbcUrl, String dbName, String dbTable) {
+        super(dbSystem, dbUser, jdbcUrl, dbName, CREATE_DATABASE.toString(), dbTable);
+    }
+
+    @Override
+    protected void assertOperationSemanticConventions(ResourceScopeSpan resourceScopeSpan) {
+        assertThat(resourceScopeSpan.getSpan().getName()).isEqualTo(String.format("%s", this.dbName));
+
+        var attributesList = resourceScopeSpan.getSpan().getAttributesList();
+        assertThat(attributesList).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_STATEMENT);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(
+                    String.format("%s %s", CREATE_DATABASE.toString().toLowerCase(), CREATE_DATABASE.getTargetDB()));
+        });
+    }
+}

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcOperationTester.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcOperationTester.java
@@ -1,0 +1,157 @@
+package software.amazon.opentelemetry.appsignals.test.jdbc.operationtests;
+
+import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
+import software.amazon.opentelemetry.appsignals.test.utils.AppSignalsConstants;
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeMetric;
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
+import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
+
+public abstract class JdbcOperationTester {
+
+    protected final String dbSystem;
+    protected final String dbUser;
+    protected final String jdbcUrl;
+    protected final String dbName;
+    protected final String dbOperation;
+    protected final String dbTable;
+
+    protected JdbcOperationTester(String dbSystem, String dbUser, String jdbcUrl, String dbName, String dbOperation, String dbTable) {
+        this.dbSystem = dbSystem;
+        this.dbUser = dbUser;
+        this.jdbcUrl = jdbcUrl;
+        this.dbName = dbName;
+        this.dbOperation = dbOperation;
+        this.dbTable = dbTable;
+    }
+
+    public void assertAwsSpanAttributes(List<ResourceScopeSpan> resourceScopeSpans, String method, String path, String type,
+            String identifier, String applicationOtelServiceName) {
+        assertThat(resourceScopeSpans).satisfiesOnlyOnce(rss -> {
+            assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+            var attributesList = rss.getSpan().getAttributesList();
+            assertAwsAttributes(attributesList, method, path, type, identifier, applicationOtelServiceName);
+        });
+    }
+
+    private void assertAwsAttributes(List<KeyValue> attributesList, String method, String endpoint, String type,
+            String identifier, String applicationOtelServiceName) {
+        var assertions = assertThat(attributesList).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(String.format("%s /%s", method, endpoint));
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(applicationOtelServiceName);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbSystem);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbOperation);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo("CLIENT");
+        });
+        if (type != null && identifier != null) {
+            assertions.satisfiesOnlyOnce((attribute) -> {
+                assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_TYPE);
+                assertThat(attribute.getValue().getStringValue()).isEqualTo(type);
+            });
+            assertions.satisfiesOnlyOnce((attribute) -> {
+                assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER);
+                assertThat(attribute.getValue().getStringValue()).isEqualTo(identifier);
+            });
+        }
+    }
+
+    public void assertSemanticConventionsSpanAttributes(List<ResourceScopeSpan> resourceScopeSpans, String otelStatusCode) {
+        assertThat(resourceScopeSpans).satisfiesOnlyOnce(rss -> {
+            assertOperationSemanticConventions(rss);
+            assertSemanticConventionsCommon(rss, otelStatusCode);
+        });
+    }
+
+    protected abstract void assertOperationSemanticConventions(ResourceScopeSpan resourceScopeSpan);
+
+    private void assertSemanticConventionsCommon (ResourceScopeSpan rss, String otelStatusCode) {
+        assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+        assertThat(rss.getSpan().getStatus().getCode().toString()).isEqualTo(otelStatusCode);
+        var attributesList = rss.getSpan().getAttributesList();
+        assertSemanticConventionsAttributes(attributesList);
+    }
+
+    protected void assertSemanticConventionsAttributes(List<KeyValue> attributesList) {
+        assertThat(attributesList).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_ID);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.THREAD_NAME);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_CONNECTION_STRING);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.jdbcUrl);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_NAME);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbName);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_USER);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbUser);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SYSTEM);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbSystem);
+        });
+    }
+
+    public void assertMetricAttributes(List<ResourceScopeMetric> resourceScopeMetrics, String method, String path,
+            String metricName, Double expectedSum, String type, String identifier, String applicationOtelServiceName) {
+        assertThat(resourceScopeMetrics).anySatisfy(metric -> {
+            assertThat(metric.getMetric().getName()).isEqualTo(metricName);
+            List<ExponentialHistogramDataPoint> dpList = metric.getMetric().getExponentialHistogram().getDataPointsList();
+            assertThat(dpList).satisfiesOnlyOnce(dp -> {
+                List<KeyValue> attributesList = dp.getAttributesList();
+                assertThat(attributesList).isNotNull();
+                var assertions = assertThat(attributesList).satisfiesOnlyOnce(attribute -> {
+                    assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_SPAN_KIND);
+                    assertThat(attribute.getValue().getStringValue()).isEqualTo("CLIENT");
+                }).satisfiesOnlyOnce(attribute -> {
+                    assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_OPERATION);
+                    assertThat(attribute.getValue().getStringValue()).isEqualTo(String.format("%s /%s", method, path));
+                }).satisfiesOnlyOnce(attribute -> {
+                    assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_LOCAL_SERVICE);
+                    assertThat(attribute.getValue().getStringValue()).isEqualTo(applicationOtelServiceName);
+                }).satisfiesOnlyOnce(attribute -> {
+                    assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_SERVICE);
+                    assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbSystem);
+                }).satisfiesOnlyOnce(attribute -> {
+                    assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_OPERATION);
+                    assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbOperation);
+                });
+                if (type != null && identifier != null) {
+                    assertions.satisfiesOnlyOnce((attribute) -> {
+                        assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_TYPE);
+                        assertThat(attribute.getValue().getStringValue()).isEqualTo(type);
+                    });
+                    assertions.satisfiesOnlyOnce((attribute) -> {
+                        assertThat(attribute.getKey()).isEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER);
+                        assertThat(attribute.getValue().getStringValue()).isEqualTo(identifier);
+                    });
+                }
+
+                if (expectedSum != null) {
+                    double actualSum = dp.getSum();
+                    switch (metricName) {
+                    case AppSignalsConstants.LATENCY_METRIC:
+                        assertThat(actualSum).isStrictlyBetween(0.0, expectedSum);
+                        break;
+                    default:
+                        assertThat(actualSum).isEqualTo(expectedSum);
+                    }
+                }
+            });
+        });
+    }
+
+}

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcOperationTesterProvider.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcOperationTesterProvider.java
@@ -1,0 +1,19 @@
+package software.amazon.opentelemetry.appsignals.test.jdbc.operationtests;
+
+public class JdbcOperationTesterProvider {
+
+    private JdbcOperationTesterProvider() {
+
+    }
+
+    public static JdbcOperationTester getOperationTester(DBOperation operation, String dbSystem, String dbUser, String jdbcUrl, String dbName, String dbTable) {
+        switch (operation) {
+        case CREATE_DATABASE:
+            return  new JdbcCreateDatabaseOperationTester(dbSystem, dbUser, jdbcUrl, dbName, dbTable);
+        case SELECT:
+            return new JdbcSelectOperationTester(dbSystem, dbUser, jdbcUrl, dbName, dbTable);
+        default:
+            throw new UnsupportedOperationException("No tests for operation: " + operation);
+        }
+    }
+}

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcSelectOperationTester.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/operationtests/JdbcSelectOperationTester.java
@@ -1,0 +1,34 @@
+package software.amazon.opentelemetry.appsignals.test.jdbc.operationtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeSpan;
+import software.amazon.opentelemetry.appsignals.test.utils.SemanticConventionsConstants;
+
+import static software.amazon.opentelemetry.appsignals.test.jdbc.operationtests.DBOperation.SELECT;
+
+public class JdbcSelectOperationTester extends JdbcOperationTester {
+
+    public JdbcSelectOperationTester(String dbSystem, String dbUser, String jdbcUrl, String dbName, String dbTable) {
+        super(dbSystem, dbUser, jdbcUrl, dbName, SELECT.toString(), dbTable);
+    }
+
+    @Override
+    protected void assertOperationSemanticConventions(ResourceScopeSpan resourceScopeSpan) {
+        assertThat(resourceScopeSpan.getSpan().getName()).isEqualTo(
+                String.format("%s %s.%s", SELECT, this.dbName, this.dbTable));
+
+        var attributesList = resourceScopeSpan.getSpan().getAttributesList();
+        assertThat(attributesList).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_STATEMENT);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(
+                    String.format("%s count(*) from %s", SELECT.toString().toLowerCase(), this.dbTable));
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_SQL_TABLE);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(this.dbTable);
+        }).satisfiesOnlyOnce(attribute -> {
+            assertThat(attribute.getKey()).isEqualTo(SemanticConventionsConstants.DB_OPERATION);
+            assertThat(attribute.getValue().getStringValue()).isEqualTo(SELECT.toString());
+        });
+    }
+}

--- a/appsignals-tests/images/jdbc/src/main/java/software/amazon/opentelemetry/AppController.java
+++ b/appsignals-tests/images/jdbc/src/main/java/software/amazon/opentelemetry/AppController.java
@@ -46,18 +46,30 @@ public class AppController {
     logger.info("Application Ready");
   }
 
-  @GetMapping("/success")
+
+  @GetMapping("/success/CREATE_DATABASE")
   @ResponseBody
-  public ResponseEntity<String> success() {
+  public ResponseEntity<String> successCreateDatabase() {
+    try {
+      jdbcTemplate.execute("create database testdb2");
+    } catch (Exception ex) {
+      return ResponseEntity.badRequest().body("failed");
+    }
+    return ResponseEntity.ok().body("success");
+  }
+
+  @GetMapping("/success/SELECT")
+  @ResponseBody
+  public ResponseEntity<String> successSelect() {
     int count = jdbcTemplate.queryForObject("select count(*) from employee", Integer.class);
     return (count == 1)
         ? ResponseEntity.ok().body("success")
         : ResponseEntity.badRequest().body("failed");
   }
 
-  @GetMapping("/fault")
+  @GetMapping("/fault/SELECT")
   @ResponseBody
-  public ResponseEntity<String> failure() {
+  public ResponseEntity<String> failureSelect() {
     int count = jdbcTemplate.queryForObject("select count(*) from userrr", Integer.class);
     return ResponseEntity.ok().body("success");
   }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Creating contract-tests for successful 'CREATE DATABASE' for MySQL and Postgres, ignoring H2.

**Note** had to change user from `sa` to `root` to be able to `create database` on MySQL.

I have tried to refactor code even more to make it easier to expand if needed later in the future, now we have per operation tests 

Additionally now it's easier to add something like the decorator pattern if there are additional tests that needed to be carried for each engine type per operation type.


Testing:

```
<whatever>: ./gradlew :appsignals-tests:contract-tests:contractTests

> Configure project :awsagentprovider
Inferred project: aws-otel-java-instrumentation, version: 1.33.0-SNAPSHOT

> Task :appsignals-tests:images:http-servers:tomcat:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-tomcat...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.tests.images.httpservers.tomcat.Main]

Built image to Docker daemon as aws-appsignals-tests-http-server-tomcat
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-servers:netty-server:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-netty-server...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.NettyServer]
Executing tasks:
[==============================] 98.7% complete
> loading to Docker daemon


> Task :appsignals-tests:images:http-clients:native-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-native-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-native-http-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:netty-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-netty-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.NettyClient]

Built image to Docker daemon as aws-appsignals-tests-netty-http-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:apache-http-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-apache-http-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]
Executing tasks:
[==============================] 99.4% complete

Built image to Docker daemon as aws-appsignals-tests-http-server-netty-server
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-clients:spring-mvc-client:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-spring-mvc-client-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.Application]

Built image to Docker daemon as aws-appsignals-tests-spring-mvc-client-app
Executing tasks:

Built image to Docker daemon as aws-appsignals-tests-apache-http-client-app
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:http-servers:spring-mvc:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-http-server-spring-mvc...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.tests.images.httpservers.springmvc.Application]

Built image to Docker daemon as aws-appsignals-tests-http-server-spring-mvc
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:kafka:kafka-producers:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-kafka-kafka-producers...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-kafka-kafka-producers
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:grpc:grpc-server:jibDockerBuild

Containerizing application to Docker daemon as grpc-server...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, software.amazon.opentelemetry.EchoerServer]

Built image to Docker daemon as grpc-server
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:kafka:kafka-consumers:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-kafka-kafka-consumers...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, App]

Built image to Docker daemon as aws-appsignals-tests-kafka-kafka-consumers
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:grpc:grpc-client:jibDockerBuild

Containerizing application to Docker daemon as grpc-client...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, software.amazon.opentelemetry.Main]

Built image to Docker daemon as grpc-client
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:aws-sdk:aws-sdk-v2:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-aws-sdk-v2...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, com.amazon.sampleapp.App]

Built image to Docker daemon as aws-appsignals-tests-aws-sdk-v2
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:mock-collector:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-mock-collector...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.appsignals.test.images.mockcollector.Main]

Built image to Docker daemon as aws-appsignals-mock-collector
Executing tasks:
[==============================] 100.0% complete


> Task :appsignals-tests:images:jdbc:jibDockerBuild

Containerizing application to Docker daemon as aws-appsignals-tests-jdbc-app...
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477

Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.Application]

Built image to Docker daemon as aws-appsignals-tests-jdbc-app
Executing tasks:
[==============================] 100.0% complete


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 15m 45s
56 actionable tasks: 17 executed, 39 up-to-date
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
