### PR TITLE
Update Dockerfile to use public ECR image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 # Stage 1: Build the cp-utility binary
-FROM rust:1.75 as builder
+FROM public.ecr.aws/docker/library/rust:1.75 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
Update Dockerfile to use public ECR image

*Issue #, if available:*

*Description of changes:*

Update Dockerfile to use public ECR image


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
