### PR TITLE
Renaming to otel-instrument and default configs

### DIFF
--- a/lambda-layer/build-layer.sh
+++ b/lambda-layer/build-layer.sh
@@ -45,4 +45,4 @@ popd
 
 ## Copy ADOT Java Agent downloaded using Gradle task and bundle it with the Lambda handler script
 cp "$SOURCEDIR"/build/javaagent/aws-opentelemetry-agent*.jar ./opentelemetry-javaagent.jar
-zip -qr opentelemetry-javaagent-layer.zip opentelemetry-javaagent.jar otel-handler
+zip -qr opentelemetry-javaagent-layer.zip opentelemetry-javaagent.jar otel-instrument

--- a/lambda-layer/otel-instrument
+++ b/lambda-layer/otel-instrument
@@ -20,13 +20,19 @@ export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
 # Use OTLP traces exporter if not specified
 export OTEL_TRACES_EXPORTER=${OTEL_TRACES_EXPORTER:-"otlp"}
 
+# Disable metrics and logs export by default if not specified
+export OTEL_METRICS_EXPORTER=${OTEL_METRICS_EXPORTER:-"none"}
+export OTEL_LOGS_EXPORTER=${OTEL_LOGS_EXPORTER:-"none"}
+
 # Enable Application Signals by default if not specified
 export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=${OTEL_AWS_APPLICATION_SIGNALS_ENABLED:-"true"}
 
-# If Application Signals is enabled
-if [ "${OTEL_AWS_APPLICATION_SIGNALS_ENABLED}" = "true" ]; then
-  export OTEL_METRICS_EXPORTER=${OTEL_METRICS_EXPORTER:-"none"}
-  export OTEL_LOGS_EXPORTER=${OTEL_LOGS_EXPORTER:-"none"}
+# Append Lambda Resource Attributes to OTel Resource Attribute List
+LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,faas.instance=$AWS_LAMBDA_LOG_STREAM_NAME,aws.log.group.names=$AWS_LAMBDA_LOG_GROUP_NAME";
+if [ -z "${OTEL_RESOURCE_ATTRIBUTES}" ]; then
+    export OTEL_RESOURCE_ATTRIBUTES=$LAMBDA_RESOURCE_ATTRIBUTES;
+else
+    export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
 fi
 
 exec "$@"

--- a/lambda-layer/otel-instrument
+++ b/lambda-layer/otel-instrument
@@ -4,10 +4,6 @@ export OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES=true
 
 export OTEL_PROPAGATORS="${OTEL_PROPAGATORS:-xray,tracecontext,b3,b3multi}"
 
-# Temporarily set OTEL_SERVICE_NAME variable to work around but in javaagent not handling
-# OTEL_RESOURCE_ATTRIBUTES as set in otel-handler-upstream. It doesn't hurt to apply this
-# to wrapper as well.
-# TODO(anuraaga): Move to opentelemetry-lambda
 export OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-${AWS_LAMBDA_FUNCTION_NAME}}
 
 export JAVA_TOOL_OPTIONS="-javaagent:/opt/opentelemetry-javaagent.jar ${JAVA_TOOL_OPTIONS}"
@@ -20,5 +16,17 @@ export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000
 
 # Disable the Application Signals runtime metrics since we are on Lambda
 export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
+
+# Use OTLP traces exporter if not specified
+export OTEL_TRACES_EXPORTER=${OTEL_TRACES_EXPORTER:-"otlp"}
+
+# Enable Application Signals by default if not specified
+export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=${OTEL_AWS_APPLICATION_SIGNALS_ENABLED:-"true"}
+
+# If Application Signals is enabled
+if [ "${OTEL_AWS_APPLICATION_SIGNALS_ENABLED}" = "true" ]; then
+  export OTEL_METRICS_EXPORTER=${OTEL_METRICS_EXPORTER:-"none"}
+  export OTEL_LOGS_EXPORTER=${OTEL_LOGS_EXPORTER:-"none"}
+fi
 
 exec "$@"


### PR DESCRIPTION
As a follow up to the https://github.com/aws-observability/aws-otel-java-instrumentation/pull/953 and from internal discussion with @wangzlei:
- Renaming `otel-handler` to `otel-instrument` to be consistent with other ADOT lambda layer script naming.
- Enabling Application Signals by default with the following environment variables already set. Note that users can still override these environment variables if they want to.
  ```
  AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler
  OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
  OTEL_LOGS_EXPORTER=none
  OTEL_METRICS_EXPORTER=none
  OTEL_TRACES_EXPORTER=otlp
  ```
- Appending Lambda resource attributes

ADOT Python implementation for reference: https://github.com/aws-observability/aws-otel-python-instrumentation/blame/main/lambda-layer/src/otel-instrument

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
