### PR TITLE
Add bedrock and bedrockRuntime support.

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -56,13 +56,11 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_QUEUE_NAME = AttributeKey.stringKey("aws.queue.name");
   static final AttributeKey<String> AWS_STREAM_NAME = AttributeKey.stringKey("aws.stream.name");
   static final AttributeKey<String> AWS_TABLE_NAME = AttributeKey.stringKey("aws.table.name");
-  static final AttributeKey<String> AWS_AGENT_ID = AttributeKey.stringKey("aws.bedrock.agent_id");
+  static final AttributeKey<String> AWS_AGENT_ID = AttributeKey.stringKey("aws.bedrock.agent.id");
   static final AttributeKey<String> AWS_KNOWLEDGEBASE_ID =
-          AttributeKey.stringKey("aws.bedrock.knowledgebase_id");
+          AttributeKey.stringKey("aws.bedrock.knowledgebase.id");
   static final AttributeKey<String> AWS_DATASOURCE_ID =
-          AttributeKey.stringKey("aws.bedrock.datasource_id");
+          AttributeKey.stringKey("aws.bedrock.datasource.id");
   static final AttributeKey<String> AWS_GUARDRAIL_ID =
-          AttributeKey.stringKey("aws.bedrock.guardrail_id");
-  static final AttributeKey<String> AWS_BEDROCK_RUNTIME_MODEL_ID =
-          AttributeKey.stringKey("gen_ai.request.model");
+          AttributeKey.stringKey("aws.bedrock.guardrail.id");
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -58,9 +58,9 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_TABLE_NAME = AttributeKey.stringKey("aws.table.name");
   static final AttributeKey<String> AWS_AGENT_ID = AttributeKey.stringKey("aws.bedrock.agent.id");
   static final AttributeKey<String> AWS_KNOWLEDGEBASE_ID =
-          AttributeKey.stringKey("aws.bedrock.knowledgebase.id");
+      AttributeKey.stringKey("aws.bedrock.knowledgebase.id");
   static final AttributeKey<String> AWS_DATASOURCE_ID =
-          AttributeKey.stringKey("aws.bedrock.datasource.id");
+      AttributeKey.stringKey("aws.bedrock.datasource.id");
   static final AttributeKey<String> AWS_GUARDRAIL_ID =
-          AttributeKey.stringKey("aws.bedrock.guardrail.id");
+      AttributeKey.stringKey("aws.bedrock.guardrail.id");
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -57,10 +57,10 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_STREAM_NAME = AttributeKey.stringKey("aws.stream.name");
   static final AttributeKey<String> AWS_TABLE_NAME = AttributeKey.stringKey("aws.table.name");
   static final AttributeKey<String> AWS_AGENT_ID = AttributeKey.stringKey("aws.bedrock.agent.id");
-  static final AttributeKey<String> AWS_KNOWLEDGEBASE_ID =
-      AttributeKey.stringKey("aws.bedrock.knowledgebase.id");
-  static final AttributeKey<String> AWS_DATASOURCE_ID =
-      AttributeKey.stringKey("aws.bedrock.datasource.id");
+  static final AttributeKey<String> AWS_KNOWLEDGE_BASE_ID =
+      AttributeKey.stringKey("aws.bedrock.knowledge_base.id");
+  static final AttributeKey<String> AWS_DATA_SOURCE_ID =
+      AttributeKey.stringKey("aws.bedrock.data_source.id");
   static final AttributeKey<String> AWS_GUARDRAIL_ID =
       AttributeKey.stringKey("aws.bedrock.guardrail.id");
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -56,4 +56,13 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_QUEUE_NAME = AttributeKey.stringKey("aws.queue.name");
   static final AttributeKey<String> AWS_STREAM_NAME = AttributeKey.stringKey("aws.stream.name");
   static final AttributeKey<String> AWS_TABLE_NAME = AttributeKey.stringKey("aws.table.name");
