### PR TITLE
Adding UdpExporter for Otlp spans

### DIFF
--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -41,14 +41,14 @@ dependencies {
   // Export configuration
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
   // For Udp emitter
-  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
-  implementation("io.opentelemetry:opentelemetry-exporter-common")
+  compileOnly("io.opentelemetry:opentelemetry-exporter-otlp-common")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("io.opentelemetry:opentelemetry-extension-aws")
   testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators")
   testImplementation("com.google.guava:guava")
+  testRuntimeOnly("io.opentelemetry:opentelemetry-exporter-otlp-common")
 
   compileOnly("com.google.code.findbugs:jsr305:3.0.2")
   testImplementation("org.mockito:mockito-core:5.3.1")

--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
   implementation("com.amazonaws:aws-java-sdk-core:1.12.773")
   // Export configuration
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
+  // For Udp emitter
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
+  implementation("io.opentelemetry:opentelemetry-exporter-common")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class OtlpUdpSpanExporter implements SpanExporter {
+
+  private static final Logger logger = Logger.getLogger(OtlpUdpSpanExporter.class.getName());
+  private static final String PROTOCOL_HEADER = "{\"format\": \"json\", \"version\": 1}";
+  private static final char PROTOCOL_DELIMITER = '\n';
+  private static final String FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX = "T1S";
+  private static final String FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX = "T1U";
+
+  private final AtomicBoolean isShutdown = new AtomicBoolean();
+
+  private final UdpSender sender;
+  private final boolean sampled;
+
+  OtlpUdpSpanExporter(UdpSender sender, boolean sampled) {
+    this.sender = sender;
+    this.sampled = sampled;
+  }
+
+  @Override
+  public CompletableResultCode export(Collection<SpanData> spans) {
+    if (isShutdown.get()) {
+      return CompletableResultCode.ofFailure();
+    }
+
+    TraceRequestMarshaler exportRequest = TraceRequestMarshaler.create(spans);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try {
+      exportRequest.writeBinaryTo(baos);
+      String payload =
+          PROTOCOL_HEADER
+              + PROTOCOL_DELIMITER
+              + (sampled
+                  ? FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX
+                  : FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX)
+              + Base64.getEncoder().encodeToString(baos.toByteArray());
+      sender.send(payload.getBytes(StandardCharsets.UTF_8));
+      System.out.println("Sending::: " + payload); // TODO: remove
+      return CompletableResultCode.ofSuccess();
+    } catch (Exception e) {
+      logger.log(Level.SEVERE, "Failed to export spans. Error: " + e.getMessage(), e);
+      return CompletableResultCode.ofFailure();
+    }
+  }
+
+  @Override
+  public CompletableResultCode flush() {
+    return CompletableResultCode.ofSuccess();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    if (!isShutdown.compareAndSet(false, true)) {
+      logger.log(Level.INFO, "Calling shutdown() multiple times.");
+      return CompletableResultCode.ofSuccess();
+    }
+    return sender.shutdown();
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporter.java
@@ -28,12 +28,26 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.Immutable;
 
+/**
+ * Exports spans via UDP, using OpenTelemetry's protobuf model. The protobuf modelled spans are
+ * Base64 encoded and prefixed with AWS X-Ray specific information before being sent over to {@link
+ * UdpSender}.
+ *
+ * <p>This exporter is NOT meant for generic use since the payload is prefixed with AWS X-Ray
+ * specific information.
+ */
 @Immutable
-public class OtlpUdpSpanExporter implements SpanExporter {
+class OtlpUdpSpanExporter implements SpanExporter {
 
   private static final Logger logger = Logger.getLogger(OtlpUdpSpanExporter.class.getName());
+
+  // The protocol header and delimiter is required for sending data to X-Ray Daemon or when running
+  // in Lambda.
+  // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-daemon
   private static final String PROTOCOL_HEADER = "{\"format\": \"json\", \"version\": 1}";
   private static final char PROTOCOL_DELIMITER = '\n';
+
+  // These prefixes help the backend identify if the spans payload is sampled or not.
   private static final String FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX = "T1S";
   private static final String FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX = "T1U";
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporter.java
@@ -65,7 +65,6 @@ public class OtlpUdpSpanExporter implements SpanExporter {
                   : FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX)
               + Base64.getEncoder().encodeToString(baos.toByteArray());
       sender.send(payload.getBytes(StandardCharsets.UTF_8));
-      System.out.println("Sending::: " + payload); // TODO: remove
       return CompletableResultCode.ofSuccess();
     } catch (Exception e) {
       logger.log(Level.SEVERE, "Failed to export spans. Error: " + e.getMessage(), e);
@@ -75,6 +74,7 @@ public class OtlpUdpSpanExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode flush() {
+    // TODO: implement
     return CompletableResultCode.ofSuccess();
   }
 
@@ -85,5 +85,15 @@ public class OtlpUdpSpanExporter implements SpanExporter {
       return CompletableResultCode.ofSuccess();
     }
     return sender.shutdown();
+  }
+
+  // Visible for testing
+  UdpSender getSender() {
+    return sender;
+  }
+
+  // Visible for testing
+  boolean isSampled() {
+    return sampled;
   }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.SocketException;
 
-public final class OtlpUdpSpanExporterBuilder {
+final class OtlpUdpSpanExporterBuilder {
 
   private static final String DEFAULT_HOST = "127.0.0.1";
   private static final int DEFAULT_PORT = 2000;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
@@ -17,15 +17,23 @@ package software.amazon.opentelemetry.javaagent.providers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.net.SocketException;
-
 final class OtlpUdpSpanExporterBuilder {
 
   private static final String DEFAULT_HOST = "127.0.0.1";
   private static final int DEFAULT_PORT = 2000;
 
+  // The protocol header and delimiter is required for sending data to X-Ray Daemon or when running
+  // in Lambda.
+  // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-daemon
+  private static final String PROTOCOL_HEADER = "{\"format\": \"json\", \"version\": 1}";
+  private static final char PROTOCOL_DELIMITER = '\n';
+
+  // These prefixes help the backend identify if the spans payload is sampled or not.
+  private static final String FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX = "T1S";
+  private static final String FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX = "T1U";
+
   private UdpSender sender;
-  private boolean sampled = true;
+  private String tracePayloadPrefix = FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX;
 
   public OtlpUdpSpanExporterBuilder setEndpoint(String endpoint) {
     requireNonNull(endpoint, "endpoint must not be null");
@@ -40,20 +48,20 @@ final class OtlpUdpSpanExporterBuilder {
     return this;
   }
 
-  public OtlpUdpSpanExporterBuilder setSampled(boolean sampled) {
-    this.sampled = sampled;
+  public OtlpUdpSpanExporterBuilder setPayloadSampleDecision(TracePayloadSampleDecision decision) {
+    this.tracePayloadPrefix =
+        decision == TracePayloadSampleDecision.SAMPLED
+            ? FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX
+            : FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX;
     return this;
   }
 
   public OtlpUdpSpanExporter build() {
     if (sender == null) {
-      try {
-        this.sender = new UdpSender(DEFAULT_HOST, DEFAULT_PORT);
-      } catch (SocketException e) {
-        throw new IllegalStateException("Failed to create OtlpUdpSpanExporter", e);
-      }
+      this.sender = new UdpSender(DEFAULT_HOST, DEFAULT_PORT);
     }
-    return new OtlpUdpSpanExporter(this.sender, this.sampled);
+    return new OtlpUdpSpanExporter(
+        this.sender, PROTOCOL_HEADER + PROTOCOL_DELIMITER + tracePayloadPrefix);
   }
 
   // Only for testing
@@ -61,4 +69,9 @@ final class OtlpUdpSpanExporterBuilder {
     this.sender = sender;
     return this;
   }
+}
+
+enum TracePayloadSampleDecision {
+  SAMPLED,
+  UNSAMPLED
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.SocketException;
+
+public final class OtlpUdpSpanExporterBuilder {
+
+  private static final String DEFAULT_HOST = "127.0.0.1";
+  private static final int DEFAULT_PORT = 2000;
+
+  private UdpSender sender;
+  private boolean sampled = true;
+
+  public OtlpUdpSpanExporterBuilder setEndpoint(String endpoint) {
+    requireNonNull(endpoint, "endpoint must not be null");
+    try {
+      String[] parts = endpoint.split(":");
+      String host = parts[0];
+      int port = Integer.parseInt(parts[1]);
+      this.sender = new UdpSender(host, port);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid endpoint, must be a valid URL: " + endpoint, e);
+    }
+    return this;
+  }
+
+  public OtlpUdpSpanExporterBuilder setSampled(boolean sampled) {
+    this.sampled = sampled;
+    return this;
+  }
+
+  public OtlpUdpSpanExporter build() {
+    if (sender == null) {
+      try {
+        this.sender = new UdpSender(DEFAULT_HOST, DEFAULT_PORT);
+      } catch (SocketException e) {
+        throw new IllegalStateException("Failed to create OtlpUdpSpanExporter", e);
+      }
+    }
+    return new OtlpUdpSpanExporter(this.sender, this.sampled);
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpUdpSpanExporterBuilder.java
@@ -55,4 +55,10 @@ public final class OtlpUdpSpanExporterBuilder {
     }
     return new OtlpUdpSpanExporter(this.sender, this.sampled);
   }
+
+  // Only for testing
+  OtlpUdpSpanExporterBuilder setSender(UdpSender sender) {
+    this.sender = sender;
+    return this;
+  }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
@@ -58,4 +58,9 @@ public class UdpSender {
       logger.log(Level.SEVERE, "Exception while sending data.", e);
     }
   }
+
+  // Visible for testing
+  InetSocketAddress getEndpoint() {
+    return endpoint;
+  }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
@@ -34,7 +34,7 @@ class UdpSender {
   private DatagramSocket socket;
   private final InetSocketAddress endpoint;
 
-  public UdpSender(String host, int port) throws SocketException {
+  public UdpSender(String host, int port) {
     this.endpoint = new InetSocketAddress(host, port);
     try {
       this.socket = new DatagramSocket();
@@ -45,6 +45,9 @@ class UdpSender {
 
   public CompletableResultCode shutdown() {
     try {
+      if (socket == null) {
+        return CompletableResultCode.ofSuccess();
+      }
       socket.close();
       return CompletableResultCode.ofSuccess();
     } catch (Exception e) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class UdpSender {
+  private static final Logger logger = Logger.getLogger(UdpSender.class.getName());
+
+  private final DatagramSocket socket;
+  private final InetSocketAddress endpoint;
+
+  public UdpSender(String host, int port) throws SocketException {
+    this.endpoint = new InetSocketAddress(host, port);
+    try {
+      socket = new DatagramSocket();
+    } catch (SocketException e) {
+      logger.log(Level.SEVERE, "Exception while instantiating UdpSender socket.", e);
+      throw e;
+    }
+  }
+
+  public CompletableResultCode shutdown() {
+    try {
+      socket.close();
+      return CompletableResultCode.ofSuccess();
+    } catch (Exception e) {
+      logger.log(Level.SEVERE, "Exception while closing UdpSender socket.", e);
+      return CompletableResultCode.ofFailure();
+    }
+  }
+
+  public void send(byte[] data) {
+    DatagramPacket packet = new DatagramPacket(data, data.length, endpoint);
+    try {
+      socket.send(packet);
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Exception while sending data.", e);
+    }
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
@@ -24,19 +24,22 @@ import java.net.SocketException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class UdpSender {
+/**
+ * This class represents a UDP sender that sends data to a specified endpoint. It is used to send
+ * data to a remote host and port using UDP protocol.
+ */
+class UdpSender {
   private static final Logger logger = Logger.getLogger(UdpSender.class.getName());
 
-  private final DatagramSocket socket;
+  private DatagramSocket socket;
   private final InetSocketAddress endpoint;
 
   public UdpSender(String host, int port) throws SocketException {
     this.endpoint = new InetSocketAddress(host, port);
     try {
-      socket = new DatagramSocket();
+      this.socket = new DatagramSocket();
     } catch (SocketException e) {
       logger.log(Level.SEVERE, "Exception while instantiating UdpSender socket.", e);
-      throw e;
     }
   }
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/UdpSender.java
@@ -57,6 +57,10 @@ class UdpSender {
   }
 
   public void send(byte[] data) {
+    if (socket == null) {
+      logger.log(Level.WARNING, "UdpSender socket is null. Cannot send data.");
+      return;
+    }
     DatagramPacket packet = new DatagramPacket(data, data.length, endpoint);
     try {
       socket.send(packet);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/UdpExporterTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/UdpExporterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.*;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class UdpExporterTest {
+  private static final boolean CONTAINS_ATTRIBUTES = true;
+
+  @Test
+  public void testExporter() { // TODO: only for testing. remove.
+    //    Tracer tracer = GlobalOpenTelemetry.getTracer("My application");
+    Tracer tracer = OpenTelemetrySdk.builder().build().getTracer("hello");
+
+    Span mySpan = tracer.spanBuilder("DoTheLoop_3").startSpan();
+    int numIterations = 5;
+    mySpan.setAttribute("NumIterations", numIterations);
+    mySpan.setAttribute(AttributeKey.stringArrayKey("foo"), Arrays.asList("bar1", "bar2"));
+    try (var scope = mySpan.makeCurrent()) {
+      for (int i = 1; i <= numIterations; i++) {
+        System.out.println("i = " + i);
+      }
+    } finally {
+      mySpan.end();
+    }
+
+    OtlpUdpSpanExporter exporter = new OtlpUdpSpanExporterBuilder().build();
+
+    ReadableSpan readableSpan = (ReadableSpan) mySpan;
+    SpanData spanData = readableSpan.toSpanData();
+
+    exporter.export(Collections.singletonList(spanData));
+  }
+
+  @Test
+  public void testUdpExporter() {
+    // Add your test logic here
+    OtlpUdpSpanExporter exporter = new OtlpUdpSpanExporterBuilder().build();
+
+    // build test span
+    SpanContext parentSpanContextMock = mock(SpanContext.class);
+    Attributes spanAttributes = buildSpanAttributes(CONTAINS_ATTRIBUTES);
+    SpanData spanDataMock = buildSpanDataMock(spanAttributes);
+    when(spanDataMock.getParentSpanContext()).thenReturn(parentSpanContextMock);
+    SpanContext spanContextMock = mock(SpanContext.class);
+    when(spanContextMock.isValid()).thenReturn(true);
+    when(spanDataMock.getSpanContext()).thenReturn(spanContextMock);
+    TraceState traceState = TraceState.builder().build();
+    when(spanContextMock.getTraceState()).thenReturn(traceState);
+    StatusData statusData = StatusData.unset();
+    when(spanDataMock.getStatus()).thenReturn(statusData);
+    when(spanDataMock.getInstrumentationScopeInfo())
+        .thenReturn(InstrumentationScopeInfo.create("Dummy Scope"));
+
+    Resource testResource = Resource.empty();
+    when(spanDataMock.getResource()).thenReturn(testResource);
+
+    exporter.export(Collections.singletonList(spanDataMock));
+  }
+
+  private static Attributes buildSpanAttributes(boolean containsAttribute) {
+    if (containsAttribute) {
+      return Attributes.of(AttributeKey.stringKey("original key"), "original value");
+    } else {
+      return Attributes.empty();
+    }
+  }
+
+  private static SpanData buildSpanDataMock(Attributes spanAttributes) {
+    // Configure spanData
+    SpanData mockSpanData = mock(SpanData.class);
+    when(mockSpanData.getAttributes()).thenReturn(spanAttributes);
+    when(mockSpanData.getTotalAttributeCount()).thenReturn(spanAttributes.size());
+    when(mockSpanData.getKind()).thenReturn(SpanKind.SERVER);
+    when(mockSpanData.getParentSpanContext()).thenReturn(null);
+    return mockSpanData;
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/UdpExporterTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/UdpExporterTest.java
@@ -39,17 +39,20 @@ public class UdpExporterTest {
     assertThat(sender.getEndpoint().getHostName())
         .isEqualTo("localhost"); // getHostName implicitly converts 127.0.0.1 to localhost
     assertThat(sender.getEndpoint().getPort()).isEqualTo(2000);
-    assertThat(exporter.isSampled()).isTrue();
+    assertThat(exporter.getPayloadPrefix()).endsWith("T1S");
   }
 
   @Test
   public void testUdpExporterWithCustomEndpointAndSample() {
     OtlpUdpSpanExporter exporter =
-        new OtlpUdpSpanExporterBuilder().setEndpoint("somehost:1000").setSampled(false).build();
+        new OtlpUdpSpanExporterBuilder()
+            .setEndpoint("somehost:1000")
+            .setPayloadSampleDecision(TracePayloadSampleDecision.UNSAMPLED)
+            .build();
     UdpSender sender = exporter.getSender();
     assertThat(sender.getEndpoint().getHostName()).isEqualTo("somehost");
     assertThat(sender.getEndpoint().getPort()).isEqualTo(1000);
-    assertThat(exporter.isSampled()).isFalse();
+    assertThat(exporter.getPayloadPrefix()).endsWith("T1U");
   }
 
   @Test
@@ -94,7 +97,10 @@ public class UdpExporterTest {
     SpanData spanData = buildSpanDataMock();
 
     OtlpUdpSpanExporter exporter =
-        new OtlpUdpSpanExporterBuilder().setSender(senderMock).setSampled(false).build();
+        new OtlpUdpSpanExporterBuilder()
+            .setSender(senderMock)
+            .setPayloadSampleDecision(TracePayloadSampleDecision.UNSAMPLED)
+            .build();
     exporter.export(Collections.singletonList(spanData));
 
     verify(senderMock, times(1)).send(any(byte[].class));


### PR DESCRIPTION
### Description of changes:
Adding a new `SpanExporter` that can export spans to a configurable endpoint over UDP.
- The spans are first protobuf encoded, then base64 encoded, then prefixed with `T1S` or `T1U` (depending on sampled), and finally appended to the `{"format":"json","version":1}\n` string before being exported to the endpoint, default is `127.0.0.1:2000`.
- Related: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/232

### Testing:
Wrote a test to create and export a real span via X-Ray Daemon running locally.
  - Unit test
    ```java
    @Test
    public void testExporter() { // TODO: only for testing. remove.
    Tracer tracer = OpenTelemetrySdk.builder().build().getTracer("hello");

    Span mySpan = tracer.spanBuilder("DoTheLoop_5").startSpan();
    int numIterations = 5;
    mySpan.setAttribute("NumIterations", numIterations);
    mySpan.setAttribute(AttributeKey.stringArrayKey("foo"), Arrays.asList("bar1", "bar2"));
    try (var scope = mySpan.makeCurrent()) {
      for (int i = 1; i <= numIterations; i++) {
        System.out.println("i = " + i);
      }
    } finally {
      mySpan.end();
    }

    OtlpUdpSpanExporter exporter = new OtlpUdpSpanExporterBuilder().build();

    ReadableSpan readableSpan = (ReadableSpan) mySpan;
    SpanData spanData = readableSpan.toSpanData();

    exporter.export(Collections.singletonList(spanData));
    }
    ```
  
  - Observed trace data in X-Ray service
     ```json
    {
    "Id": "1-246f2975-8c1d813535803fea548be818",
    "Duration": 0.003,
    "LimitExceeded": false,
    "Segments": [
        {
            "Id": "455654be8f47d669",
            "Document": {
                "id": "455654be8f47d669",
                "name": "DoTheLoop_5",
                "start_time": 1730828092.934588,
                "trace_id": "1-246f2975-8c1d813535803fea548be818",
                "end_time": 1730828092.9371202,
                "annotations": {
                    "span.name": "DoTheLoop_5",
                    "span.kind": "INTERNAL"
                },
                "metadata": {
                    "telemetry.sdk.language": "java",
                    "service.name": "unknown_service:java",
                    "foo": [
                        "bar1",
                        "bar2"
                    ],
                    "NumIterations": 5,
                    "telemetry.sdk.version": "1.34.1",
                    "telemetry.sdk.name": "opentelemetry"
                }
            }
        }
    ]
    }
    ```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
