### PR TITLE
Clean up E2E Operator resources if tests fail or are cancelled

### DIFF
--- a/.github/workflows/e2e-tests-with-operator.yml
+++ b/.github/workflows/e2e-tests-with-operator.yml
@@ -189,7 +189,7 @@ jobs:
       # file locks are being held from SIGTERMS dispatched in previous
       # steps.
       - name: Destroy resources
-        if: ${{ cancelled() }}
+        if: ${{ cancelled() || failure() }}
         shell: bash {0}
         working-directory: testing-framework/terraform
         run: |


### PR DESCRIPTION
In this PR, we are changing E2E Operator tests to clean up after themselves on failure or cancellation. Currently, this only happens on cancellation, but we need to do this on failure too, as tests can fail due to leaked resources.

This operation is safe to perform, as E2E Operator tests are only run from [two locations](https://github.com/search?q=repo%3Aaws-observability%2Faws-otel-java-instrumentation%20e2e-tests-with-operator.yml&type=code):
1. [main-build](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/90901b191b0f9e934a4c698ec1d1448364ad86fd/.github/workflows/main-build.yml#L160-L162)
2. [nightly-upstream-snapshot-build](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/90901b191b0f9e934a4c698ec1d1448364ad86fd/.github/workflows/nightly-upstream-snapshot-build.yml#L99-L102)

In both cases, they are running with a concurrency group of `e2e-adot-agent-operator-test` which prevents overlapping test runs.

Note: A number of code samples showing `cancelled or failed`: https://github.com/search?q=%22if%3A+%24%7B%7B+cancelled%28%29+%7C%7C+failure%28%29+%7D%7D%22&type=code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
