### PR TITLE
Switch isEmpty() to .isPresent() for Optionals Type

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -502,7 +502,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       remoteResourceIdentifier = getDbConnection(span);
     }
 
-    if (cloudformationPrimaryIdentifier.isEmpty()) {
+    if (!cloudformationPrimaryIdentifier.isPresent()) {
       cloudformationPrimaryIdentifier = remoteResourceIdentifier;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Main-build Enablement E2E tests started failing starting from this [PR](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/899). It was due to the usage of `isEmpty()` for Optional datatypes, which is available only from Java 11

*Description of changes:*
Change .isEmpty() to .isPresent() for optional types


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