+  static final AttributeKey<String> AWS_AGENT_ID = AttributeKey.stringKey("aws.bedrock.agent_id");
+  static final AttributeKey<String> AWS_KNOWLEDGEBASE_ID =
+          AttributeKey.stringKey("aws.bedrock.knowledgebase_id");
+  static final AttributeKey<String> AWS_DATASOURCE_ID =
+          AttributeKey.stringKey("aws.bedrock.datasource_id");
+  static final AttributeKey<String> AWS_GUARDRAIL_ID =
+          AttributeKey.stringKey("aws.bedrock.guardrail_id");
+  static final AttributeKey<String> AWS_BEDROCK_RUNTIME_MODEL_ID =
+          AttributeKey.stringKey("gen_ai.request.model");
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -42,9 +42,9 @@ import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATA_SOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGEBASE_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGE_BASE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
@@ -428,14 +428,14 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Agent");
         remoteResourceIdentifier =
             Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_AGENT_ID)));
-      } else if (isKeyPresent(span, AWS_KNOWLEDGEBASE_ID)) {
+      } else if (isKeyPresent(span, AWS_KNOWLEDGE_BASE_ID)) {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::KnowledgeBase");
         remoteResourceIdentifier =
-            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_KNOWLEDGEBASE_ID)));
-      } else if (isKeyPresent(span, AWS_DATASOURCE_ID)) {
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_KNOWLEDGE_BASE_ID)));
+      } else if (isKeyPresent(span, AWS_DATA_SOURCE_ID)) {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::DataSource");
         remoteResourceIdentifier =
-            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_DATASOURCE_ID)));
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_DATA_SOURCE_ID)));
       } else if (isKeyPresent(span, AWS_GUARDRAIL_ID)) {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Guardrail");
         remoteResourceIdentifier =

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -369,7 +369,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
           return NORMALIZED_SQS_SERVICE_NAME;
           // For Bedrock, Bedrock Agent, and Bedrock Agent Runtime, we can align with AWS Cloud
           // Control and use AWS::Bedrock for RemoteService.
-        case "Bedrock": // AWS SDK v2 & v1
+        case "AmazonBedrock": // AWS SDK v1
+        case "Bedrock": // AWS SDK v2
         case "AWSBedrockAgentRuntime": // AWS SDK v1
         case "BedrockAgentRuntime": // AWS SDK v2
         case "AWSBedrockAgent": // AWS SDK v1

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -42,7 +42,6 @@ import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BEDROCK_RUNTIME_MODEL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGEBASE_ID;
@@ -63,6 +62,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessin
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_SERVICE;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.GEN_AI_REQUEST_MODEL;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isAwsSDKSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isDBSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresent;
@@ -367,12 +367,14 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         case "AmazonSQS": // AWS SDK v1
         case "Sqs": // AWS SDK v2
           return NORMALIZED_SQS_SERVICE_NAME;
+        // For Bedrock, Bedrock Agent, and Bedrock Agent Runtime, we can align with AWS Cloud Control and use AWS::Bedrock for RemoteService.
         case "Bedrock": // AWS SDK v2 & v1
         case "AWSBedrockAgentRuntime": // AWS SDK v1
         case "BedrockAgentRuntime": // AWS SDK v2
         case "AWSBedrockAgent": // AWS SDK v1
         case "BedrockAgent": // AWS SDK v2
           return NORMALIZED_BEDROCK_SERVICE_NAME;
+        // For BedrockRuntime, we are using AWS::BedrockRuntime as the associated remote resource (Model) is not listed in Cloud Control.
         case "AmazonBedrockRuntime": // AWS SDK v1
         case "BedrockRuntime": // AWS SDK v2
           return NORMALIZED_BEDROCK_RUNTIME_SERVICE_NAME;
@@ -435,11 +437,11 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Guardrail");
         remoteResourceIdentifier =
             Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_GUARDRAIL_ID)));
