### PR TITLE
Enable smoke test controller telemetry.

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - OTEL_JAVAAGENT_DEBUG=true
       - OTEL_METRICS_EXPORTER=otlp
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED=true
     volumes:
       - /tmp/awscreds:/tmp/awscreds
     ports:


### PR DESCRIPTION
*Description of changes:*
Previously, in v1.x, the springboot controller telemetry data is enabled by default.

Starting from upstream v2.x, the controller telemetry need to be enable by setting up env `OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED`: https://opentelemetry.io/docs/zero-code/java/agent/disable/#suppressing-controller-andor-view-spans. 

This PR enable the telemetry data to align with smoke test validator.
https://opentelemetry.io/docs/zero-code/java/agent/disable/#suppressing-controller-andor-view-spans




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
