### PR TITLE
Fix nightly-upstream-snapshot-build.yml

### DIFF
--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -149,13 +149,10 @@ jobs:
       group: e2e-adot-test
       cancel-in-progress: false
     needs: [build,default-region-output]
-    uses: ./.github/workflows/appsignals-e2e-eks-test.yml
+    uses: ./.github/workflows/application-signals-e2e-test.yml
     secrets: inherit
     with:
-      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
-      test-cluster-name: "e2e-adot-test"
-      appsignals-adot-image-name: ${{ needs.build.outputs.release-candidate-image }}
-      caller-workflow-name: 'nightly-upstream-snapshot-build'
+      adot-image-name: ${{ needs.build.outputs.release-candidate-image }}
 
   publish-build-status:
     needs: [ build, contract-tests ]

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -145,9 +145,6 @@ jobs:
 
   # AppSignals specific e2e tests
   appsignals-e2e-test:
-    concurrency:
-      group: e2e-adot-test
-      cancel-in-progress: false
     needs: [build,default-region-output]
     uses: ./.github/workflows/application-signals-e2e-test.yml
     secrets: inherit


### PR DESCRIPTION
Pointing to old workflow. Updated to align with main_build: https://github.com/aws-observability/aws-otel-java-instrumentation/blob/6158a3bf83538a448ea7e3da45faba751aee3c03/.github/workflows/main-build.yml#L226-L231

Sample failure: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/10553009806

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