-      } else if (isKeyPresent(span, AWS_BEDROCK_RUNTIME_MODEL_ID)) {
+      } else if (isKeyPresent(span, GEN_AI_REQUEST_MODEL)) {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Model");
         remoteResourceIdentifier =
             Optional.ofNullable(
-                escapeDelimiters(span.getAttributes().get(AWS_BEDROCK_RUNTIME_MODEL_ID)));
+                escapeDelimiters(span.getAttributes().get(GEN_AI_REQUEST_MODEL)));
       }
     } else if (isDBSpan(span)) {
       remoteResourceType = Optional.of(DB_CONNECTION_RESOURCE_TYPE);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -40,8 +40,8 @@ import static io.opentelemetry.semconv.SemanticAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGEBASE_ID;
@@ -56,13 +56,13 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_SPAN_KIND;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_STREAM_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_TABLE_NAME;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.GEN_AI_REQUEST_MODEL;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.MAX_KEYWORD_LENGTH;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.SQL_DIALECT_PATTERN;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_SERVICE;
-import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.GEN_AI_REQUEST_MODEL;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isAwsSDKSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isDBSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresent;
@@ -367,14 +367,16 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         case "AmazonSQS": // AWS SDK v1
         case "Sqs": // AWS SDK v2
           return NORMALIZED_SQS_SERVICE_NAME;
-        // For Bedrock, Bedrock Agent, and Bedrock Agent Runtime, we can align with AWS Cloud Control and use AWS::Bedrock for RemoteService.
+          // For Bedrock, Bedrock Agent, and Bedrock Agent Runtime, we can align with AWS Cloud
+          // Control and use AWS::Bedrock for RemoteService.
         case "Bedrock": // AWS SDK v2 & v1
         case "AWSBedrockAgentRuntime": // AWS SDK v1
         case "BedrockAgentRuntime": // AWS SDK v2
         case "AWSBedrockAgent": // AWS SDK v1
         case "BedrockAgent": // AWS SDK v2
           return NORMALIZED_BEDROCK_SERVICE_NAME;
-        // For BedrockRuntime, we are using AWS::BedrockRuntime as the associated remote resource (Model) is not listed in Cloud Control.
+          // For BedrockRuntime, we are using AWS::BedrockRuntime as the associated remote resource
+          // (Model) is not listed in Cloud Control.
         case "AmazonBedrockRuntime": // AWS SDK v1
         case "BedrockRuntime": // AWS SDK v2
           return NORMALIZED_BEDROCK_RUNTIME_SERVICE_NAME;
@@ -440,8 +442,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       } else if (isKeyPresent(span, GEN_AI_REQUEST_MODEL)) {
         remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Model");
         remoteResourceIdentifier =
-            Optional.ofNullable(
-                escapeDelimiters(span.getAttributes().get(GEN_AI_REQUEST_MODEL)));
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(GEN_AI_REQUEST_MODEL)));
       }
     } else if (isDBSpan(span)) {
       remoteResourceType = Optional.of(DB_CONNECTION_RESOURCE_TYPE);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -41,6 +41,11 @@ import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
 import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BEDROCK_RUNTIME_MODEL_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGEBASE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
@@ -104,6 +109,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static final String NORMALIZED_KINESIS_SERVICE_NAME = "AWS::Kinesis";
   private static final String NORMALIZED_S3_SERVICE_NAME = "AWS::S3";
   private static final String NORMALIZED_SQS_SERVICE_NAME = "AWS::SQS";
+  private static final String NORMALIZED_BEDROCK_SERVICE_NAME = "AWS::Bedrock";
+  private static final String NORMALIZED_BEDROCK_RUNTIME_SERVICE_NAME = "AWS::BedrockRuntime";
 
   // Special DEPENDENCY attribute value if GRAPHQL_OPERATION_TYPE attribute key is present.
   private static final String GRAPHQL = "graphql";
@@ -360,6 +367,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         case "AmazonSQS": // AWS SDK v1
         case "Sqs": // AWS SDK v2
           return NORMALIZED_SQS_SERVICE_NAME;
+        case "Bedrock": // AWS SDK v2 & v1
+        case "AWSBedrockAgentRuntime": // AWS SDK v1
+        case "BedrockAgentRuntime": // AWS SDK v2
+        case "AWSBedrockAgent": // AWS SDK v1
+        case "BedrockAgent": // AWS SDK v2
+          return NORMALIZED_BEDROCK_SERVICE_NAME;
+        case "AmazonBedrockRuntime": // AWS SDK v1
+        case "BedrockRuntime": // AWS SDK v2
+          return NORMALIZED_BEDROCK_RUNTIME_SERVICE_NAME;
         default:
           return "AWS::" + serviceName;
       }
@@ -403,6 +419,27 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         remoteResourceType = Optional.of(NORMALIZED_SQS_SERVICE_NAME + "::Queue");
         remoteResourceIdentifier =
             SqsUrlParser.getQueueName(escapeDelimiters(span.getAttributes().get(AWS_QUEUE_URL)));
