### PR TITLE
Migrate logging to debug exporter to match with latest otel colletor.

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -5,8 +5,8 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  logging:
-    loglevel: info
+  debug:
+    verbosity: normal
   awsxray:
     region: us-west-2
   awsemf:
@@ -21,11 +21,11 @@ service:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsxray
     metrics:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsemf


### PR DESCRIPTION
*Description of changes:*
The previous [ADOT Java main build failed](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/12421612708) because of it is using the collector version v0.42.0 released 8 hours ago, where the logging exporter has been deprecated. This PR migrate to debug exporter according to:
https://github.com/open-telemetry/opentelemetry-collector/issues/11337.

Same fix has been applied to v2.x branch: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/979

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
