### PR TITLE
Update settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
     id("com.github.jk1.dependency-license-report") version "2.5"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.google.cloud.tools.jib") version "3.4.3"
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("nebula.release") version "18.0.6"
     id("org.springframework.boot") version "2.7.17"
     id("org.owasp.dependencycheck") version "8.4.0"


### PR DESCRIPTION
Bump to gradle-nexus publish-plugin 2.0.0 to attempt to fix main build issue where we can no longer publish to maven.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
