### PR TITLE
Align failure metrics with other repos

### DIFF
--- a/.github/workflows/publish-status.yml
+++ b/.github/workflows/publish-status.yml
@@ -46,13 +46,13 @@ jobs:
         if: ${{ inputs.success }}
         run: |
           aws cloudwatch put-metric-data --namespace '${{ inputs.namespace }}' \
-            --metric-name Success \
+            --metric-name Failure \
             --dimensions repository=${{ inputs.repository }},branch=${{ inputs.branch }},workflow=${{ inputs.workflow }} \
-            --value 1.0
+            --value 0.0
       - name: Publish status failure
         if: ${{ !inputs.success }}
         run: |
           aws cloudwatch put-metric-data --namespace '${{ inputs.namespace }}' \
-            --metric-name Success \
+            --metric-name Failure \
             --dimensions repository=${{ inputs.repository }},branch=${{ inputs.branch }},workflow=${{ inputs.workflow }} \
-            --value 0.0
+            --value 1.0


### PR DESCRIPTION
Emit failure metrics instead of success metrics for easier monitoring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
