### PR TITLE
Migrate logging to debug exporter to match with latest otel colletor.

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -5,8 +5,8 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  logging:
-    loglevel: info
+  debug:
+    verbosity: normal
   awsxray:
     region: us-west-2
   awsemf:
@@ -21,11 +21,11 @@ service:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsxray
     metrics:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsemf

--- a/.github/workflows/e2e-tests-app-with-java-agent.yml
+++ b/.github/workflows/e2e-tests-app-with-java-agent.yml
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 23
           distribution: 'temurin'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 23
           distribution: 'temurin'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -145,7 +145,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 23
           distribution: 'temurin'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/e2e-tests-app-with-java-agent.yml
+++ b/.github/workflows/e2e-tests-app-with-java-agent.yml
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 23
+          java-version: 17
           distribution: 'temurin'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 23
+          java-version: 17
           distribution: 'temurin'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -145,7 +145,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 23
+          java-version: 17
           distribution: 'temurin'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/scripts/docker/corretto-slim/Dockerfile
+++ b/scripts/docker/corretto-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/amazoncorretto:23-alpine-jdk
+FROM public.ecr.aws/docker/library/amazoncorretto:17-alpine-jdk
 
 # Copied from https://github.com/corretto/corretto-docker/blob/master/11/jre/alpine/Dockerfile
 RUN apk update && apk add binutils && jlink --endian little --release-info $JAVA_HOME/release \


### PR DESCRIPTION
*Description of changes:*
Change back to use java 17 base image.

The previous [ADOT Java main build failed](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/12421612708/job/34682282673) because of it is using the collector version v0.42.0 released 8 hours ago, where the logging exporter has been deprecated. This PR migrate to debug exporter according to:
https://github.com/open-telemetry/opentelemetry-collector/issues/11337.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