+      } else if (isKeyPresent(span, AWS_AGENT_ID)) {
+        remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Agent");
+        remoteResourceIdentifier =
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_AGENT_ID)));
+      } else if (isKeyPresent(span, AWS_KNOWLEDGEBASE_ID)) {
+        remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::KnowledgeBase");
+        remoteResourceIdentifier =
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_KNOWLEDGEBASE_ID)));
+      } else if (isKeyPresent(span, AWS_DATASOURCE_ID)) {
+        remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::DataSource");
+        remoteResourceIdentifier =
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_DATASOURCE_ID)));
+      } else if (isKeyPresent(span, AWS_GUARDRAIL_ID)) {
+        remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Guardrail");
+        remoteResourceIdentifier =
+            Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_GUARDRAIL_ID)));
+      } else if (isKeyPresent(span, AWS_BEDROCK_RUNTIME_MODEL_ID)) {
+        remoteResourceType = Optional.of(NORMALIZED_BEDROCK_SERVICE_NAME + "::Model");
+        remoteResourceIdentifier =
+            Optional.ofNullable(
+                escapeDelimiters(span.getAttributes().get(AWS_BEDROCK_RUNTIME_MODEL_ID)));
       }
     } else if (isDBSpan(span)) {
       remoteResourceType = Optional.of(DB_CONNECTION_RESOURCE_TYPE);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -58,7 +58,7 @@ final class AwsSpanProcessingUtil {
   static final int MAX_KEYWORD_LENGTH = 27;
   // TODO: Use Semantic Conventions once upgrade once upgrade to v1.26.0
   static final AttributeKey<String> GEN_AI_REQUEST_MODEL =
-          AttributeKey.stringKey("gen_ai.request.model");
+      AttributeKey.stringKey("gen_ai.request.model");
   static final Pattern SQL_DIALECT_PATTERN =
       Pattern.compile("^(?:" + String.join("|", getDialectKeywords()) + ")\\b");
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -56,6 +56,9 @@ final class AwsSpanProcessingUtil {
   // The current longest command word is DATETIME_INTERVAL_PRECISION at 27 characters.
   // If we add a longer keyword to the sql dialect keyword list, need to update the constant below.
   static final int MAX_KEYWORD_LENGTH = 27;
+  // TODO: Use Semantic Conventions once upgrade once upgrade to v1.26.0
+  static final AttributeKey<String> GEN_AI_REQUEST_MODEL =
+          AttributeKey.stringKey("gen_ai.request.model");
   static final Pattern SQL_DIALECT_PATTERN =
       Pattern.compile("^(?:" + String.join("|", getDialectKeywords()) + ")\\b");
 

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -21,7 +21,12 @@ import static io.opentelemetry.semconv.SemanticAttributes.MessagingOperationValu
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BEDROCK_RUNTIME_MODEL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGEBASE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
@@ -700,6 +705,30 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAttributes("AWS::DynamoDB::Table", "aws_table^^name");
     mockAttribute(AWS_TABLE_NAME, null);
 
+    // Validate behaviour of AWS_BEDROCK_AGENT_ID attribute, then remove it.
+    mockAttribute(AWS_AGENT_ID, "test_agent_id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Agent", "test_agent_id");
+    mockAttribute(AWS_AGENT_ID, null);
+
+    // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute, then remove it.
+    mockAttribute(AWS_KNOWLEDGEBASE_ID, "test_knowledgeBase_id");
+    validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_id");
+    mockAttribute(AWS_KNOWLEDGEBASE_ID, null);
+
+    // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute, then remove it.
+    mockAttribute(AWS_DATASOURCE_ID, "test_datasource_id");
+    validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_id");
+    mockAttribute(AWS_DATASOURCE_ID, null);
+
+    // Validate behaviour of AWS_GUARDRAIL_ID attribute, then remove it.
+    mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Guardrail", "test_guardrail_id");
+    mockAttribute(AWS_GUARDRAIL_ID, null);
+
+    // Validate behaviour of AWS_BEDROCK_RUNTIME_MODEL_ID attribute, then remove it.
+    mockAttribute(AWS_BEDROCK_RUNTIME_MODEL_ID, "test.service-id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service-id");
+    mockAttribute(AWS_BEDROCK_RUNTIME_MODEL_ID, null);
     mockAttribute(RPC_SYSTEM, "null");
   }
 
@@ -1047,12 +1076,20 @@ class AwsMetricAttributeGeneratorTest {
     testAwsSdkServiceNormalization("AmazonKinesis", "AWS::Kinesis");
     testAwsSdkServiceNormalization("Amazon S3", "AWS::S3");
     testAwsSdkServiceNormalization("AmazonSQS", "AWS::SQS");
+    testAwsSdkServiceNormalization("Bedrock", "AWS::Bedrock");
+    testAwsSdkServiceNormalization("AWSBedrockAgentRuntime", "AWS::Bedrock");
+    testAwsSdkServiceNormalization("AWSBedrockAgent", "AWS::Bedrock");
+    testAwsSdkServiceNormalization("AmazonBedrockRuntime", "AWS::BedrockRuntime");
 
     // AWS SDK V2
     testAwsSdkServiceNormalization("DynamoDb", "AWS::DynamoDB");
     testAwsSdkServiceNormalization("Kinesis", "AWS::Kinesis");
     testAwsSdkServiceNormalization("S3", "AWS::S3");
     testAwsSdkServiceNormalization("Sqs", "AWS::SQS");
+    testAwsSdkServiceNormalization("Bedrock", "AWS::Bedrock");
+    testAwsSdkServiceNormalization("BedrockAgentRuntime", "AWS::Bedrock");
+    testAwsSdkServiceNormalization("BedrockAgent", "AWS::Bedrock");
+    testAwsSdkServiceNormalization("BedrockRuntime", "AWS::BedrockRuntime");
   }
 
   private void testAwsSdkServiceNormalization(String serviceName, String expectedRemoteService) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BEDROCK_RUNTIME_MODEL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
@@ -40,6 +39,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_TABLE_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.MetricAttributeGenerator.DEPENDENCY_METRIC;
 import static software.amazon.opentelemetry.javaagent.providers.MetricAttributeGenerator.SERVICE_METRIC;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.GEN_AI_REQUEST_MODEL;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -710,9 +710,19 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAttributes("AWS::Bedrock::Agent", "test_agent_id");
     mockAttribute(AWS_AGENT_ID, null);
 
+    // Validate behaviour of AWS_BEDROCK_AGENT_ID attribute with special chars(^), then remove it.
+    mockAttribute(AWS_AGENT_ID, "test_agent_^id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Agent", "test_agent_^^id");
+    mockAttribute(AWS_AGENT_ID, null);
+
     // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute, then remove it.
     mockAttribute(AWS_KNOWLEDGEBASE_ID, "test_knowledgeBase_id");
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_id");
+    mockAttribute(AWS_KNOWLEDGEBASE_ID, null);
+
+    // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute with special chars(^), then remove it.
+    mockAttribute(AWS_KNOWLEDGEBASE_ID, "test_knowledgeBase_^id");
+    validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_^^id");
     mockAttribute(AWS_KNOWLEDGEBASE_ID, null);
 
     // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute, then remove it.
@@ -720,15 +730,31 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_id");
     mockAttribute(AWS_DATASOURCE_ID, null);
 
+    // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute with special chars(^), then remove it.
+    mockAttribute(AWS_DATASOURCE_ID, "test_datasource_^id");
+    validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_^^id");
+    mockAttribute(AWS_DATASOURCE_ID, null);
+
     // Validate behaviour of AWS_GUARDRAIL_ID attribute, then remove it.
     mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_id");
     validateRemoteResourceAttributes("AWS::Bedrock::Guardrail", "test_guardrail_id");
     mockAttribute(AWS_GUARDRAIL_ID, null);
 
+    // Validate behaviour of AWS_GUARDRAIL_ID attribute with special chars(^), then remove it.
+    mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_^id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Guardrail", "test_guardrail_^^id");
+    mockAttribute(AWS_GUARDRAIL_ID, null);
+
     // Validate behaviour of AWS_BEDROCK_RUNTIME_MODEL_ID attribute, then remove it.
-    mockAttribute(AWS_BEDROCK_RUNTIME_MODEL_ID, "test.service-id");
-    validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service-id");
-    mockAttribute(AWS_BEDROCK_RUNTIME_MODEL_ID, null);
+    mockAttribute(GEN_AI_REQUEST_MODEL, "test.service_id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service_id");
+    mockAttribute(GEN_AI_REQUEST_MODEL, null);
+    mockAttribute(RPC_SYSTEM, "null");
+
+    // Validate behaviour of AWS_BEDROCK_RUNTIME_MODEL_ID attribute with special chars(^), then remove it.
+    mockAttribute(GEN_AI_REQUEST_MODEL, "test.service_^id");
+    validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service_^^id");
+    mockAttribute(GEN_AI_REQUEST_MODEL, null);
     mockAttribute(RPC_SYSTEM, "null");
   }
 

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_AGENT_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_BUCKET_NAME;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATASOURCE_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_DATA_SOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGEBASE_ID;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGE_BASE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_QUEUE_NAME;
@@ -716,25 +716,25 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(AWS_AGENT_ID, null);
 
     // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute, then remove it.
-    mockAttribute(AWS_KNOWLEDGEBASE_ID, "test_knowledgeBase_id");
+    mockAttribute(AWS_KNOWLEDGE_BASE_ID, "test_knowledgeBase_id");
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_id");
-    mockAttribute(AWS_KNOWLEDGEBASE_ID, null);
+    mockAttribute(AWS_KNOWLEDGE_BASE_ID, null);
 
     // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute with special chars(^), then remove it.
-    mockAttribute(AWS_KNOWLEDGEBASE_ID, "test_knowledgeBase_^id");
+    mockAttribute(AWS_KNOWLEDGE_BASE_ID, "test_knowledgeBase_^id");
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_^^id");
-    mockAttribute(AWS_KNOWLEDGEBASE_ID, null);
+    mockAttribute(AWS_KNOWLEDGE_BASE_ID, null);
 
     // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute, then remove it.
-    mockAttribute(AWS_DATASOURCE_ID, "test_datasource_id");
+    mockAttribute(AWS_DATA_SOURCE_ID, "test_datasource_id");
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_id");
-    mockAttribute(AWS_DATASOURCE_ID, null);
+    mockAttribute(AWS_DATA_SOURCE_ID, null);
 
     // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute with special chars(^), then remove
     // it.
-    mockAttribute(AWS_DATASOURCE_ID, "test_datasource_^id");
+    mockAttribute(AWS_DATA_SOURCE_ID, "test_datasource_^id");
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_^^id");
-    mockAttribute(AWS_DATASOURCE_ID, null);
+    mockAttribute(AWS_DATA_SOURCE_ID, null);
 
     // Validate behaviour of AWS_GUARDRAIL_ID attribute, then remove it.
     mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_id");

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -37,9 +37,9 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_SPAN_KIND;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_STREAM_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_TABLE_NAME;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.GEN_AI_REQUEST_MODEL;
 import static software.amazon.opentelemetry.javaagent.providers.MetricAttributeGenerator.DEPENDENCY_METRIC;
 import static software.amazon.opentelemetry.javaagent.providers.MetricAttributeGenerator.SERVICE_METRIC;
-import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.GEN_AI_REQUEST_MODEL;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -730,7 +730,8 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_id");
     mockAttribute(AWS_DATASOURCE_ID, null);
 
-    // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute with special chars(^), then remove it.
+    // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute with special chars(^), then remove
+    // it.
     mockAttribute(AWS_DATASOURCE_ID, "test_datasource_^id");
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_^^id");
     mockAttribute(AWS_DATASOURCE_ID, null);
@@ -749,9 +750,9 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(GEN_AI_REQUEST_MODEL, "test.service_id");
     validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service_id");
     mockAttribute(GEN_AI_REQUEST_MODEL, null);
-    mockAttribute(RPC_SYSTEM, "null");
 
-    // Validate behaviour of AWS_BEDROCK_RUNTIME_MODEL_ID attribute with special chars(^), then remove it.
+    // Validate behaviour of AWS_BEDROCK_RUNTIME_MODEL_ID attribute with special chars(^), then
+    // remove it.
     mockAttribute(GEN_AI_REQUEST_MODEL, "test.service_^id");
     validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service_^^id");
     mockAttribute(GEN_AI_REQUEST_MODEL, null);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -715,22 +715,22 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAttributes("AWS::Bedrock::Agent", "test_agent_^^id");
     mockAttribute(AWS_AGENT_ID, null);
 
-    // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute, then remove it.
+    // Validate behaviour of AWS_KNOWLEDGE_BASE_ID attribute, then remove it.
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, "test_knowledgeBase_id");
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_id");
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, null);
 
