### PR TITLE
Align metrics with other Repos

### DIFF
--- a/.github/workflows/e2e-tests-app-with-java-agent.yml
+++ b/.github/workflows/e2e-tests-app-with-java-agent.yml
@@ -179,6 +179,6 @@ jobs:
       success: ${{  needs.test_Spring_App_With_Java_Agent.result == 'success'  &&
                     needs.test_Spark_App_With_Java_Agent.result == 'success'  &&
                     needs.test_Spark_AWS_SDK_V1_App_With_Java_Agent.result == 'success' }}
-      region: us-west-2
+      region: us-east-1
     secrets:
       roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/e2e-tests-with-operator.yml
+++ b/.github/workflows/e2e-tests-with-operator.yml
@@ -207,6 +207,6 @@ jobs:
       branch: ${{ github.ref_name }}
       workflow: ${{ inputs.caller-workflow-name }}
       success: ${{  needs.run-batch-job.result == 'success' }}
-      region: us-west-2
+      region: us-east-1
     secrets:
       roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -241,6 +241,6 @@ jobs:
       workflow: main-build
       success: ${{  needs.build.result == 'success' &&
                     needs.contract-tests.result == 'success'  }}
-      region: us-west-2
+      region: us-east-1
     secrets:
       roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -168,6 +168,6 @@ jobs:
       workflow: nightly-upstream-snapshot-build
       success: ${{  needs.build.result == 'success' &&
                     needs.contract-tests.result == 'success'  }}
-      region: us-west-2
+      region: us-east-1
     secrets:
       roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -64,7 +64,7 @@ jobs:
       workflow: owasp
       success: ${{ needs.check-dependencies-adot-java.result == 'success' &&
                    needs.check-dependencies-otel-java.result == 'success'}}
-      region: us-west-2
+      region: us-east-1
     secrets:
       roleArn: ${{ secrets.METRICS_ROLE_ARN }}
 


### PR DESCRIPTION
We want to report to us-east-1, as we do in Python https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/.github/workflows/daily_scan.yml#L16


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
