### PR TITLE
Adding data base user attribute in EMF logs

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
@@ -365,7 +365,6 @@ public class JdbcContractTestBase extends ContractTestBase {
     assertThat(response.status().isServerError()).isTrue();
 
     var traces = mockCollectorClient.getTraces();
-    System.out.println("Traces----------" + traces);
     assertAwsSpanAttributes(traces, method, path, dbSystem, dbOperation, dbUser, type, identifier);
     assertSemanticConventionsSpanAttributes(
         traces, otelStatusCode, dbSqlTable, dbSystem, dbOperation, dbUser, dbName, jdbcUrl);

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/utils/AppSignalsConstants.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/utils/AppSignalsConstants.java
@@ -32,4 +32,5 @@ public class AppSignalsConstants {
   public static final String AWS_REMOTE_RESOURCE_TYPE = "aws.remote.resource.type";
   public static final String AWS_REMOTE_RESOURCE_IDENTIFIER = "aws.remote.resource.identifier";
   public static final String AWS_SPAN_KIND = "aws.span.kind";
+  public static final String AWS_REMOTE_DB_USER = "aws.remote.db.user";
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -41,7 +41,8 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_REMOTE_RESOURCE_TYPE =
       AttributeKey.stringKey("aws.remote.resource.type");
 
-  static final AttributeKey<String> AWS_REMOTE_DB_USER = AttributeKey.stringKey("aws.remote.db.user");
+  static final AttributeKey<String> AWS_REMOTE_DB_USER =
+      AttributeKey.stringKey("aws.remote.db.user");
 
   static final AttributeKey<String> AWS_SDK_DESCENDANT =
       AttributeKey.stringKey("aws.sdk.descendant");

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -41,6 +41,8 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_REMOTE_RESOURCE_TYPE =
       AttributeKey.stringKey("aws.remote.resource.type");
 
+  static final AttributeKey<String> AWS_REMOTE_DB_USER = AttributeKey.stringKey("aws.remote.db.user");
+
   static final AttributeKey<String> AWS_SDK_DESCENDANT =
       AttributeKey.stringKey("aws.sdk.descendant");
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.semconv.SemanticAttributes.DB_NAME;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_USER;
 import static io.opentelemetry.semconv.SemanticAttributes.FAAS_INVOKED_NAME;
 import static io.opentelemetry.semconv.SemanticAttributes.FAAS_TRIGGER;
 import static io.opentelemetry.semconv.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
@@ -41,6 +42,7 @@ import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_DB_USER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
@@ -151,6 +153,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     setRemoteResourceTypeAndIdentifier(span, builder);
     setSpanKindForDependency(span, builder);
     setHttpStatus(span, builder);
+    setRemoteDbUser(span, builder);
 
     return builder.build();
   }
@@ -523,6 +526,12 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     Long statusCode = getAwsStatusCode(span);
     if (statusCode != null) {
       builder.put(HTTP_STATUS_CODE, statusCode);
+    }
+  }
+
+  private static void setRemoteDbUser(SpanData span, AttributesBuilder builder) {
+    if (isDBSpan(span) && isKeyPresent(span, DB_USER)) {
+      builder.put(AWS_REMOTE_DB_USER, span.getAttributes().get(DB_USER));
     }
   }
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -47,6 +47,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_URL;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_DB_USER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_RESOURCE_IDENTIFIER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_RESOURCE_TYPE;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -42,7 +42,6 @@ import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_DB_USER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -18,6 +18,7 @@ package software.amazon.opentelemetry.javaagent.providers;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_USER;
 import static io.opentelemetry.semconv.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_OPERATION;
