### PR TITLE
Remove JVM metrics for CW JMX release

### DIFF
--- a/instrumentation/jmx-metrics/src/main/resources/jmx/rules/jvm.yaml
+++ b/instrumentation/jmx-metrics/src/main/resources/jmx/rules/jvm.yaml
@@ -58,9 +58,6 @@ rules:
     metricAttribute:
       name: param(name)
     mapping:
-      CollectionUsage.used:
-        metric: used_after_last_gc
-        desc: Memory used after the most recent gc event
       Usage.init:
         metric: init
         desc: The initial amount of memory that the JVM requests from the operating system for the memory pool
@@ -110,10 +107,6 @@ rules:
         metric: jvm.system.cpu.utilization
         desc: The current load of CPU in host
         unit: "1"
-      ProcessCpuTime:
-        metric: jvm.cpu.time
-        unit: ns
-        desc: CPU time used
       ProcessCpuLoad:
         metric: jvm.cpu.recent_utilization
         unit: "1"


### PR DESCRIPTION
*Issue #, if available:*
Remove JVM metrics that are only used by Application Signals runtime to unblock CW JMX release.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
