### PR TITLE
Assert extra spans for MySQlConnectorJ-8.4.

### DIFF
--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
@@ -64,17 +64,6 @@ public class JdbcContractTestBase extends ContractTestBase {
               assertAwsAttributes(
                   attributesList, method, path, dbSystem, dbOperation, dbUser, type, identifier);
             });
-    if (dbOperation.equals(DB_SELECT_OPERATION)) {
-      // assert an extra select that happens under the hood during connect operation
-      assertThat(resourceScopeSpans)
-          .satisfiesOnlyOnce(
-              rss -> {
-                assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
-                var attributesList = rss.getSpan().getAttributesList();
-                assertAwsAttributes(
-                    attributesList, method, path, dbSystem, dbOperation, dbUser, null, null);
-              });
-    }
   }
 
   protected void assertAwsAttributes(

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcContractTestBase.java
@@ -16,15 +16,12 @@
 package software.amazon.opentelemetry.appsignals.test.jdbc;
 
 import static io.opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT;
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-
 import software.amazon.opentelemetry.appsignals.test.base.ContractTestBase;
 import software.amazon.opentelemetry.appsignals.test.utils.AppSignalsConstants;
 import software.amazon.opentelemetry.appsignals.test.utils.ResourceScopeMetric;
@@ -67,17 +64,16 @@ public class JdbcContractTestBase extends ContractTestBase {
               assertAwsAttributes(
                   attributesList, method, path, dbSystem, dbOperation, dbUser, type, identifier);
             });
-    if(dbOperation.equals(DB_SELECT_OPERATION)) {
-        // assert an extra select that happens under the hood during connect operation
-        assertThat(resourceScopeSpans)
-            .satisfiesOnlyOnce(
-                rss -> {
-                  assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
-                  var attributesList = rss.getSpan().getAttributesList();
-                  assertAwsAttributes(
-                      attributesList, method, path, dbSystem, dbOperation, dbUser, null, null);
-                }
-            );
+    if (dbOperation.equals(DB_SELECT_OPERATION)) {
+      // assert an extra select that happens under the hood during connect operation
+      assertThat(resourceScopeSpans)
+          .satisfiesOnlyOnce(
+              rss -> {
+                assertThat(rss.getSpan().getKind()).isEqualTo(SPAN_KIND_CLIENT);
+                var attributesList = rss.getSpan().getAttributesList();
+                assertAwsAttributes(
+                    attributesList, method, path, dbSystem, dbOperation, dbUser, null, null);
+              });
     }
   }
 
@@ -140,10 +136,11 @@ public class JdbcContractTestBase extends ContractTestBase {
     } else {
       assertions.allSatisfy(
           (attribute) -> {
-            assertThat(attribute.getKey()).isNotEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_TYPE);
-            assertThat(attribute.getKey()).isNotEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER);
+            assertThat(attribute.getKey())
+                .isNotEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_TYPE);
+            assertThat(attribute.getKey())
+                .isNotEqualTo(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER);
           });
-
     }
   }
 

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
@@ -113,7 +113,7 @@ public class JdbcMySQLTest extends JdbcContractTestBase {
     return List.of(mySQLContainer);
   }
 
-  private void assertExtraSelectSpans() {
+  private void assertExtraSelectSpan() {
     var resourceScopeSpans = mockCollectorClient.getTraces();
     assertThat(resourceScopeSpans)
         .satisfiesOnlyOnce(

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/jdbc/JdbcMySQLTest.java
@@ -113,7 +113,7 @@ public class JdbcMySQLTest extends JdbcContractTestBase {
     return List.of(mySQLContainer);
   }
 
-  private void assertExtraSelectSpan() {
+  private void assertExtraSelectSpans() {
     var resourceScopeSpans = mockCollectorClient.getTraces();
     assertThat(resourceScopeSpans)
         .satisfiesOnlyOnce(

--- a/appsignals-tests/images/jdbc/build.gradle.kts
+++ b/appsignals-tests/images/jdbc/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   implementation("com.h2database:h2:2.2.224")
   implementation("org.slf4j:slf4j-simple")
   implementation("org.postgresql:postgresql:42.2.0")
+  implementation("io.opentelemetry:opentelemetry-api:1.34.1")
   implementation("com.mysql:mysql-connector-j:8.4.0")
 }
 


### PR DESCRIPTION
*Description of changes:*
Assert extra spans for MySQlConnectorJ-8.4.

When making a database query, Pulse agent leverage OTEL agent to intercept the database queries and send them to Cloud-watch agent. Then CloudWatch agent send all telemetry into Cloud-watch

We noticed that there will be two separate EMF log entries, one without remote identifier and one with remote identifier, this extra EMF comes in due to extra telemetry traces that come with mysqlConnector version 8.4

> The feature is supported by [component_telemetry](https://dev.mysql.com/doc/refman/8.4/en/telemetry-trace-install.html). MySQL Connector/J 8.4.0 introduces the client-side counterpart feature, with the capability of propagating the context to the MySQL Server it connects to and allowing a more complete observability for an application stack. ([Ref](https://dev.mysql.com/doc/connector-j/en/connector-j-opentelemetry.html))

The following commit adds the extra assertion of asserting the extra SELECT span.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
