### PR TITLE
Upgrade jib

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dependencies {
-  implementation("com.google.cloud.tools:jib-gradle-plugin:3.4.0")
+  implementation("com.google.cloud.tools:jib-gradle-plugin:3.4.3")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
     id("com.github.ben-manes.versions") version "0.50.0"
     id("com.github.jk1.dependency-license-report") version "2.5"
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.google.cloud.tools.jib") version "3.4.0"
+    id("com.google.cloud.tools.jib") version "3.4.3"
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
     id("nebula.release") version "18.0.6"
     id("org.springframework.boot") version "2.7.17"


### PR DESCRIPTION
PR workflows are failing due to a somewhat arcane message relating to Docker and jib: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/9568113061/job/26377760995?pr=818

Found an issue that seems at least somewhat related, which was resolved in jib 3.4.1: https://github.com/GoogleContainerTools/jib/issues/4171

In this PR we are upgrading jib from 3.4.0 to 3.4.3, since a) it is generally a good thing to be up to date with dependencies and b) I suspect it will resolve this issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
