### PR TITLE
Configure SDK when running in Lambda environment

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -96,6 +96,8 @@ public class AwsApplicationSignalsCustomizerProvider
   private static final String DEFAULT_UDP_ENDPOINT = "127.0.0.1:2000";
   private static final String OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG =
       "otel.java.disabled.resource.providers";
+  private static final String OTEL_BSP_MAX_EXPORT_BATCH_SIZE_CONFIG =
+      "otel.bsp.max.export.batch.size";
 
   // UDP packet can be upto 64KB. To limit the packet size, we limit the exported batch size.
   // This is a bit of a magic number, as there is no simple way to tell how many spans can make a
@@ -164,7 +166,7 @@ public class AwsApplicationSignalsCustomizerProvider
 
       // Set the max export batch size for BatchSpanProcessors
       propsOverride.put(
-          "otel.bsp.max.export.batch.size", String.valueOf(LAMBDA_SPAN_EXPORT_BATCH_SIZE));
+          OTEL_BSP_MAX_EXPORT_BATCH_SIZE_CONFIG, String.valueOf(LAMBDA_SPAN_EXPORT_BATCH_SIZE));
 
       return propsOverride;
     }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -41,7 +41,14 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessor.java
@@ -34,10 +34,6 @@ final class AwsUnsampledOnlySpanProcessor implements SpanProcessor {
     this.delegate = delegate;
   }
 
-  public static AwsUnsampledOnlySpanProcessorBuilder builder() {
-    return new AwsUnsampledOnlySpanProcessorBuilder();
-  }
-
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
     if (!span.getSpanContext().isSampled()) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
