### PR TITLE
temp: Comment out ECR-related release steps

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -35,74 +35,74 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_password: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+      #     aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
 
-      - name: Log in to AWS ECR
-        uses: docker/login-action@v3
-        with:
-          registry: public.ecr.aws
+      # - name: Log in to AWS ECR
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: public.ecr.aws
 
-      - name: Build release with Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+      # - name: Build release with Gradle
+      #   uses: gradle/gradle-build-action@v3
+      #   with:
+      #     arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
+      # - name: Configure AWS Credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
+      #     aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
 
-      - name: Log in to AWS ECR
-        uses: docker/login-action@v3
-        with:
-          registry: public.ecr.aws
+      # - name: Log in to AWS ECR
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: public.ecr.aws
 
-      - name: Configure AWS Credentials for Private ECR
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
+      # - name: Configure AWS Credentials for Private ECR
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
+      #     aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
 
-      - name: Log in to AWS private ECR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.PRIVATE_REGISTRY }}
+      # - name: Log in to AWS private ECR
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ${{ env.PRIVATE_REGISTRY }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
-      - name: Build image for testing
-        uses: docker/build-push-action@v5
-        with:
-          push: false
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
-          context: .
-          platforms: linux/amd64
-          tags: ${{ env.TEST_TAG }}
-          load: true
+      # - name: Build image for testing
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     push: false
+      #     build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+      #     context: .
+      #     platforms: linux/amd64
+      #     tags: ${{ env.TEST_TAG }}
+      #     load: true
 
-      - name: Test docker image
-        shell: bash
-        run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "${{ github.event.inputs.version }}"
+      # - name: Test docker image
+      #   shell: bash
+      #   run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "${{ github.event.inputs.version }}"
 
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
-          context: .
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
-            ${{ env.PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
+      # - name: Build and push image
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     push: true
+      #     build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+      #     context: .
+      #     platforms: linux/amd64,linux/arm64
+      #     tags: |
+      #       ${{ env.PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
+      #       ${{ env.PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
       - name: Build and Publish release with Gradle
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,10 +46,10 @@ jobs:
       #   with:
       #     registry: public.ecr.aws
 
-      # - name: Build release with Gradle
-      #   uses: gradle/gradle-build-action@v3
-      #   with:
-      #     arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+      - name: Build release with Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
 
       # - name: Configure AWS Credentials
       #   uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
The 1.32.3 release failed to publish non-K8s/EKS related artifacts. As such, we will temporarily comment these out while working to resolve the authentication issues for the Maven artifacts that are not being published. In this way, we will only perform the failed steps and their prerequisite steps on the next attempt, so as to not change the image digest of the ECRs that have already been published.

Changing a github workflow file will NOT impact the released artifacts.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
