### PR TITLE
Updating Lambda Patch v1.33.6 + Fast Startup capability

### DIFF
--- a/lambda-layer/.gitignore
+++ b/lambda-layer/.gitignore
@@ -3,3 +3,9 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore Terraform state files
+.terraform
+*.tfstate
+*.tfstate.backup
+*.lock.hcl

--- a/lambda-layer/build-layer.sh
+++ b/lambda-layer/build-layer.sh
@@ -4,6 +4,7 @@ SOURCEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 
 ## Get OTel version
+echo "Info: Getting OTEL Version"
 file="$SOURCEDIR/../.github/patches/versions"
 version=$(awk -F'=v' '/OTEL_JAVA_INSTRUMENTATION_VERSION/ {print $2}' "$file")
 echo "Found OTEL Version: ${version}"
@@ -15,15 +16,16 @@ fi
 
 
 ## Clone and Patch the OpenTelemetry Java Instrumentation Repository
+echo "Info: Cloning and Patching OpenTelemetry Java Instrumentation Repository"
 git clone https://github.com/open-telemetry/opentelemetry-java-instrumentation.git
 pushd opentelemetry-java-instrumentation
 git checkout v${version} -b tag-v${version}
 
-# This patch is for Lambda related context propagation
-patch -p1 < "$SOURCEDIR"/patches/opentelemetry-java-instrumentation.patch
-
 # There is another patch in the .github/patches directory for other changes. We should apply them too for consistency.
 patch -p1 < "$SOURCEDIR"/../.github/patches/opentelemetry-java-instrumentation.patch
+
+# This patch is for Lambda related context propagation
+patch -p1 < "$SOURCEDIR"/patches/opentelemetry-java-instrumentation.patch
 
 git add -A
 git commit -m "Create patch version"
@@ -33,6 +35,7 @@ rm -rf opentelemetry-java-instrumentation
 
 
 ## Build the ADOT Java from current source
+echo "Info: Building ADOT Java from current source"
 pushd "$SOURCEDIR"/..
 patch  -p1 < "${SOURCEDIR}"/patches/aws-otel-java-instrumentation.patch
 CI=false ./gradlew publishToMavenLocal -Prelease.version=${version}-adot-lambda1
@@ -40,9 +43,11 @@ popd
 
 
 ## Build ADOT Lambda Java SDK Layer Code
-./gradlew build
+echo "Info: Building ADOT Lambda Java SDK Layer Code"
+./gradlew build -PotelVersion=${version}
 
 
 ## Copy ADOT Java Agent downloaded using Gradle task and bundle it with the Lambda handler script
+echo "Info: Creating the layer artifact"
 cp "$SOURCEDIR"/build/javaagent/aws-opentelemetry-agent*.jar ./opentelemetry-javaagent.jar
 zip -qr opentelemetry-javaagent-layer.zip opentelemetry-javaagent.jar otel-instrument

--- a/lambda-layer/build.gradle.kts
+++ b/lambda-layer/build.gradle.kts
@@ -27,13 +27,15 @@ val javaagentDependency by configurations.creating {
   extendsFrom()
 }
 
