### PR TITLE
Comment out E2E Operator Test

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -157,19 +157,22 @@ jobs:
             echo "ref=terraform" >> $GITHUB_OUTPUT
           fi
 
-  e2e-operator-test:
-    concurrency:
-      group: e2e-adot-agent-operator-test
-      cancel-in-progress: false
-    needs: [ build, create-test-ref, default-region-output ]
-    uses: ./.github/workflows/e2e-tests-with-operator.yml
-    secrets: inherit
-    with:
-      aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
-      image_tag: ${{ needs.build.outputs.java_agent_tag }}
-      image_uri: ${{ needs.build.outputs.staging_registry }}/${{ needs.build.outputs.staging_repository }}
-      test_ref: ${{ needs.create-test-ref.outputs.testRef }}
-      caller-workflow-name: 'main-build'
+  # TODO: This test is currently failing due to infrastructure problems. Commented it out because we are ignoring it during release. 
+  # Need to fix in the future. Ex: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/11525535146/job/32241628521
+
+  # e2e-operator-test:
+  #   concurrency:
+  #     group: e2e-adot-agent-operator-test
+  #     cancel-in-progress: false
+  #   needs: [ build, create-test-ref, default-region-output ]
+  #   uses: ./.github/workflows/e2e-tests-with-operator.yml
+  #   secrets: inherit
+  #   with:
+  #     aws-region: ${{ needs.default-region-output.outputs.aws_default_region }}
+  #     image_tag: ${{ needs.build.outputs.java_agent_tag }}
+  #     image_uri: ${{ needs.build.outputs.staging_registry }}/${{ needs.build.outputs.staging_repository }}
+  #     test_ref: ${{ needs.create-test-ref.outputs.testRef }}
+  #     caller-workflow-name: 'main-build'
 
   # E2E tests where SampleApp has Java Agent
   e2e-test:


### PR DESCRIPTION
*Issue #, if available:*
E2E Operator test is currently failing due to a known issue. We do not have an immediate plan to fix it so commenting it out for now. 

Example failed run: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/11525535146/job/32241628521

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