@@ -21,6 +21,9 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 final class AwsUnsampledOnlySpanProcessorBuilder {
+  public static AwsUnsampledOnlySpanProcessorBuilder create() {
+    return new AwsUnsampledOnlySpanProcessorBuilder();
+  }
 
   // Default exporter is OtlpUdpSpanExporter with unsampled payload prefix
   private SpanExporter exporter =

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorBuilder.java
@@ -31,18 +31,30 @@ final class AwsUnsampledOnlySpanProcessorBuilder {
           .setPayloadSampleDecision(TracePayloadSampleDecision.UNSAMPLED)
           .build();
 
+  // Default batch size to be same as Otel BSP default
+  private int maxExportBatchSize = 512;
+
   public AwsUnsampledOnlySpanProcessorBuilder setSpanExporter(SpanExporter exporter) {
     requireNonNull(exporter, "exporter cannot be null");
     this.exporter = exporter;
     return this;
   }
 
+  public AwsUnsampledOnlySpanProcessorBuilder setMaxExportBatchSize(int maxExportBatchSize) {
+    this.maxExportBatchSize = maxExportBatchSize;
+    return this;
+  }
+
   public AwsUnsampledOnlySpanProcessor build() {
     BatchSpanProcessor bsp =
-        BatchSpanProcessor.builder(exporter).setExportUnsampledSpans(true).build();
+        BatchSpanProcessor.builder(exporter)
+            .setExportUnsampledSpans(true)
+            .setMaxExportBatchSize(maxExportBatchSize)
+            .build();
     return new AwsUnsampledOnlySpanProcessor(bsp);
   }
 
+  // Visible for testing
   SpanExporter getSpanExporter() {
     return exporter;
   }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
@@ -35,19 +35,19 @@ public class AwsUnsampledOnlySpanProcessorTest {
 
   @Test
   public void testIsStartRequired() {
-    SpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    SpanProcessor processor = AwsUnsampledOnlySpanProcessorBuilder.create().build();
     assertThat(processor.isStartRequired()).isTrue();
   }
 
   @Test
   public void testIsEndRequired() {
-    SpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    SpanProcessor processor = AwsUnsampledOnlySpanProcessorBuilder.create().build();
     assertThat(processor.isEndRequired()).isTrue();
   }
 
   @Test
   public void testDefaultSpanProcessor() {
-    AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessor.builder();
+    AwsUnsampledOnlySpanProcessorBuilder builder = AwsUnsampledOnlySpanProcessorBuilder.create();
     AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
 
     assertThat(builder.getSpanExporter()).isInstanceOf(OtlpUdpSpanExporter.class);
@@ -64,7 +64,8 @@ public class AwsUnsampledOnlySpanProcessorTest {
   @Test
   public void testSpanProcessorWithExporter() {
     AwsUnsampledOnlySpanProcessorBuilder builder =
-        AwsUnsampledOnlySpanProcessor.builder().setSpanExporter(InMemorySpanExporter.create());
+        AwsUnsampledOnlySpanProcessorBuilder.create()
+            .setSpanExporter(InMemorySpanExporter.create());
     AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
 
     assertThat(builder.getSpanExporter()).isInstanceOf(InMemorySpanExporter.class);
@@ -85,7 +86,7 @@ public class AwsUnsampledOnlySpanProcessorTest {
     ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
     when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
 
-    AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessorBuilder.create().build();
     processor.onStart(parentContextMock, spanMock);
 
     // verify setAttribute was never called
@@ -100,7 +101,7 @@ public class AwsUnsampledOnlySpanProcessorTest {
     ReadWriteSpan spanMock = mock(ReadWriteSpan.class);
     when(spanMock.getSpanContext()).thenReturn(mockSpanContext);
 
-    AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessor.builder().build();
+    AwsUnsampledOnlySpanProcessor processor = AwsUnsampledOnlySpanProcessorBuilder.create().build();
     processor.onStart(parentContextMock, spanMock);
 
     // verify setAttribute was called with the correct arguments

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsUnsampledOnlySpanProcessorTest.java
@@ -59,6 +59,7 @@ public class AwsUnsampledOnlySpanProcessorTest {
         .contains(
             "spanExporter=software.amazon.opentelemetry.javaagent.providers.OtlpUdpSpanExporter");
     assertThat(delegateBspString).contains("exportUnsampledSpans=true");
+    assertThat(delegateBspString).contains("maxExportBatchSize=512");
   }
 
   @Test
@@ -76,6 +77,19 @@ public class AwsUnsampledOnlySpanProcessorTest {
     assertThat(delegateBspString)
         .contains("spanExporter=io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter");
     assertThat(delegateBspString).contains("exportUnsampledSpans=true");
+  }
+
+  @Test
+  public void testSpanProcessorWithBatchSize() {
+    AwsUnsampledOnlySpanProcessorBuilder builder =
+        AwsUnsampledOnlySpanProcessorBuilder.create().setMaxExportBatchSize(100);
+    AwsUnsampledOnlySpanProcessor unsampledSP = builder.build();
+
+    SpanProcessor delegate = unsampledSP.getDelegate();
+    assertThat(delegate).isInstanceOf(BatchSpanProcessor.class);
+    BatchSpanProcessor delegateBsp = (BatchSpanProcessor) delegate;
+    String delegateBspString = delegateBsp.toString();
+    assertThat(delegateBspString).contains("maxExportBatchSize=100");
   }
 
   @Test


### PR DESCRIPTION
#### Description of changes:
The following behaviors are implemented when the ADOT Java SDK is running in a Lambda environment:
- Replace the OTLP SpanExporters (either HTTP or GRPC ones) with `OtlpUdpSpanExporter` to export spans to Lambda agent over UDP.
- Disable the other AWS resource providers via [the `otel.java.disabled.resource.providers` configuration](https://opentelemetry.io/docs/languages/java/configuration/#properties-general).
- Set [the BSP configuration](https://opentelemetry.io/docs/languages/java/configuration/#properties-traces) `otel.bsp.max.export.batch.size` to 10 for the auto-configured BatchSpanProcessor that exports the sampled spans.
- When Application Signals is enabled:
  - Export unsampled spans too via the `AwsUnsampledOnlySpanProcessor`. Also, setting the batch size for the `AwsUnsampledOnlySpanProcessor` to be 10. 
  - Disable generating Application Signals metrics from the SDK.


Compare to the ADOT Python implementation: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/257

#### Testing
- The unit tests for `AwsApplicationSignalsCustomizerProvider` does not exist and is high effort to add it with this PR. 
- Built the agent jar and tested with a simple application. Captured the debug logs from the ADOT Java agent.
  - The `maxExportBatchSize` is 10 for the default auto-configured BatchSpanProcessor
      > spanProcessorsAll=[BatchSpanProcessor{spanExporter=software.amazon.opentelemetry.javaagent.providers.AwsMetricAttributesSpanExporter@193f604a, exportUnsampledSpans=false, scheduleDelayNanos=5000000000, maxExportBatchSize=10, exporterTimeoutNanos=30000000000}, io.opentelemetry.javaagent.tooling.AddThreadDetailsSpanProcessor@50ad3bc1, SimpleSpanProcessor{spanExporter=LoggingSpanExporter{}, exportUnsampledSpans=false}, software.amazon.opentelemetry.javaagent.providers.AttributePropagatingSpanProcessor@223aa2f7, software.amazon.opentelemetry.javaagent.providers.AwsUnsampledOnlySpanProcessor@6d3a388c]}} 
  - When Application Signals is disabled, the configured exporter is still the OtlpUdpSpanExporter
    > spanProcessorsAll=[BatchSpanProcessor{spanExporter=software.amazon.opentelemetry.javaagent.providers.OtlpUdpSpanExporter@394df057, exportUnsampledSpans=false, scheduleDelayNanos=5000000000, maxExportBatchSize=10, exporterTimeoutNanos=30000000000}, io.opentelemetry.javaagent.tooling.AddThreadDetailsSpanProcessor@71e9ddb4, SimpleSpanProcessor{spanExporter=LoggingSpanExporter{}, exportUnsampledSpans=false}]



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
