### PR TITLE
Migrate logging to debug exporter to match with latest otel colletor.

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -5,8 +5,8 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  logging:
-    loglevel: info
+  debug:
+    verbosity: normal
   awsxray:
     region: us-west-2
   awsemf:
@@ -21,11 +21,11 @@ service:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsxray
     metrics:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsemf

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,6 +33,13 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
+      # Cleanup directories before proceeding with setup
+      - name: Clean up old installations
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,13 +33,6 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
-      # Cleanup directories before proceeding with setup
-      - name: Clean up old installations
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-
       - uses: ./.github/actions/patch-dependencies
         with:
           run_tests: "true"
@@ -69,6 +62,13 @@ jobs:
           distribution: temurin
 
       - uses: gradle/wrapper-validation-action@v1
+
+      # Cleanup directories before proceeding with setup
+      - name: Clean up old installations
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
 
         # cache local patch outputs
       - name: Cache local Maven repository


### PR DESCRIPTION
*Description of changes:*
The previous [ADOT Java main build failed](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/12421612708) because of it is using the collector version v0.42.0 released 8 hours ago, where the logging exporter has been deprecated. This PR migrate to debug exporter according to:
https://github.com/open-telemetry/opentelemetry-collector/issues/11337.

Also, add a step in PR build to clean up the storage to avoid "No space left in the device" failure.

Same fix has been applied to v2.x branch: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/979

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
