### PR TITLE
Use grpc exporter for agent test workflow.

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - AWS_REGION=us-west-2
       - OTEL_JAVAAGENT_DEBUG=true
       - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
     volumes:
       - /tmp/awscreds:/tmp/awscreds
     ports:


### PR DESCRIPTION
*Description of changes:*
Add `OTEL_EXPORTER_OTLP_PROTOCOL` to `grpc` for instrumentation as in [version v2.0.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0):

> The default OTLP protocol has been changed from grpc to http/protobuf in orderto align with the specification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
