### PR TITLE
Add ECS E2E test into main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -38,48 +38,48 @@ jobs:
       - name: Upload main-build adot.jar to s3
         run: aws s3 cp ./aws-opentelemetry-agent-*-SNAPSHOT.jar s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar
 
-#  java-ec2-default-e2e-test:
-#    needs: [ upload-main-build ]
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-default-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      caller-workflow-name: 'main-build'
-#
-#  java-ec2-asg-e2e-test:
-#    needs: [ upload-main-build ]
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-asg-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      caller-workflow-name: 'main-build'
-#
-#  java-eks-e2e-test:
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      test-cluster-name: 'e2e-adot-test'
-#      adot-image-name: ${{ inputs.adot-image-name }}
-#      caller-workflow-name: 'main-build'
-#
-#  java-metric-limiter-e2e-test:
-#    needs: [ java-eks-e2e-test ]
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/metric-limiter-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      test-cluster-name: 'e2e-adot-test'
-#      adot-image-name: ${{ inputs.adot-image-name }}
-#      caller-workflow-name: 'main-build'
-#
-#  java-k8s-e2e-test:
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-k8s-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      adot-image-name: ${{ inputs.adot-image-name }}
-#      caller-workflow-name: 'main-build'
+  java-ec2-default-e2e-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-default-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
+  java-ec2-asg-e2e-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-asg-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
+  java-eks-e2e-test:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+
+  java-metric-limiter-e2e-test:
+    needs: [ java-eks-e2e-test ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/metric-limiter-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+
+  java-k8s-e2e-test:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-k8s-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
 
   java-ecs-e2e-test:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ecs-test.yml@main

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -38,43 +38,51 @@ jobs:
       - name: Upload main-build adot.jar to s3
         run: aws s3 cp ./aws-opentelemetry-agent-*-SNAPSHOT.jar s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar
 
-  java-ec2-default-e2e-test:
-    needs: [ upload-main-build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-default-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      caller-workflow-name: 'main-build'
+#  java-ec2-default-e2e-test:
+#    needs: [ upload-main-build ]
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-default-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      caller-workflow-name: 'main-build'
+#
+#  java-ec2-asg-e2e-test:
+#    needs: [ upload-main-build ]
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-asg-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      caller-workflow-name: 'main-build'
+#
+#  java-eks-e2e-test:
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      test-cluster-name: 'e2e-adot-test'
+#      adot-image-name: ${{ inputs.adot-image-name }}
+#      caller-workflow-name: 'main-build'
+#
+#  java-metric-limiter-e2e-test:
+#    needs: [ java-eks-e2e-test ]
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/metric-limiter-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      test-cluster-name: 'e2e-adot-test'
+#      adot-image-name: ${{ inputs.adot-image-name }}
+#      caller-workflow-name: 'main-build'
+#
+#  java-k8s-e2e-test:
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-k8s-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      adot-image-name: ${{ inputs.adot-image-name }}
+#      caller-workflow-name: 'main-build'
 
-  java-ec2-asg-e2e-test:
-    needs: [ upload-main-build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-asg-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      caller-workflow-name: 'main-build'
-
-  java-eks-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-
-  java-metric-limiter-e2e-test:
-    needs: [ java-eks-e2e-test ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/metric-limiter-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-
-  java-k8s-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-k8s-test.yml@main
+  java-ecs-e2e-test:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ecs-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - "release/v*"
+      - ecs-entry
 env:
   AWS_DEFAULT_REGION: us-east-1
   STAGING_ECR_REGISTRY: 611364707713.dkr.ecr.us-west-2.amazonaws.com
@@ -181,47 +182,47 @@ jobs:
       image_tag: ${{ github.sha }}
       caller-workflow-name: 'main-build'
 
-  # AppSignals Contract Tests
-  contract-tests:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-      - uses: gradle/wrapper-validation-action@v1
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-      - name: Log in to AWS ECR
-        uses: docker/login-action@v3
-        with:
-          registry: public.ecr.aws
-
-      # cache local patch outputs
-      - name: Cache local Maven repository
-        id: cache-local-maven-repo
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
-      - name: Pull base image of Contract Tests Sample Apps
-        run: docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine
-
-      - name: Build snapshot with Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: contractTests -PlocalDocker=true
+#  # AppSignals Contract Tests
+#  contract-tests:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#      - uses: actions/setup-java@v4
+#        with:
+#          java-version: 17
+#          distribution: 'temurin'
+#      - uses: gradle/wrapper-validation-action@v1
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+#          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+#
+#      - name: Log in to AWS ECR
+#        uses: docker/login-action@v3
+#        with:
+#          registry: public.ecr.aws
+#
+#      # cache local patch outputs
+#      - name: Cache local Maven repository
+#        id: cache-local-maven-repo
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.m2/repository/io/opentelemetry/
+#          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+#
+#      - name: Pull base image of Contract Tests Sample Apps
+#        run: docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine
+#
+#      - name: Build snapshot with Gradle
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          arguments: contractTests -PlocalDocker=true
 
   application-signals-e2e-test:
     needs: [build]
@@ -230,17 +231,17 @@ jobs:
     with:
       adot-image-name: ${{ needs.build.outputs.staging-image }}
 
-  publish-build-status:
-    needs: [ build, contract-tests ]
-    if: ${{ always() }}
-    uses: ./.github/workflows/publish-status.yml
-    with:
-      namespace: 'ADOT/GitHubActions'
-      repository: ${{ github.repository }}
-      branch: ${{ github.ref_name }}
-      workflow: main-build
-      success: ${{  needs.build.result == 'success' &&
-                    needs.contract-tests.result == 'success'  }}
-      region: us-east-1
-    secrets:
-      roleArn: ${{ secrets.METRICS_ROLE_ARN }}
+#  publish-build-status:
+#    needs: [ build, contract-tests ]
+#    if: ${{ always() }}
+#    uses: ./.github/workflows/publish-status.yml
+#    with:
+#      namespace: 'ADOT/GitHubActions'
+#      repository: ${{ github.repository }}
+#      branch: ${{ github.ref_name }}
+#      workflow: main-build
+#      success: ${{  needs.build.result == 'success' &&
+#                    needs.contract-tests.result == 'success'  }}
+#      region: us-east-1
+#    secrets:
+#      roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - ecs-entry
 env:
   AWS_DEFAULT_REGION: us-east-1
   STAGING_ECR_REGISTRY: 611364707713.dkr.ecr.us-west-2.amazonaws.com
@@ -182,47 +181,47 @@ jobs:
       image_tag: ${{ github.sha }}
       caller-workflow-name: 'main-build'
 
-#  # AppSignals Contract Tests
-#  contract-tests:
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#      - uses: actions/setup-java@v4
-#        with:
-#          java-version: 17
-#          distribution: 'temurin'
-#      - uses: gradle/wrapper-validation-action@v1
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-#          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-#
-#      - name: Log in to AWS ECR
-#        uses: docker/login-action@v3
-#        with:
-#          registry: public.ecr.aws
-#
-#      # cache local patch outputs
-#      - name: Cache local Maven repository
-#        id: cache-local-maven-repo
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~/.m2/repository/io/opentelemetry/
-#          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-#
-#      - name: Pull base image of Contract Tests Sample Apps
-#        run: docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine
-#
-#      - name: Build snapshot with Gradle
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          arguments: contractTests -PlocalDocker=true
+  # AppSignals Contract Tests
+  contract-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@v3
+        with:
+          registry: public.ecr.aws
+
+      # cache local patch outputs
+      - name: Cache local Maven repository
+        id: cache-local-maven-repo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
+      - name: Pull base image of Contract Tests Sample Apps
+        run: docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine
+
+      - name: Build snapshot with Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: contractTests -PlocalDocker=true
 
   application-signals-e2e-test:
     needs: [build]
@@ -231,17 +230,17 @@ jobs:
     with:
       adot-image-name: ${{ needs.build.outputs.staging-image }}
 
-#  publish-build-status:
-#    needs: [ build, contract-tests ]
-#    if: ${{ always() }}
-#    uses: ./.github/workflows/publish-status.yml
-#    with:
-#      namespace: 'ADOT/GitHubActions'
-#      repository: ${{ github.repository }}
-#      branch: ${{ github.ref_name }}
-#      workflow: main-build
-#      success: ${{  needs.build.result == 'success' &&
-#                    needs.contract-tests.result == 'success'  }}
-#      region: us-east-1
-#    secrets:
-#      roleArn: ${{ secrets.METRICS_ROLE_ARN }}
+  publish-build-status:
+    needs: [ build, contract-tests ]
+    if: ${{ always() }}
+    uses: ./.github/workflows/publish-status.yml
+    with:
+      namespace: 'ADOT/GitHubActions'
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      workflow: main-build
+      success: ${{  needs.build.result == 'success' &&
+                    needs.contract-tests.result == 'success'  }}
+      region: us-east-1
+    secrets:
+      roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ ARG ADOT_JAVA_VERSION
 COPY --from=builder /usr/src/cp-utility/bin/cp-utility /bin/cp
 
 
-COPY --chmod=go+r ./otelagent/build/libs/aws-opentelemetry-agent-${ADOT_JAVA_VERSION}.jar  /javaagent.jar
+COPY --chmod=0644 ./otelagent/build/libs/aws-opentelemetry-agent-${ADOT_JAVA_VERSION}.jar  /javaagent.jar


### PR DESCRIPTION
This PR do the following two things:
1. Fix [recent main build failure](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/10926150649/job/30330248240) by updating Dockerfile syntax.

2. Add ECS E2E test entry point into main build.

An example of succeed test workflow: 
https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/10926900740
(E2E operator test failure is expected, will plan on the effort fixing it).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