-    // Validate behaviour of AWS_KNOWLEDGEBASE_ID attribute with special chars(^), then remove it.
+    // Validate behaviour of AWS_KNOWLEDGE_BASE_ID attribute with special chars(^), then remove it.
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, "test_knowledgeBase_^id");
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_^^id");
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, null);
 
-    // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute, then remove it.
+    // Validate behaviour of AWS_DATA_SOURCE_ID attribute, then remove it.
     mockAttribute(AWS_DATA_SOURCE_ID, "test_datasource_id");
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_id");
     mockAttribute(AWS_DATA_SOURCE_ID, null);
 
-    // Validate behaviour of AWS_BEDROCK_DATASOURCE_ID attribute with special chars(^), then remove
+    // Validate behaviour of AWS_DATA_SOURCE_ID attribute with special chars(^), then remove
     // it.
     mockAttribute(AWS_DATA_SOURCE_ID, "test_datasource_^id");
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_^^id");


### PR DESCRIPTION
The PR add new `RemoteResourceType` and `RemoteResourceIdentifier` for AWS Bedrock and BedrockRuntime services:
```
"RemoteResourceType": "AWS::Bedrock::Agent"
"RemoteResourceIdentifier": "<agent_id>"

"RemoteResourceType": "AWS::Bedrock::DataSource"
"RemoteResourceIdentifier": "<datasource_id>"

"RemoteResourceType": "AWS::Bedrock::Guardrail"
"RemoteResourceIdentifier": "<guardrail_id>"

"RemoteResourceType": "AWS::Bedrock::KnowledgeBase"
"RemoteResourceIdentifier": "<knowledgeBase_id>"

"RemoteResourceType": "AWS::Bedrock::Model"
"RemoteResourceIdentifier": "<modelId>"
``` 

