### PR TITLE
Adding AwsUnsampledOnlySpanProcessor to export batches of unsampled spans

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -70,6 +70,9 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
       AttributeKey.stringKey("aws.lambda.resource_mapping.id");
 
+  static final AttributeKey<Boolean> AWS_TRACE_FLAG_SAMPLED =
+      AttributeKey.booleanKey("aws.trace.flag.sampled");
+
   // use the same AWS Resource attribute name defined by OTel java auto-instr for aws_sdk_v_1_1
   // TODO: all AWS specific attributes should be defined in semconv package and reused cross all
   // otel packages. Related sim -

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
@@ -57,12 +57,12 @@ final class AwsUnsampledOnlySpanProcessor implements SpanProcessor {
 
   @Override
   public boolean isStartRequired() {
-    return delegate.isStartRequired();
+    return true;
   }
 
   @Override
   public boolean isEndRequired() {
-    return delegate.isEndRequired();
+    return true;
   }
 
   @Override

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
@@ -21,6 +21,10 @@ import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
+/**
+ * {@link SpanProcessor} that only exports unsampled spans in a batch via a delegated @{link BatchSpanProcessor}.
+ * The processor also adds an attribute to each processed span to indicate that it was sampled or not.
+ */
 final class AwsUnsampledOnlySpanProcessor implements SpanProcessor {
 
   private final SpanProcessor delegate;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+
+final class AwsUnsampledOnlySpanProcessor implements SpanProcessor {
+
+  private final SpanProcessor delegate;
+
+  AwsUnsampledOnlySpanProcessor(SpanProcessor delegate) {
+    this.delegate = delegate;
+  }
+
+  public static AwsUnsampledOnlySpanProcessorBuilder builder() {
+    return new AwsUnsampledOnlySpanProcessorBuilder();
+  }
+
+  @Override
+  public void onStart(Context parentContext, ReadWriteSpan span) {
+    if (span.getSpanContext().isSampled()) {
+      span.setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, true);
+    } else {
+      span.setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, false);
+    }
+    delegate.onStart(parentContext, span);
+  }
+
+  @Override
+  public void onEnd(ReadableSpan span) {
+    if (!span.getSpanContext().isSampled()) {
+      delegate.onEnd(span);
+    }
+  }
+
+  @Override
+  public boolean isStartRequired() {
+    return delegate.isStartRequired();
+  }
+
+  @Override
+  public boolean isEndRequired() {
+    return delegate.isEndRequired();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return delegate.shutdown();
+  }
+
+  @Override
+  public CompletableResultCode forceFlush() {
+    return delegate.forceFlush();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  // Visible for testing
+  SpanProcessor getDelegate() {
+    return delegate;
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
@@ -22,8 +22,9 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
 /**
- * {@link SpanProcessor} that only exports unsampled spans in a batch via a delegated @{link BatchSpanProcessor}.
- * The processor also adds an attribute to each processed span to indicate that it was sampled or not.
+ * {@link SpanProcessor} that only exports unsampled spans in a batch via a delegated @{link
+ * BatchSpanProcessor}. The processor also adds an attribute to each processed span to indicate that
+ * it was sampled or not.
  */
 final class AwsUnsampledOnlySpanProcessor implements SpanProcessor {
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
@@ -40,9 +40,7 @@ final class AwsUnsampledOnlySpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
-    if (span.getSpanContext().isSampled()) {
-      span.setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, true);
-    } else {
+    if (!span.getSpanContext().isSampled()) {
       span.setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, false);
     }
     delegate.onStart(parentContext, span);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
@@ -34,11 +34,6 @@ final class AwsUnsampledOnlySpanProcessorBuilder {
     return this;
   }
 
-  public AwsUnsampledOnlySpanProcessorBuilder setMaxQueueSize(int maxQueueSize) {
-
-    return this;
-  }
-
   public AwsUnsampledOnlySpanProcessor build() {
     BatchSpanProcessor bsp =
         BatchSpanProcessor.builder(exporter).setExportUnsampledSpans(true).build();

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+import static java.util.Objects.requireNonNull;
+
+final class AwsUnsampledOnlySpanProcessorBuilder {
+
+  // Default exporter is OtlpUdpSpanExporter with unsampled payload prefix
+  private SpanExporter exporter = new OtlpUdpSpanExporterBuilder()
+          .setPayloadSampleDecision(TracePayloadSampleDecision.UNSAMPLED)
+          .build();
+
+  public AwsUnsampledOnlySpanProcessorBuilder setSpanExporter(SpanExporter exporter) {
+    requireNonNull(exporter, "exporter cannot be null");
+    this.exporter = exporter;
+    return this;
+  }
+
+  public AwsUnsampledOnlySpanProcessorBuilder setMaxQueueSize(int maxQueueSize) {
+
+    return this;
+  }
+
+  public AwsUnsampledOnlySpanProcessor build() {
+  BatchSpanProcessor bsp =
+        BatchSpanProcessor.builder(exporter).setExportUnsampledSpans(true).build();
+    return new AwsUnsampledOnlySpanProcessor(bsp);
+  }
+
+  SpanExporter getSpanExporter() {
+    return exporter;
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
@@ -15,16 +15,16 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessorBuilder;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
-
 import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 final class AwsUnsampledOnlySpanProcessorBuilder {
 
   // Default exporter is OtlpUdpSpanExporter with unsampled payload prefix
-  private SpanExporter exporter = new OtlpUdpSpanExporterBuilder()
+  private SpanExporter exporter =
+      new OtlpUdpSpanExporterBuilder()
           .setPayloadSampleDecision(TracePayloadSampleDecision.UNSAMPLED)
           .build();
 
@@ -40,7 +40,7 @@ final class AwsUnsampledOnlySpanProcessorBuilder {
   }
 
   public AwsUnsampledOnlySpanProcessor build() {
-  BatchSpanProcessor bsp =
+    BatchSpanProcessor bsp =
         BatchSpanProcessor.builder(exporter).setExportUnsampledSpans(true).build();
     return new AwsUnsampledOnlySpanProcessor(bsp);
   }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
@@ -88,8 +88,8 @@ public class AwsUnsampledOnlySpanProcessorTest {
     AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
     processor.onStart(parentContextMock, spanMock);
 
-    // verify setAttribute was called with the correct arguments
-    verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, true);
+    // verify setAttribute was never called
+    verify(spanMock, never()).setAttribute(any(), anyBoolean());
   }
 
   @Test

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
@@ -1,0 +1,118 @@
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class AwsUnsampledOnlySpanProcessorTest {
+
+    @Test
+    public void testDefaultSpanProcessor() {
+        AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor.builder();
+        AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
+
+        assertThat(builder.getSpanExporter()).isInstanceOf(OtlpUdpSpanExporter.class);
+        SpanProcessor delegate = unsampledSP.getDelegate();
+        assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
+        BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
+        String delegateBspString = delegateBsp.toString();
+        assertThat(delegateBspString).contains("spanExporter=software.amazon.opentelemetry.javaagent.providers.OtlpUdpSpanExporter");
+        assertThat(delegateBspString).contains("exportUnsampledSpans=true");
+    }
+
+    @Test
+    public void testSpanProcessorWithExporter() {
+        AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor
+                .builder()
+                .setSpanExporter(InMemorySpanExporter.create());
+        AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
+
+        assertThat(builder.getSpanExporter()).isInstanceOf(InMemorySpanExporter.class);
+        SpanProcessor delegate = unsampledSP.getDelegate();
+        assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
+        BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
+        String delegateBspString = delegateBsp.toString();
+        assertThat(delegateBspString).contains("spanExporter=io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter");
+        assertThat(delegateBspString).contains("exportUnsampledSpans=true");
+    }
+
+    @Test
+    public void testStartAddsAttributeToSampledSpan() {
+        SpanContext mockSpanContext = mock(SpanContext.class);
+        when(mockSpanContext.isSampled()).thenReturn(true);
+        Context parentContextMock = mock(Context.class);
+        ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
+        when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
+
+        AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+        processor.onStart(parentContextMock, spanMock);
+
+        //verify setAttribute was called with the correct arguments
+        verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, true);
+    }
+
+    @Test
+    public void testStartAddsAttributeToUnsampledSpan() {
+        SpanContext mockSpanContext = mock(SpanContext.class);
+        when(mockSpanContext.isSampled()).thenReturn(false);
+        Context parentContextMock = mock(Context.class);
+        ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
+        when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
+
+        AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+        processor.onStart(parentContextMock, spanMock);
+
+        //verify setAttribute was called with the correct arguments
+        verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, false);
+    }
+
+    @Test
+    public void testExportsOnlyUnsampledSpans() {
+        SpanExporter mockExporter = mock(SpanExporter.class);
+        when(mockExporter.export(anyCollection())).thenReturn(CompletableResultCode.ofSuccess());
+
+        BatchSpanProcessor delegate = BatchSpanProcessor.builder(mockExporter)
+                .setExportUnsampledSpans(true)
+                .setMaxExportBatchSize(1)
+                .setMaxQueueSize(1)
+                .build();
+
+        AwsUnsampledOnlySpanProcessor processor = new AwsUnsampledOnlySpanProcessor(delegate);
+
+        // unsampled span
+        SpanContext mockSpanContextUnsampled = mock(SpanContext.class);
+        when(mockSpanContextUnsampled.isSampled()).thenReturn(false);
+        ReadableSpan mockSpanUnsampled = mock(ReadableSpan.class);
+        when(mockSpanUnsampled.getSpanContext()).thenReturn(mockSpanContextUnsampled);
+
+        // sampled span
+        SpanContext mockSpanContextSampled = mock(SpanContext.class);
+        when(mockSpanContextSampled.isSampled()).thenReturn(true);
+        ReadableSpan mockSpanSampled = mock(ReadableSpan.class);
+        when(mockSpanSampled.getSpanContext()).thenReturn(mockSpanContextSampled);
+
+        // flush the unsampled span and verify export was called once
+        processor.onEnd(mockSpanUnsampled);
+        processor.forceFlush();
+        verify(mockExporter, times(1)).export(anyCollection());
+
+        // flush the sampled span and verify export was not called again
+        processor.onEnd(mockSpanSampled);
+        processor.forceFlush();
+        verify(mockExporter, times(1)).export(anyCollection());
+    }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -7,112 +25,105 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-
-import java.util.Collection;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 public class AwsUnsampledOnlySpanProcessorTest {
 
-    @Test
-    public void testDefaultSpanProcessor() {
-        AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor.builder();
-        AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
+  @Test
+  public void testDefaultSpanProcessor() {
+    AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor.builder();
+    AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
 
-        assertThat(builder.getSpanExporter()).isInstanceOf(OtlpUdpSpanExporter.class);
-        SpanProcessor delegate = unsampledSP.getDelegate();
-        assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
-        BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
-        String delegateBspString = delegateBsp.toString();
-        assertThat(delegateBspString).contains("spanExporter=software.amazon.opentelemetry.javaagent.providers.OtlpUdpSpanExporter");
-        assertThat(delegateBspString).contains("exportUnsampledSpans=true");
-    }
+    assertThat(builder.getSpanExporter()).isInstanceOf(OtlpUdpSpanExporter.class);
+    SpanProcessor delegate = unsampledSP.getDelegate();
+    assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
+    BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
+    String delegateBspString = delegateBsp.toString();
+    assertThat(delegateBspString)
+        .contains(
+            "spanExporter=software.amazon.opentelemetry.javaagent.providers.OtlpUdpSpanExporter");
+    assertThat(delegateBspString).contains("exportUnsampledSpans=true");
+  }
 
-    @Test
-    public void testSpanProcessorWithExporter() {
-        AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor
-                .builder()
-                .setSpanExporter(InMemorySpanExporter.create());
-        AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
+  @Test
+  public void testSpanProcessorWithExporter() {
+    AwsUnsampledOnlySpanProcessorBuilder builder =
+        AwsUnsampledOnlySpanProcessor.builder().setSpanExporter(InMemorySpanExporter.create());
+    AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
 
-        assertThat(builder.getSpanExporter()).isInstanceOf(InMemorySpanExporter.class);
-        SpanProcessor delegate = unsampledSP.getDelegate();
-        assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
-        BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
-        String delegateBspString = delegateBsp.toString();
-        assertThat(delegateBspString).contains("spanExporter=io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter");
-        assertThat(delegateBspString).contains("exportUnsampledSpans=true");
-    }
+    assertThat(builder.getSpanExporter()).isInstanceOf(InMemorySpanExporter.class);
+    SpanProcessor delegate = unsampledSP.getDelegate();
+    assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
+    BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
+    String delegateBspString = delegateBsp.toString();
+    assertThat(delegateBspString)
+        .contains("spanExporter=io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter");
+    assertThat(delegateBspString).contains("exportUnsampledSpans=true");
+  }
 
-    @Test
-    public void testStartAddsAttributeToSampledSpan() {
-        SpanContext mockSpanContext = mock(SpanContext.class);
-        when(mockSpanContext.isSampled()).thenReturn(true);
-        Context parentContextMock = mock(Context.class);
-        ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
-        when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
+  @Test
+  public void testStartAddsAttributeToSampledSpan() {
+    SpanContext mockSpanContext = mock(SpanContext.class);
+    when(mockSpanContext.isSampled()).thenReturn(true);
+    Context parentContextMock = mock(Context.class);
+    ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
+    when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
 
-        AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
-        processor.onStart(parentContextMock, spanMock);
+    AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    processor.onStart(parentContextMock, spanMock);
 
-        //verify setAttribute was called with the correct arguments
-        verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, true);
-    }
+    // verify setAttribute was called with the correct arguments
+    verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, true);
+  }
 
-    @Test
-    public void testStartAddsAttributeToUnsampledSpan() {
-        SpanContext mockSpanContext = mock(SpanContext.class);
-        when(mockSpanContext.isSampled()).thenReturn(false);
-        Context parentContextMock = mock(Context.class);
-        ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
-        when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
+  @Test
+  public void testStartAddsAttributeToUnsampledSpan() {
+    SpanContext mockSpanContext = mock(SpanContext.class);
+    when(mockSpanContext.isSampled()).thenReturn(false);
+    Context parentContextMock = mock(Context.class);
+    ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
+    when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
 
-        AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
-        processor.onStart(parentContextMock, spanMock);
+    AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    processor.onStart(parentContextMock, spanMock);
 
-        //verify setAttribute was called with the correct arguments
-        verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, false);
-    }
+    // verify setAttribute was called with the correct arguments
+    verify(spanMock, times(1)).setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, false);
+  }
 
-    @Test
-    public void testExportsOnlyUnsampledSpans() {
-        SpanExporter mockExporter = mock(SpanExporter.class);
-        when(mockExporter.export(anyCollection())).thenReturn(CompletableResultCode.ofSuccess());
+  @Test
+  public void testExportsOnlyUnsampledSpans() {
+    SpanExporter mockExporter = mock(SpanExporter.class);
+    when(mockExporter.export(anyCollection())).thenReturn(CompletableResultCode.ofSuccess());
 
-        BatchSpanProcessor delegate = BatchSpanProcessor.builder(mockExporter)
-                .setExportUnsampledSpans(true)
-                .setMaxExportBatchSize(1)
-                .setMaxQueueSize(1)
-                .build();
+    AwsUnsampledOnlySpanProcessor processor =
+        AwsUnsampledOnlySpanProcessor.builder().setSpanExporter(mockExporter).build();
 
-        AwsUnsampledOnlySpanProcessor processor = new AwsUnsampledOnlySpanProcessor(delegate);
+    BatchSpanProcessor delegate =
+        BatchSpanProcessor.builder(mockExporter).setExportUnsampledSpans(true).build();
 
-        // unsampled span
-        SpanContext mockSpanContextUnsampled = mock(SpanContext.class);
-        when(mockSpanContextUnsampled.isSampled()).thenReturn(false);
-        ReadableSpan mockSpanUnsampled = mock(ReadableSpan.class);
-        when(mockSpanUnsampled.getSpanContext()).thenReturn(mockSpanContextUnsampled);
+    // unsampled span
+    SpanContext mockSpanContextUnsampled = mock(SpanContext.class);
+    when(mockSpanContextUnsampled.isSampled()).thenReturn(false);
+    ReadableSpan mockSpanUnsampled = mock(ReadableSpan.class);
+    when(mockSpanUnsampled.getSpanContext()).thenReturn(mockSpanContextUnsampled);
 
-        // sampled span
-        SpanContext mockSpanContextSampled = mock(SpanContext.class);
-        when(mockSpanContextSampled.isSampled()).thenReturn(true);
-        ReadableSpan mockSpanSampled = mock(ReadableSpan.class);
-        when(mockSpanSampled.getSpanContext()).thenReturn(mockSpanContextSampled);
+    // sampled span
+    SpanContext mockSpanContextSampled = mock(SpanContext.class);
+    when(mockSpanContextSampled.isSampled()).thenReturn(true);
+    ReadableSpan mockSpanSampled = mock(ReadableSpan.class);
+    when(mockSpanSampled.getSpanContext()).thenReturn(mockSpanContextSampled);
 
-        // flush the unsampled span and verify export was called once
-        processor.onEnd(mockSpanUnsampled);
-        processor.forceFlush();
-        verify(mockExporter, times(1)).export(anyCollection());
+    // flush the unsampled span and verify export was called once
+    processor.onEnd(mockSpanUnsampled);
+    processor.forceFlush();
+    verify(mockExporter, times(1)).export(anyCollection());
 
-        // flush the sampled span and verify export was not called again
-        processor.onEnd(mockSpanSampled);
-        processor.forceFlush();
-        verify(mockExporter, times(1)).export(anyCollection());
-    }
+    // flush the sampled span and verify export was not called again
+    processor.onEnd(mockSpanSampled);
+    processor.forceFlush();
+    verify(mockExporter, times(1)).export(anyCollection());
+  }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
@@ -34,6 +34,18 @@ import org.junit.jupiter.api.Test;
 public class AwsUnsampledOnlySpanProcessorTest {
 
   @Test
+  public void testIsStartRequired() {
+    SpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    assertThat(processor.isStartRequired()).isTrue();
+  }
+
+  @Test
+  public void testIsEndRequired() {
+    SpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    assertThat(processor.isEndRequired()).isTrue();
+  }
+
+  @Test
   public void testDefaultSpanProcessor() {
     AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor.builder();
     AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();


### PR DESCRIPTION
#### Description of changes

Following the approach as ADOT Python: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/247. Note that the span attribute key was [later changed to `aws.trace.flag.sampled`](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/260).

Introducing `AwsUnsampledOnlySpanProcessor` that can be appended to a `TracerProvider`. This span processor wraps a `BatchSpanProcessor` for delegating all the operations after processing. The `AwsUnsampledOnlySpanProcessor` does 2 things:
  - onStart - Sets the `aws.trace.flag.sampled` span attribute on each span.
  - onEnd - If the span is unsampled, only then it is delegated to the BSP, otherwise it is dropped.


#### Testing
##### Setup
```
@Test
  public void testExportingUnsampledSpan() {
    SpanProcessor unsampledSpanProcessor = AwsUnsampledOnlySpanProcessor.builder().build();

    SdkTracerProvider tp =
        SdkTracerProvider.builder()
            .addSpanProcessor(unsampledSpanProcessor)
            .setSampler(AlwaysRecordSampler.create(Sampler.alwaysOff())) // change to alwaysOn to sample
            .build();

    Tracer tracer = OpenTelemetrySdk.builder().setTracerProvider(tp).build().getTracer("hello");

    Span span = tracer.spanBuilder("MySpan_unsampled_006").startSpan();
    span.setAttribute("foo", "bar");
    span.end();

    unsampledSpanProcessor.forceFlush();

    // add 5 seconds delay
    try {
      Thread.sleep(5000);
    } catch (InterruptedException e) {
      e.printStackTrace();
    }
  }
```

##### Observations:
- Unsampled span is exported in a batch.
- Switching to `alwaysOn` sampler, the sampled span is not exported at all.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