+val otelVersion: String by project
+
 dependencies {
-  compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.32.1"))
-  compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.32.1-alpha"))
+  compileOnly(platform("io.opentelemetry:opentelemetry-bom:$otelVersion"))
+  compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:$otelVersion-alpha"))
   // Already included in wrapper so compileOnly
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")
-  javaagentDependency("software.amazon.opentelemetry:aws-opentelemetry-agent:1.32.1-adot-lambda1")
+  javaagentDependency("software.amazon.opentelemetry:aws-opentelemetry-agent:$otelVersion-adot-lambda1")
 }
 
 tasks.register<Copy>("download") {

--- a/lambda-layer/otel-instrument
+++ b/lambda-layer/otel-instrument
@@ -35,4 +35,25 @@ else
     export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
 fi
 
-exec "$@"
+ARGS=("$@")
+EXTRA_ARGS=()
+
+if [ "${OTEL_JAVA_AGENT_FAST_STARTUP_ENABLED}" == "true" ]; then
+  echo "[OTEL] Enabling fast startup mode ..."
+  # Disable bytecode verification
+  EXTRA_ARGS+=("-Xverify:none")
+  # Be sure that tiered compilation is enabled
+  EXTRA_ARGS+=("-XX:+TieredCompilation")
+  # Stop tiered compilation at level 1
+  EXTRA_ARGS+=("-XX:TieredStopAtLevel=1")
+  for i in "${!ARGS[@]}"; do
+    # If tiered compilation is disabled, ignore it as we enable it at level 1 for fast startup
+    if [[ ${ARGS[i]} = "-XX:-TieredCompilation" ]]; then
+      unset 'ARGS[i]'
+    fi
+  done
+fi
+
+ARGS=("${ARGS[0]}" "${EXTRA_ARGS[@]}" "${ARGS[@]:1}")
+
+exec "${ARGS[@]}"

--- a/lambda-layer/patches/aws-otel-java-instrumentation.patch
+++ b/lambda-layer/patches/aws-otel-java-instrumentation.patch
@@ -6,8 +6,8 @@ index 9493189..6090207 100644
  val TEST_SNAPSHOTS = rootProject.findProperty("testUpstreamSnapshots") == "true"
 
  // This is the version of the upstream instrumentation BOM
--val otelVersion = "1.32.1-adot2"
-+val otelVersion = "1.32.1-adot-lambda1"
- val otelSnapshotVersion = "1.33.0"
+-val otelVersion = "1.33.6-adot1"
++val otelVersion = "1.33.6-adot-lambda1"
+ val otelSnapshotVersion = "1.33.6"
  val otelAlphaVersion = if (!TEST_SNAPSHOTS) "$otelVersion-alpha" else "$otelSnapshotVersion-alpha-SNAPSHOT"
  val otelJavaAgentVersion = if (!TEST_SNAPSHOTS) otelVersion else "$otelSnapshotVersion-SNAPSHOT"

--- a/lambda-layer/patches/opentelemetry-java-instrumentation.patch
+++ b/lambda-layer/patches/opentelemetry-java-instrumentation.patch
@@ -636,10 +636,10 @@ index cc1414c0bf..db8a59b046 100644
 --- a/version.gradle.kts
 +++ b/version.gradle.kts
 @@ -1,5 +1,5 @@
--val stableVersion = "1.32.1"
--val alphaVersion = "1.32.1-alpha"
-+val stableVersion = "1.32.1-adot-lambda1"
-+val alphaVersion = "1.32.1-adot-lambda1-alpha"
+-val stableVersion = "1.33.6"
+-val alphaVersion = "1.33.6-alpha"
++val stableVersion = "1.33.6-adot-lambda1"
++val alphaVersion = "1.33.6-adot-lambda1-alpha"
 
  allprojects {
    if (findProperty("otel.stable") != "true") {

--- a/lambda-layer/patches/opentelemetry-java-instrumentation.patch
+++ b/lambda-layer/patches/opentelemetry-java-instrumentation.patch
@@ -636,8 +636,8 @@ index cc1414c0bf..db8a59b046 100644
 --- a/version.gradle.kts
 +++ b/version.gradle.kts
 @@ -1,5 +1,5 @@
--val stableVersion = "1.33.6"
--val alphaVersion = "1.33.6-alpha"
+-val stableVersion = "1.33.6-adot1"
+-val alphaVersion = "1.33.6-adot1-alpha"
 +val stableVersion = "1.33.6-adot-lambda1"
 +val alphaVersion = "1.33.6-adot-lambda1-alpha"
 


### PR DESCRIPTION
### Description of changes:
- Fast Startup feature was added as opt-in in the upstream some time ago: https://github.com/open-telemetry/opentelemetry-lambda/pull/1180 (includes perf improvement results)
  - Did some of my own testing on a Java17 Lambda function with 3GB of memory and noticed cold start time improvement from 8.7 seconds to 4.2 seconds.

- Since the ADOT 1.x version has been updated to lated 1.33.6 version of upstream, we need to update the lambda layer related patches to this version as well. 
  - Tested by manually building the layer and instrumenting a sample lambda function. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