Testing: E2E test performed to confirm trace, metrics are generated:
Traces:

AWS Java SDK V1:
![Screenshot 2024-07-08 at 5 02 30 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/06b26629-479e-4b03-806c-f58cf4682d58)
![Screenshot 2024-07-08 at 5 03 00 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/93e97ea2-195d-4668-b597-a3554436dbbd)
![Screenshot 2024-07-08 at 5 04 24 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/b71182df-3470-4407-ba2c-ac010fb97382)
![Screenshot 2024-07-08 at 5 05 57 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/5889a101-0bdd-4040-81df-fe11d64141a1)



AWS Java SDK V2:
![Screenshot 2024-07-08 at 3 56 01 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/197be468-648a-4817-b644-e521bd8f7e0e)
![Screenshot 2024-07-08 at 3 57 56 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/a7b4ae0f-3aac-4cce-8611-8334d644774a)
![Screenshot 2024-07-08 at 3 59 19 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/415ef59c-c531-44ca-90b7-ba9b9ca633bf)
![Screenshot 2024-07-08 at 4 00 50 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/4df79836-4480-4af2-91ac-6223f7169f31)
![Screenshot 2024-07-08 at 4 02 52 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/be50c724-fda1-4fee-8976-b3de1be8619a)
![Screenshot 2024-07-08 at 5 46 25 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/5dd139e7-1b56-4324-aa9a-0188de95184c)



Metrics:
AWS Java SDK V1:
![Screenshot 2024-07-08 at 5 17 52 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/25f68010-7ff2-4e02-a390-401c86d8a732)
![Screenshot 2024-07-08 at 5 22 07 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/c457685d-9e82-4aa3-8dcd-f48fdcee3701)
![Screenshot 2024-07-08 at 5 48 34 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/fcfa89eb-e738-46e9-8d3a-600181955bca)
![Screenshot 2024-07-08 at 5 53 10 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/7e29dfe0-393f-4b5d-8513-e06a4238743d)




AWS Java SDK V2:
![Screenshot 2024-07-08 at 6 08 54 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/ff4ee345-4fae-428b-b138-bf72ce5c185c)
![Screenshot 2024-07-08 at 6 09 30 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/6bb9f769-3b25-4ca7-ad94-b91541a9e162)
![Screenshot 2024-07-08 at 6 12 16 PM](https://github.com/aws-observability/aws-otel-java-instrumentation/assets/146124015/b0a22d1a-86b9-47b4-ac5f-6ba716ae92a7)





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