@@ -226,6 +227,7 @@ final class AwsSpanProcessingUtil {
   static boolean isDBSpan(SpanData span) {
     return isKeyPresent(span, DB_SYSTEM)
         || isKeyPresent(span, DB_OPERATION)
+        || isKeyPresent(span, DB_USER)
         || isKeyPresent(span, DB_STATEMENT);
   }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -18,7 +18,6 @@ package software.amazon.opentelemetry.javaagent.providers;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
-import static io.opentelemetry.semconv.SemanticAttributes.DB_USER;
 import static io.opentelemetry.semconv.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_OPERATION;
@@ -227,7 +226,6 @@ final class AwsSpanProcessingUtil {
   static boolean isDBSpan(SpanData span) {
     return isKeyPresent(span, DB_SYSTEM)
         || isKeyPresent(span, DB_OPERATION)
-        || isKeyPresent(span, DB_USER)
         || isKeyPresent(span, DB_STATEMENT);
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1031,7 +1031,7 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  void testDBUserAttribute() {
+  public void testDBUserAttribute() {
     mockAttribute(DB_SYSTEM, "db_system");
     mockAttribute(DB_OPERATION, "db_operation");
     mockAttribute(DB_STATEMENT, "db_statement");
@@ -1045,7 +1045,7 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  void testDBUserAttributeAbsent() {
+  public void testDBUserAttributeAbsent() {
     mockAttribute(DB_USER, null);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
@@ -1055,7 +1055,7 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  void testDBUserAttributeWithDifferentValues() {
+  public void testDBUserAttributeWithDifferentValues() {
     mockAttribute(DB_SYSTEM, "db_system");
     mockAttribute(DB_OPERATION, "db_operation");
     mockAttribute(DB_STATEMENT, "db_statement");
@@ -1068,7 +1068,7 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  void testDBUserAttributeNotPresentInServiceMetricForServerSpan() {
+  public void testDBUserAttributeNotPresentInServiceMetricForServerSpan() {
     String dbUser = "db_user";
     mockAttribute(DB_USER, dbUser);
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1080,7 +1080,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-            GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isNull();
   }
 

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -22,11 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_DB_USER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_URL;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_DB_USER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_RESOURCE_IDENTIFIER;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_RESOURCE_TYPE;
@@ -1065,7 +1065,7 @@ class AwsMetricAttributeGeneratorTest {
   @Test
   void testDBUserAttributeNotPresentInServiceMetricForServerSpan() {
     String dbUser = "test_user";
-    mockAttribute(AWS_REMOTE_DB_USER, dbUser);
+    mockAttribute(DB_USER, dbUser);
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
 
     Attributes actualAttributes =

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1032,9 +1032,7 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   public void testDBUserAttribute() {
-    mockAttribute(DB_SYSTEM, "db_system");
     mockAttribute(DB_OPERATION, "db_operation");
-    mockAttribute(DB_STATEMENT, "db_statement");
     mockAttribute(DB_USER, "db_user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
@@ -1046,6 +1044,7 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   public void testDBUserAttributeAbsent() {
+    mockAttribute(DB_SYSTEM, "db_system");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
@@ -1055,9 +1054,7 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   public void testDBUserAttributeWithDifferentValues() {
-    mockAttribute(DB_SYSTEM, "db_system");
     mockAttribute(DB_OPERATION, "db_operation");
-    mockAttribute(DB_STATEMENT, "db_statement");
     mockAttribute(DB_USER, "non_db_user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
@@ -1068,8 +1065,8 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   public void testDBUserAttributeNotPresentInServiceMetricForServerSpan() {
-    String dbUser = "db_user";
-    mockAttribute(DB_USER, dbUser);
+    mockAttribute(DB_USER, "db_user");
+    mockAttribute(DB_SYSTEM, "db_system");
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
 
     Attributes actualAttributes =
@@ -1078,34 +1075,13 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  public void testIsDbSpanTrueWhenDbSystemKeyIsPresent() {
-    mockAttribute(DB_SYSTEM, "DB system");
-    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
-
-    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isTrue();
-  }
-
-  @Test
-  public void testIsDbSpanTrueWhenDbOperationKeyIsPresent() {
-    mockAttribute(DB_OPERATION, "DB operation");
-    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
-
-    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isTrue();
-  }
-
-  @Test
-  public void testIsDbSpanFalseWhenOnlyDbUserKeyIsPresent() {
+  public void testDbUserPresentAndIsDbSpanFalse() {
     mockAttribute(DB_USER, "DB user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
-    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isFalse();
-  }
-
-  @Test
-  public void testIsDbSpanFalse() {
-    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
-
-    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isFalse();
+    Attributes actualAttributes =
+            GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+    assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isNull();
   }
 
   @Test

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1032,13 +1032,16 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   void testDBUserAttribute() {
-    String dbUser = "test_user";
-    mockAttribute(DB_USER, dbUser);
+    mockAttribute(DB_SYSTEM, "db_system");
+    mockAttribute(DB_OPERATION, "db_operation");
+    mockAttribute(DB_STATEMENT, "db_statement");
+    mockAttribute(DB_USER, "db_user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
         GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
-    assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isEqualTo(dbUser);
+    assertThat(actualAttributes.get(AWS_REMOTE_OPERATION)).isEqualTo("db_operation");
+    assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isEqualTo("db_user");
   }
 
   @Test
@@ -1053,24 +1056,44 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   void testDBUserAttributeWithDifferentValues() {
-    String dbUser = "non_db_user";
-    mockAttribute(DB_USER, dbUser);
+    mockAttribute(DB_SYSTEM, "db_system");
+    mockAttribute(DB_OPERATION, "db_operation");
+    mockAttribute(DB_STATEMENT, "db_statement");
+    mockAttribute(DB_USER, "non_db_user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
         GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
-    assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isEqualTo(dbUser);
+    assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isEqualTo("non_db_user");
   }
 
   @Test
   void testDBUserAttributeNotPresentInServiceMetricForServerSpan() {
-    String dbUser = "test_user";
+    String dbUser = "db_user";
     mockAttribute(DB_USER, dbUser);
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
 
     Attributes actualAttributes =
         GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isNull();
+  }
+
+  @Test
+  public void testIsDbSpanTrue() {
+    mockAttribute(DB_SYSTEM, "DB system");
+    mockAttribute(DB_OPERATION, "DB operation");
+    mockAttribute(DB_USER, "DB user");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
+
+    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isTrue();
+  }
+
+  @Test
+  public void testIsDbSpanFalse() {
+    mockAttribute(DB_SYSTEM, null);
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
+
+    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isFalse();
   }
 
   @Test

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1046,7 +1046,6 @@ class AwsMetricAttributeGeneratorTest {
 
   @Test
   public void testDBUserAttributeAbsent() {
-    mockAttribute(DB_USER, null);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
@@ -1079,18 +1078,31 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  public void testIsDbSpanTrue() {
+  public void testIsDbSpanTrueWhenDbSystemKeyIsPresent() {
     mockAttribute(DB_SYSTEM, "DB system");
-    mockAttribute(DB_OPERATION, "DB operation");
-    mockAttribute(DB_USER, "DB user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isTrue();
   }
 
   @Test
+  public void testIsDbSpanTrueWhenDbOperationKeyIsPresent() {
+    mockAttribute(DB_OPERATION, "DB operation");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
+
+    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isTrue();
+  }
+
+  @Test
+  public void testIsDbSpanTrueWhenDbUserKeyIsPresent() {
+    mockAttribute(DB_USER, "DB user");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
+
+    assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isFalse();
+  }
+
+  @Test
   public void testIsDbSpanFalse() {
-    mockAttribute(DB_SYSTEM, null);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     assertThat(AwsSpanProcessingUtil.isDBSpan(spanDataMock)).isFalse();

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1094,7 +1094,7 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  public void testIsDbSpanFalseWhenDbUserKeyIsPresent() {
+  public void testIsDbSpanFalseWhenOnlyDbUserKeyIsPresent() {
     mockAttribute(DB_USER, "DB user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -1094,7 +1094,7 @@ class AwsMetricAttributeGeneratorTest {
   }
 
   @Test
-  public void testIsDbSpanTrueWhenDbUserKeyIsPresent() {
+  public void testIsDbSpanFalseWhenDbUserKeyIsPresent() {
     mockAttribute(DB_USER, "DB user");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added data base user attribute in EMF logs - `db.user`.
- Added unit test for data base user attribute
- Added contract-tests

Output of EMF log:
```
{
    "Environment": "ECS",
     ... ,
    "aws.remote.db.user": "myuser", <- Added Data base user
    "Error": {
        "Values": [
            0
        ],
        "Counts": [
            75574
        ]
       }
        ...
}
```

```
> Task :appsignals-tests:images:jdbc:jibDockerBuild                                                                                                                                            
                                                                                                                                                                                               
Containerizing application to Docker daemon as aws-appsignals-tests-jdbc-app...                                                                                                                
Base image 'public.ecr.aws/docker/library/amazoncorretto:17-alpine' does not use a specific image digest - build may not be reproducible                                                       
The base image requires auth. Trying again for public.ecr.aws/docker/library/amazoncorretto:17-alpine...                                                                                       
Using base image with digest: sha256:2122cb140fa94053abce343fb854d24f4c62ba3c1ac701882dce12980396b477                                                                                          
                                                                                                                                                                                               
Container entrypoint set to [java, -cp, @/app/jib-classpath-file, software.amazon.opentelemetry.Application]                                                                                   
                                                                                                                                                                                               
Built image to Docker daemon as aws-appsignals-tests-jdbc-app                                                                                                                                  
Executing tasks:                                                                                                                                                                               
[==============================] 100.0% complete 

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.                                                                                                    

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.                                                      

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.                                   

BUILD SUCCESSFUL in 16m 10s                                                                                                                                                                    
56 actionable tasks: 16 executed, 40 up-to-date    
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
