### PR TITLE
Update dependencies and Otel to v2.10.0

### DIFF
--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -327,7 +327,7 @@ index 096c7826a1..a271b16da8 100644
    private AwsExperimentalAttributes() {}
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
-index 541e67d23b..6627348e73 100644
+index 541e67d23b..1abf8e9c28 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
 @@ -6,12 +6,30 @@
@@ -469,7 +469,7 @@ index 541e67d23b..6627348e73 100644
 +        if (!Objects.equals(requestClassName, "InvokeModelRequest")) {
 +          break;
 +        }
-+        attributes.put(AWS_BEDROCK_SYSTEM, "aws_bedrock");
++        attributes.put(AWS_BEDROCK_SYSTEM, "aws.bedrock");
 +        Function<Object, String> getter = RequestAccess::getModelId;
 +        String modelId = getter.apply(originalRequest);
 +        attributes.put(AWS_BEDROCK_RUNTIME_MODEL_ID, modelId);
@@ -554,36 +554,302 @@ index 541e67d23b..6627348e73 100644
 -      @Nullable Response<?> response,
 -      @Nullable Throwable error) {}
  }
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/BedrockJsonParser.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/BedrockJsonParser.java
+new file mode 100644
+index 0000000000..d1acc5768a
+--- /dev/null
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/BedrockJsonParser.java
+@@ -0,0 +1,267 @@
++/*
++ * Copyright The OpenTelemetry Authors
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++package io.opentelemetry.instrumentation.awssdk.v1_11;
++
++import java.util.ArrayList;
++import java.util.HashMap;
++import java.util.List;
++import java.util.Map;
++
++public class BedrockJsonParser {
++
++  // Prevent instantiation
++  private BedrockJsonParser() {
++    throw new UnsupportedOperationException("Utility class");
++  }
++
++  public static LlmJson parse(String jsonString) {
++    JsonParser parser = new JsonParser(jsonString);
++    Map<String, Object> jsonBody = parser.parse();
++    return new LlmJson(jsonBody);
++  }
++
++  static class JsonParser {
++    private final String json;
++    private int position;
++
++    public JsonParser(String json) {
++      this.json = json.trim();
++      this.position = 0;
++    }
++
++    private void skipWhitespace() {
++      while (position < json.length() && Character.isWhitespace(json.charAt(position))) {
++        position++;
++      }
++    }
++
++    private char currentChar() {
++      return json.charAt(position);
++    }
++
++    private static boolean isHexDigit(char c) {
++      return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
++    }
++
++    private void expect(char c) {
++      skipWhitespace();
++      if (currentChar() != c) {
++        throw new IllegalArgumentException(
++            "Expected '" + c + "' but found '" + currentChar() + "'");
++      }
++      position++;
++    }
++
++    private String readString() {
++      skipWhitespace();
++      expect('"'); // Ensure the string starts with a quote
++      StringBuilder result = new StringBuilder();
++      while (currentChar() != '"') {
++        // Handle escape sequences
++        if (currentChar() == '\\') {
++          position++; // Move past the backslash
++          if (position >= json.length()) {
++            throw new IllegalArgumentException("Unexpected end of input in string escape sequence");
++          }
++          char escapeChar = currentChar();
++          switch (escapeChar) {
++            case '"':
++            case '\\':
++            case '/':
++              result.append(escapeChar);
++              break;
++            case 'b':
++              result.append('\b');
++              break;
++            case 'f':
++              result.append('\f');
++              break;
++            case 'n':
++              result.append('\n');
++              break;
++            case 'r':
++              result.append('\r');
++              break;
++            case 't':
++              result.append('\t');
++              break;
++            case 'u': // Unicode escape sequence
++              if (position + 4 >= json.length()) {
++                throw new IllegalArgumentException("Invalid unicode escape sequence in string");
++              }
++              char[] hexChars = new char[4];
++              for (int i = 0; i < 4; i++) {
++                position++; // Move to the next character
++                char hexChar = json.charAt(position);
++                if (!isHexDigit(hexChar)) {
++                  throw new IllegalArgumentException(
++                      "Invalid hexadecimal digit in unicode escape sequence");
++                }
++                hexChars[i] = hexChar;
++              }
++              int unicodeValue = Integer.parseInt(new String(hexChars), 16);
++              result.append((char) unicodeValue);
++              break;
++            default:
++              throw new IllegalArgumentException("Invalid escape character: \\" + escapeChar);
++          }
++          position++;
++        } else {
++          result.append(currentChar());
++          position++;
++        }
++      }
++      position++; // Skip closing quote
++      return result.toString();
++    }
++
++    private Object readValue() {
++      skipWhitespace();
++      char c = currentChar();
++
++      if (c == '"') {
++        return readString();
++      } else if (Character.isDigit(c)) {
++        return readScopedNumber();
++      } else if (c == '{') {
++        return readObject(); // JSON Objects
++      } else if (c == '[') {
++        return readArray(); // JSON Arrays
++      } else if (json.startsWith("true", position)) {
++        position += 4;
++        return true;
++      } else if (json.startsWith("false", position)) {
++        position += 5;
++        return false;
++      } else if (json.startsWith("null", position)) {
++        position += 4;
++        return null; // JSON null
++      } else {
++        throw new IllegalArgumentException("Unexpected character: " + c);
++      }
++    }
++
++    private Number readScopedNumber() {
++      int start = position;
++
++      // Consume digits and the optional decimal point
++      while (position < json.length()
++          && (Character.isDigit(json.charAt(position)) || json.charAt(position) == '.')) {
++        position++;
++      }
++
++      String number = json.substring(start, position);
++
++      if (number.contains(".")) {
++        double value = Double.parseDouble(number);
++        if (value < 0.0 || value > 1.0) {
++          throw new IllegalArgumentException(
++              "Value out of bounds for Bedrock Floating Point Attribute: " + number);
++        }
++        return value;
++      } else {
++        return Integer.parseInt(number);
++      }
++    }
++
++    private Map<String, Object> readObject() {
++      Map<String, Object> map = new HashMap<>();
++      expect('{');
++      skipWhitespace();
++      while (currentChar() != '}') {
++        String key = readString();
++        expect(':');
++        Object value = readValue();
++        map.put(key, value);
++        skipWhitespace();
++        if (currentChar() == ',') {
++          position++;
++        }
++      }
++      position++; // Skip closing brace
++      return map;
++    }
++
++    private List<Object> readArray() {
++      List<Object> list = new ArrayList<>();
++      expect('[');
++      skipWhitespace();
++      while (currentChar() != ']') {
++        list.add(readValue());
++        skipWhitespace();
++        if (currentChar() == ',') {
++          position++;
++        }
++      }
++      position++;
++      return list;
++    }
++
++    public Map<String, Object> parse() {
++      return readObject();
++    }
++  }
++
++  // Resolves paths in a JSON structure
++  static class JsonPathResolver {
++
++    // Private constructor to prevent instantiation
++    private JsonPathResolver() {
++      throw new UnsupportedOperationException("Utility class");
++    }
++
++    public static Object resolvePath(LlmJson llmJson, String... paths) {
++      for (String path : paths) {
++        Object value = resolvePath(llmJson.getJsonBody(), path);
++        if (value != null) {
++          return value;
++        }
++      }
++      return null;
++    }
++
++    private static Object resolvePath(Map<String, Object> json, String path) {
++      String[] keys = path.split("/");
++      Object current = json;
++
++      for (String key : keys) {
++        if (key.isEmpty()) {
++          continue;
++        }
++
++        if (current instanceof Map) {
++          current = ((Map<?, ?>) current).get(key);
++        } else if (current instanceof List) {
++          try {
++            int index = Integer.parseInt(key);
++            current = ((List<?>) current).get(index);
++          } catch (NumberFormatException | IndexOutOfBoundsException e) {
++            return null;
++          }
++        } else {
++          return null;
++        }
++
++        if (current == null) {
++          return null;
++        }
++      }
++      return current;
++    }
++  }
++
++  public static class LlmJson {
++    private final Map<String, Object> jsonBody;
++
++    public LlmJson(Map<String, Object> jsonBody) {
++      this.jsonBody = jsonBody;
++    }
++
++    public Map<String, Object> getJsonBody() {
++      return jsonBody;
++    }
++  }
++}
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
-index c212a69678..6a3db50881 100644
+index c212a69678..3101685194 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
-@@ -5,9 +5,17 @@
- 
- package io.opentelemetry.instrumentation.awssdk.v1_11;
- 
-+import com.fasterxml.jackson.databind.JsonNode;
-+import com.fasterxml.jackson.databind.ObjectMapper;
-+import java.io.IOException;
+@@ -8,6 +8,12 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
  import java.lang.invoke.MethodHandle;
  import java.lang.invoke.MethodHandles;
  import java.lang.invoke.MethodType;
 +import java.lang.reflect.Method;
 +import java.nio.ByteBuffer;
++import java.nio.charset.StandardCharsets;
 +import java.util.Arrays;
 +import java.util.Objects;
 +import java.util.stream.Stream;
  import javax.annotation.Nullable;
  
  final class RequestAccess {
-@@ -20,48 +28,383 @@ final class RequestAccess {
+@@ -20,48 +26,392 @@ final class RequestAccess {
          }
        };
  
-+  private static final ObjectMapper objectMapper = new ObjectMapper();
-+
 +  @Nullable
-+  private static JsonNode parseTargetBody(ByteBuffer buffer) {
++  private static BedrockJsonParser.LlmJson parseTargetBody(ByteBuffer buffer) {
 +    try {
 +      byte[] bytes;
 +      // Create duplicate to avoid mutating the original buffer position
@@ -598,14 +864,15 @@ index c212a69678..6a3db50881 100644
 +        bytes = new byte[buffer.remaining()];
 +        buffer.get(bytes);
 +      }
-+      return objectMapper.readTree(bytes);
-+    } catch (IOException e) {
++      String jsonString = new String(bytes, StandardCharsets.UTF_8); // Convert to String
++      return BedrockJsonParser.parse(jsonString);
++    } catch (RuntimeException e) {
 +      return null;
 +    }
 +  }
 +
 +  @Nullable
-+  private static JsonNode getJsonBody(Object target) {
++  private static BedrockJsonParser.LlmJson getJsonBody(Object target) {
 +    if (target == null) {
 +      return null;
 +    }
@@ -620,47 +887,36 @@ index c212a69678..6a3db50881 100644
 +  }
 +
 +  @Nullable
-+  private static String findFirstMatchingPath(JsonNode jsonBody, String... paths) {
++  private static String findFirstMatchingPath(BedrockJsonParser.LlmJson jsonBody, String... paths) {
 +    if (jsonBody == null) {
 +      return null;
 +    }
 +
 +    return Stream.of(paths)
-+        .map(
-+            path -> {
-+              JsonNode node = jsonBody.at(path);
-+              if (node != null && !node.isMissingNode()) {
-+                return node.asText();
-+              }
-+              return null;
-+            })
++        .map(path -> BedrockJsonParser.JsonPathResolver.resolvePath(jsonBody, path))
 +        .filter(Objects::nonNull)
++        .map(Object::toString)
 +        .findFirst()
 +        .orElse(null);
 +  }
 +
 +  @Nullable
-+  private static String approximateTokenCount(JsonNode jsonBody, String... textPaths) {
++  private static String approximateTokenCount(
++      BedrockJsonParser.LlmJson jsonBody, String... textPaths) {
 +    if (jsonBody == null) {
 +      return null;
 +    }
 +
 +    return Stream.of(textPaths)
-+        .map(
-+            path -> {
-+              JsonNode node = jsonBody.at(path);
-+              if (node != null && !node.isMissingNode()) {
-+                int tokenEstimate = (int) Math.ceil(node.asText().length() / 6.0);
-+                return Integer.toString(tokenEstimate);
-+              }
-+              return null;
-+            })
-+        .filter(Objects::nonNull)
++        .map(path -> BedrockJsonParser.JsonPathResolver.resolvePath(jsonBody, path))
++        .filter(value -> value instanceof String)
++        .map(value -> Integer.toString((int) Math.ceil(((String) value).length() / 6.0)))
 +        .findFirst()
 +        .orElse(null);
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/inferenceConfig/max_new_tokens"
 +  // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
 +  // Anthropic Claude -> "/max_tokens"
 +  // Cohere Command -> "/max_tokens"
@@ -670,11 +926,17 @@ index c212a69678..6a3db50881 100644
 +  // Mistral AI -> "/max_tokens"
 +  @Nullable
 +  static String getMaxTokens(Object target) {
++    BedrockJsonParser.LlmJson jsonBody = getJsonBody(target);
 +    return findFirstMatchingPath(
-+        getJsonBody(target), "/textGenerationConfig/maxTokenCount", "/max_tokens", "/max_gen_len");
++        jsonBody,
++        "/max_tokens",
++        "/max_gen_len",
++        "/textGenerationConfig/maxTokenCount",
++        "/inferenceConfig/max_new_tokens");
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/inferenceConfig/temperature"
 +  // Amazon Titan -> "/textGenerationConfig/temperature"
 +  // Anthropic Claude -> "/temperature"
 +  // Cohere Command -> "/temperature"
@@ -684,11 +946,16 @@ index c212a69678..6a3db50881 100644
 +  // Mistral AI -> "/temperature"
 +  @Nullable
 +  static String getTemperature(Object target) {
++    BedrockJsonParser.LlmJson jsonBody = getJsonBody(target);
 +    return findFirstMatchingPath(
-+        getJsonBody(target), "/textGenerationConfig/temperature", "/temperature");
++        jsonBody,
++        "/temperature",
++        "/textGenerationConfig/temperature",
++        "inferenceConfig/temperature");
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/inferenceConfig/top_p"
 +  // Amazon Titan -> "/textGenerationConfig/topP"
 +  // Anthropic Claude -> "/top_p"
 +  // Cohere Command -> "/p"
@@ -698,10 +965,13 @@ index c212a69678..6a3db50881 100644
 +  // Mistral AI -> "/top_p"
 +  @Nullable
 +  static String getTopP(Object target) {
-+    return findFirstMatchingPath(getJsonBody(target), "/textGenerationConfig/topP", "/top_p", "/p");
++    BedrockJsonParser.LlmJson jsonBody = getJsonBody(target);
++    return findFirstMatchingPath(
++        jsonBody, "/top_p", "/p", "/textGenerationConfig/topP", "/inferenceConfig/top_p");
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/usage/inputTokens"
 +  // Amazon Titan -> "/inputTextTokenCount"
 +  // Anthropic Claude -> "/usage/input_tokens"
 +  // Cohere Command -> "/prompt"
@@ -711,21 +981,22 @@ index c212a69678..6a3db50881 100644
 +  // Mistral AI -> "/prompt"
 +  @Nullable
 +  static String getInputTokens(Object target) {
-+    JsonNode jsonBody = getJsonBody(target);
++    BedrockJsonParser.LlmJson jsonBody = getJsonBody(target);
 +    if (jsonBody == null) {
 +      return null;
 +    }
 +
-+    // Try direct tokens counts first
++    // Try direct token counts first
 +    String directCount =
 +        findFirstMatchingPath(
 +            jsonBody,
 +            "/inputTextTokenCount",
++            "/prompt_token_count",
 +            "/usage/input_tokens",
 +            "/usage/prompt_tokens",
-+            "/prompt_token_count");
++            "/usage/inputTokens");
 +
-+    if (directCount != null) {
++    if (directCount != null && !directCount.equals("null")) {
 +      return directCount;
 +    }
 +
@@ -734,6 +1005,7 @@ index c212a69678..6a3db50881 100644
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/usage/outputTokens"
 +  // Amazon Titan -> "/results/0/tokenCount"
 +  // Anthropic Claude -> "/usage/output_tokens"
 +  // Cohere Command -> "/generations/0/text"
@@ -743,7 +1015,7 @@ index c212a69678..6a3db50881 100644
 +  // Mistral AI -> "/outputs/0/text"
 +  @Nullable
 +  static String getOutputTokens(Object target) {
-+    JsonNode jsonBody = getJsonBody(target);
++    BedrockJsonParser.LlmJson jsonBody = getJsonBody(target);
 +    if (jsonBody == null) {
 +      return null;
 +    }
@@ -752,19 +1024,22 @@ index c212a69678..6a3db50881 100644
 +    String directCount =
 +        findFirstMatchingPath(
 +            jsonBody,
++            "/generation_token_count",
 +            "/results/0/tokenCount",
 +            "/usage/output_tokens",
 +            "/usage/completion_tokens",
-+            "/generation_token_count");
++            "/usage/outputTokens");
 +
-+    if (directCount != null) {
++    if (directCount != null && !directCount.equals("null")) {
 +      return directCount;
 +    }
 +
-+    return approximateTokenCount(jsonBody, "/outputs/0/text", "/text");
++    // Fall back to token approximation
++    return approximateTokenCount(jsonBody, "/text", "/outputs/0/text");
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/stopReason"
 +  // Amazon Titan -> "/results/0/completionReason"
 +  // Anthropic Claude -> "/stop_reason"
 +  // Cohere Command -> "/generations/0/finish_reason"
@@ -774,15 +1049,17 @@ index c212a69678..6a3db50881 100644
 +  // Mistral AI -> "/outputs/0/stop_reason"
 +  @Nullable
 +  static String getFinishReasons(Object target) {
++    BedrockJsonParser.LlmJson jsonBody = getJsonBody(target);
 +    String finishReason =
 +        findFirstMatchingPath(
-+            getJsonBody(target),
-+            "/results/0/completionReason",
++            jsonBody,
++            "/stopReason",
++            "/finish_reason",
 +            "/stop_reason",
++            "/results/0/completionReason",
 +            "/generations/0/finish_reason",
 +            "/choices/0/finish_reason",
-+            "/outputs/0/stop_reason",
-+            "/finish_reason");
++            "/outputs/0/stop_reason");
 +
 +    return finishReason != null ? "[" + finishReason + "]" : null;
 +  }
@@ -960,7 +1237,7 @@ index c212a69678..6a3db50881 100644
    @Nullable
    private static String invokeOrNull(@Nullable MethodHandle method, Object obj) {
      if (method == null) {
-@@ -74,6 +417,19 @@ final class RequestAccess {
+@@ -74,6 +424,19 @@ final class RequestAccess {
      }
    }
  
@@ -980,7 +1257,7 @@ index c212a69678..6a3db50881 100644
    @Nullable private final MethodHandle getBucketName;
    @Nullable private final MethodHandle getQueueUrl;
    @Nullable private final MethodHandle getQueueName;
-@@ -81,24 +437,66 @@ final class RequestAccess {
+@@ -81,24 +444,66 @@ final class RequestAccess {
    @Nullable private final MethodHandle getTableName;
    @Nullable private final MethodHandle getTopicArn;
    @Nullable private final MethodHandle getTargetArn;
@@ -1056,6 +1333,119 @@ index c212a69678..6a3db50881 100644
 +    return (current instanceof String) ? (String) current : null;
 +  }
  }
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/BedrockJsonParserTest.groovy b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/BedrockJsonParserTest.groovy
+new file mode 100644
+index 0000000000..03563b1d5b
+--- /dev/null
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/BedrockJsonParserTest.groovy
+@@ -0,0 +1,107 @@
++/*
++ * Copyright The OpenTelemetry Authors
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++package io.opentelemetry.instrumentation.awssdk.v1_11
++
++import spock.lang.Specification
++
++class BedrockJsonParserTest extends Specification {
++  def "should parse simple JSON object"() {
++    given:
++    String json = '{"key":"value"}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++
++    then:
++    parsedJson.getJsonBody() == [key: "value"]
++  }
++
++  def "should parse nested JSON object"() {
++    given:
++    String json = '{"parent":{"child":"value"}}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++
++    then:
++    def parent = parsedJson.getJsonBody().get("parent")
++    parent instanceof Map
++    parent["child"] == "value"
++  }
++
++  def "should parse JSON array"() {
++    given:
++    String json = '{"array":[1, "two", 1.0]}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++
++    then:
++    def array = parsedJson.getJsonBody().get("array")
++    array instanceof List
++    array == [1, "two", 1.0]
++  }
++
++  def "should parse escape sequences"() {
++    given:
++    String json = '{"escaped":"Line1\\nLine2\\tTabbed\\\"Quoted\\\"\\bBackspace\\fFormfeed\\rCarriageReturn\\\\Backslash\\/Slash\\u0041"}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++
++    then:
++    parsedJson.getJsonBody().get("escaped") ==
++        "Line1\nLine2\tTabbed\"Quoted\"\bBackspace\fFormfeed\rCarriageReturn\\Backslash/SlashA"
++  }
++
++  def "should throw exception for malformed JSON"() {
++    given:
++    String malformedJson = '{"key":value}'
++
++    when:
++    BedrockJsonParser.parse(malformedJson)
++
++    then:
++    def ex = thrown(IllegalArgumentException)
++    ex.message.contains("Unexpected character")
++  }
++
++  def "should resolve path in JSON object"() {
++    given:
++    String json = '{"parent":{"child":{"key":"value"}}}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++    def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/parent/child/key")
++
++    then:
++    resolvedValue == "value"
++  }
++
++  def "should resolve path in JSON array"() {
++    given:
++    String json = '{"array":[{"key":"value1"}, {"key":"value2"}]}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++    def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/array/1/key")
++
++    then:
++    resolvedValue == "value2"
++  }
++
++  def "should return null for invalid path resolution"() {
++    given:
++    String json = '{"parent":{"child":{"key":"value"}}}'
++
++    when:
++    def parsedJson = BedrockJsonParser.parse(json)
++    def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/invalid/path")
++
++    then:
++    resolvedValue == null
++  }
++}
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts b/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
 index 545f5dffce..227a205ebd 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/build.gradle.kts
@@ -1256,7 +1646,7 @@ index 0000000000..498fbc2433
 +}
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractBedrockRuntimeClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractBedrockRuntimeClientTest.java
 new file mode 100644
-index 0000000000..e9d2c32262
+index 0000000000..a2a27f6ab2
 --- /dev/null
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractBedrockRuntimeClientTest.java
 @@ -0,0 +1,125 @@
@@ -1319,7 +1709,7 @@ index 0000000000..e9d2c32262
 +          "{\"choices\":[{\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":42}}",
 +          ImmutableMap.of(
 +              "gen_ai.request.model", "ai21.jamba-1-5-mini-v1:0",
-+              "gen_ai.system", "aws_bedrock",
++              "gen_ai.system", "aws.bedrock",
 +              "gen_ai.request.max_tokens", "1000",
 +              "gen_ai.request.temperature", "0.7",
 +              "gen_ai.request.top_p", "0.8",
@@ -1333,7 +1723,7 @@ index 0000000000..e9d2c32262
 +          "{\"inputTextTokenCount\":5,\"results\":[{\"tokenCount\":42,\"outputText\":\"Hi! I'm Titan, an AI assistant.\",\"completionReason\":\"stop\"}]}",
 +          ImmutableMap.of(
 +              "gen_ai.request.model", "amazon.titan-text-premier-v1:0",
-+              "gen_ai.system", "aws_bedrock",
++              "gen_ai.system", "aws.bedrock",
 +              "gen_ai.request.max_tokens", "100",
 +              "gen_ai.request.temperature", "0.7",
 +              "gen_ai.request.top_p", "0.9",
@@ -1347,7 +1737,7 @@ index 0000000000..e9d2c32262
 +          "{\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":2095,\"output_tokens\":503}}",
 +          ImmutableMap.of(
 +              "gen_ai.request.model", "anthropic.claude-3-5-sonnet-20241022-v2:0",
-+              "gen_ai.system", "aws_bedrock",
++              "gen_ai.system", "aws.bedrock",
 +              "gen_ai.request.max_tokens", "100",
 +              "gen_ai.request.temperature", "0.7",
 +              "gen_ai.request.top_p", "0.9",
@@ -1361,7 +1751,7 @@ index 0000000000..e9d2c32262
 +          "{\"prompt_token_count\":2095,\"generation_token_count\":503,\"stop_reason\":\"stop\"}",
 +          ImmutableMap.of(
 +              "gen_ai.request.model", "meta.llama3-70b-instruct-v1:0",
-+              "gen_ai.system", "aws_bedrock",
++              "gen_ai.system", "aws.bedrock",
 +              "gen_ai.request.max_tokens", "128",
 +              "gen_ai.request.temperature", "0.1",
 +              "gen_ai.request.top_p", "0.9",
@@ -1375,7 +1765,7 @@ index 0000000000..e9d2c32262
 +          "{\"text\":\"test-output\",\"finish_reason\":\"COMPLETE\"}",
 +          ImmutableMap.of(
 +              "gen_ai.request.model", "cohere.command-r-v1:0",
-+              "gen_ai.system", "aws_bedrock",
++              "gen_ai.system", "aws.bedrock",
 +              "gen_ai.request.max_tokens", "4096",
 +              "gen_ai.request.temperature", "0.8",
 +              "gen_ai.request.top_p", "0.45",
@@ -1989,6 +2379,291 @@ index 274ec27194..83d9353c3b 100644
  
    // Wrapping in unmodifiableMap
    @SuppressWarnings("ImmutableEnumChecker")
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockJsonParser.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockJsonParser.java
+new file mode 100644
+index 0000000000..9812f1afa5
+--- /dev/null
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockJsonParser.java
+@@ -0,0 +1,279 @@
++/*
++ * Copyright The OpenTelemetry Authors
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
++
++import java.util.ArrayList;
++import java.util.HashMap;
++import java.util.List;
++import java.util.Map;
++
++/**
++ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
++ * any time.
++ */
++public class BedrockJsonParser {
++
++  // Prevent instantiation
++  private BedrockJsonParser() {
++    throw new UnsupportedOperationException("Utility class");
++  }
++
++  /**
++   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
++   * any time.
++   */
++  public static LlmJson parse(String jsonString) {
++    JsonParser parser = new JsonParser(jsonString);
++    Map<String, Object> jsonBody = parser.parse();
++    return new LlmJson(jsonBody);
++  }
++
++  static class JsonParser {
++    private final String json;
++    private int position;
++
++    public JsonParser(String json) {
++      this.json = json.trim();
++      this.position = 0;
++    }
++
++    private void skipWhitespace() {
++      while (position < json.length() && Character.isWhitespace(json.charAt(position))) {
++        position++;
++      }
++    }
++
++    private char currentChar() {
++      return json.charAt(position);
++    }
++
++    private static boolean isHexDigit(char c) {
++      return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
++    }
++
++    private void expect(char c) {
++      skipWhitespace();
++      if (currentChar() != c) {
++        throw new IllegalArgumentException(
++            "Expected '" + c + "' but found '" + currentChar() + "'");
++      }
++      position++;
++    }
++
++    private String readString() {
++      skipWhitespace();
++      expect('"'); // Ensure the string starts with a quote
++      StringBuilder result = new StringBuilder();
++      while (currentChar() != '"') {
++        // Handle escape sequences
++        if (currentChar() == '\\') {
++          position++; // Move past the backslash
++          if (position >= json.length()) {
++            throw new IllegalArgumentException("Unexpected end of input in string escape sequence");
++          }
++          char escapeChar = currentChar();
++          switch (escapeChar) {
++            case '"':
++            case '\\':
++            case '/':
++              result.append(escapeChar);
++              break;
++            case 'b':
++              result.append('\b');
++              break;
++            case 'f':
++              result.append('\f');
++              break;
++            case 'n':
++              result.append('\n');
++              break;
++            case 'r':
++              result.append('\r');
++              break;
++            case 't':
++              result.append('\t');
++              break;
++            case 'u': // Unicode escape sequence
++              if (position + 4 >= json.length()) {
++                throw new IllegalArgumentException("Invalid unicode escape sequence in string");
++              }
++              char[] hexChars = new char[4];
++              for (int i = 0; i < 4; i++) {
++                position++; // Move to the next character
++                char hexChar = json.charAt(position);
++                if (!isHexDigit(hexChar)) {
++                  throw new IllegalArgumentException(
++                      "Invalid hexadecimal digit in unicode escape sequence");
++                }
++                hexChars[i] = hexChar;
++              }
++              int unicodeValue = Integer.parseInt(new String(hexChars), 16);
++              result.append((char) unicodeValue);
++              break;
++            default:
++              throw new IllegalArgumentException("Invalid escape character: \\" + escapeChar);
++          }
++          position++;
++        } else {
++          result.append(currentChar());
++          position++;
++        }
++      }
++      position++; // Skip closing quote
++      return result.toString();
++    }
++
++    private Object readValue() {
++      skipWhitespace();
++      char c = currentChar();
++
++      if (c == '"') {
++        return readString();
++      } else if (Character.isDigit(c)) {
++        return readScopedNumber();
++      } else if (c == '{') {
++        return readObject(); // JSON Objects
++      } else if (c == '[') {
++        return readArray(); // JSON Arrays
++      } else if (json.startsWith("true", position)) {
++        position += 4;
++        return true;
++      } else if (json.startsWith("false", position)) {
++        position += 5;
++        return false;
++      } else if (json.startsWith("null", position)) {
++        position += 4;
++        return null; // JSON null
++      } else {
++        throw new IllegalArgumentException("Unexpected character: " + c);
++      }
++    }
++
++    private Number readScopedNumber() {
++      int start = position;
++
++      // Consume digits and the optional decimal point
++      while (position < json.length()
++          && (Character.isDigit(json.charAt(position)) || json.charAt(position) == '.')) {
++        position++;
++      }
++
++      String number = json.substring(start, position);
++
++      if (number.contains(".")) {
++        double value = Double.parseDouble(number);
++        if (value < 0.0 || value > 1.0) {
++          throw new IllegalArgumentException(
++              "Value out of bounds for Bedrock Floating Point Attribute: " + number);
++        }
++        return value;
++      } else {
++        return Integer.parseInt(number);
++      }
++    }
++
++    private Map<String, Object> readObject() {
++      Map<String, Object> map = new HashMap<>();
++      expect('{');
++      skipWhitespace();
++      while (currentChar() != '}') {
++        String key = readString();
++        expect(':');
++        Object value = readValue();
++        map.put(key, value);
++        skipWhitespace();
++        if (currentChar() == ',') {
++          position++;
++        }
++      }
++      position++; // Skip closing brace
++      return map;
++    }
++
++    private List<Object> readArray() {
++      List<Object> list = new ArrayList<>();
++      expect('[');
++      skipWhitespace();
++      while (currentChar() != ']') {
++        list.add(readValue());
++        skipWhitespace();
++        if (currentChar() == ',') {
++          position++;
++        }
++      }
++      position++;
++      return list;
++    }
++
++    public Map<String, Object> parse() {
++      return readObject();
++    }
++  }
++
++  // Resolves paths in a JSON structure
++  static class JsonPathResolver {
++
++    // Private constructor to prevent instantiation
++    private JsonPathResolver() {
++      throw new UnsupportedOperationException("Utility class");
++    }
++
++    public static Object resolvePath(LlmJson llmJson, String... paths) {
++      for (String path : paths) {
++        Object value = resolvePath(llmJson.getJsonBody(), path);
++        if (value != null) {
++          return value;
++        }
++      }
++      return null;
++    }
++
++    private static Object resolvePath(Map<String, Object> json, String path) {
++      String[] keys = path.split("/");
++      Object current = json;
++
++      for (String key : keys) {
++        if (key.isEmpty()) {
++          continue;
++        }
++
++        if (current instanceof Map) {
++          current = ((Map<?, ?>) current).get(key);
++        } else if (current instanceof List) {
++          try {
++            int index = Integer.parseInt(key);
++            current = ((List<?>) current).get(index);
++          } catch (NumberFormatException | IndexOutOfBoundsException e) {
++            return null;
++          }
++        } else {
++          return null;
++        }
++
++        if (current == null) {
++          return null;
++        }
++      }
++      return current;
++    }
++  }
++
++  /**
++   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
++   * any time.
++   */
++  public static class LlmJson {
++    private final Map<String, Object> jsonBody;
++
++    public LlmJson(Map<String, Object> jsonBody) {
++      this.jsonBody = jsonBody;
++    }
++
++    public Map<String, Object> getJsonBody() {
++      return jsonBody;
++    }
++  }
++}
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/FieldMapper.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/FieldMapper.java
 index 9e7aeacbce..9a38a753ca 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/FieldMapper.java
@@ -2009,49 +2684,35 @@ index 9e7aeacbce..9a38a753ca 100644
          span.setAttribute(fieldMapping.getAttribute(), value);
        }
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Serializer.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Serializer.java
-index 7ae1590152..18f9dd41ee 100644
+index 7ae1590152..5b7a188914 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Serializer.java
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Serializer.java
-@@ -5,13 +5,19 @@
+@@ -7,11 +7,14 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
  
- package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
- 
-+import com.fasterxml.jackson.core.JsonProcessingException;
-+import com.fasterxml.jackson.databind.JsonNode;
-+import com.fasterxml.jackson.databind.ObjectMapper;
  import java.io.IOException;
  import java.io.InputStream;
++import java.util.Arrays;
  import java.util.Collection;
  import java.util.Map;
 +import java.util.Objects;
  import java.util.Optional;
  import java.util.stream.Collectors;
-+import java.util.stream.Stream;
  import javax.annotation.Nullable;
 +import software.amazon.awssdk.core.SdkBytes;
  import software.amazon.awssdk.core.SdkPojo;
  import software.amazon.awssdk.http.ContentStreamProvider;
  import software.amazon.awssdk.http.SdkHttpFullRequest;
-@@ -21,6 +27,8 @@ import software.amazon.awssdk.utils.StringUtils;
- 
- class Serializer {
- 
-+  private static final ObjectMapper objectMapper = new ObjectMapper();
-+
-   @Nullable
-   String serialize(Object target) {
- 
-@@ -41,6 +49,41 @@ class Serializer {
+@@ -41,6 +44,45 @@ class Serializer {
      return target.toString();
    }
  
 +  @Nullable
 +  String serialize(String attributeName, Object target) {
 +    try {
-+      JsonNode jsonBody;
++      // Extract JSON string from target if it is a Bedrock Runtime JSON blob
++      String jsonString;
 +      if (target instanceof SdkBytes) {
-+        String jsonString = ((SdkBytes) target).asUtf8String();
-+        jsonBody = objectMapper.readTree(jsonString);
++        jsonString = ((SdkBytes) target).asUtf8String();
 +      } else {
 +        if (target != null) {
 +          return target.toString();
@@ -2059,23 +2720,27 @@ index 7ae1590152..18f9dd41ee 100644
 +        return null;
 +      }
 +
++      // Parse the LLM JSON string into a Map
++      BedrockJsonParser.LlmJson llmJson = BedrockJsonParser.parse(jsonString);
++
++      // Use attribute name to extract the corresponding value
 +      switch (attributeName) {
 +        case "gen_ai.request.max_tokens":
-+          return getMaxTokens(jsonBody);
++          return getMaxTokens(llmJson);
 +        case "gen_ai.request.temperature":
-+          return getTemperature(jsonBody);
++          return getTemperature(llmJson);
 +        case "gen_ai.request.top_p":
-+          return getTopP(jsonBody);
++          return getTopP(llmJson);
 +        case "gen_ai.response.finish_reasons":
-+          return getFinishReasons(jsonBody);
++          return getFinishReasons(llmJson);
 +        case "gen_ai.usage.input_tokens":
-+          return getInputTokens(jsonBody);
++          return getInputTokens(llmJson);
 +        case "gen_ai.usage.output_tokens":
-+          return getOutputTokens(jsonBody);
++          return getOutputTokens(llmJson);
 +        default:
 +          return null;
 +      }
-+    } catch (JsonProcessingException e) {
++    } catch (RuntimeException e) {
 +      return null;
 +    }
 +  }
@@ -2083,43 +2748,20 @@ index 7ae1590152..18f9dd41ee 100644
    @Nullable
    private static String serialize(SdkPojo sdkPojo) {
      ProtocolMarshaller<SdkHttpFullRequest> marshaller =
-@@ -65,4 +108,162 @@ class Serializer {
+@@ -65,4 +107,167 @@ class Serializer {
      String serialized = collection.stream().map(this::serialize).collect(Collectors.joining(","));
      return (StringUtils.isEmpty(serialized) ? null : "[" + serialized + "]");
    }
 +
 +  @Nullable
-+  private static String findFirstMatchingPath(JsonNode jsonBody, String... paths) {
-+    if (jsonBody == null) {
-+      return null;
-+    }
-+
-+    return Stream.of(paths)
++  private static String approximateTokenCount(
++      BedrockJsonParser.LlmJson jsonBody, String... textPaths) {
++    return Arrays.stream(textPaths)
 +        .map(
 +            path -> {
-+              JsonNode node = jsonBody.at(path);
-+              if (node != null && !node.isMissingNode()) {
-+                return node.asText();
-+              }
-+              return null;
-+            })
-+        .filter(Objects::nonNull)
-+        .findFirst()
-+        .orElse(null);
-+  }
-+
-+  @Nullable
-+  private static String approximateTokenCount(JsonNode jsonBody, String... textPaths) {
-+    if (jsonBody == null) {
-+      return null;
-+    }
-+
-+    return Stream.of(textPaths)
-+        .map(
-+            path -> {
-+              JsonNode node = jsonBody.at(path);
-+              if (node != null && !node.isMissingNode()) {
-+                int tokenEstimate = (int) Math.ceil(node.asText().length() / 6.0);
++              Object value = BedrockJsonParser.JsonPathResolver.resolvePath(jsonBody, path);
++              if (value instanceof String) {
++                int tokenEstimate = (int) Math.ceil(((String) value).length() / 6.0);
 +                return Integer.toString(tokenEstimate);
 +              }
 +              return null;
@@ -2130,6 +2772,7 @@ index 7ae1590152..18f9dd41ee 100644
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/inferenceConfig/max_new_tokens"
 +  // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
 +  // Anthropic Claude -> "/max_tokens"
 +  // Cohere Command -> "/max_tokens"
@@ -2138,12 +2781,19 @@ index 7ae1590152..18f9dd41ee 100644
 +  // Meta Llama -> "/max_gen_len"
 +  // Mistral AI -> "/max_tokens"
 +  @Nullable
-+  private static String getMaxTokens(JsonNode jsonBody) {
-+    return findFirstMatchingPath(
-+        jsonBody, "/textGenerationConfig/maxTokenCount", "/max_tokens", "/max_gen_len");
++  private static String getMaxTokens(BedrockJsonParser.LlmJson jsonBody) {
++    Object value =
++        BedrockJsonParser.JsonPathResolver.resolvePath(
++            jsonBody,
++            "/max_tokens",
++            "/max_gen_len",
++            "/textGenerationConfig/maxTokenCount",
++            "inferenceConfig/max_new_tokens");
++    return value != null ? String.valueOf(value) : null;
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/inferenceConfig/temperature"
 +  // Amazon Titan -> "/textGenerationConfig/temperature"
 +  // Anthropic Claude -> "/temperature"
 +  // Cohere Command -> "/temperature"
@@ -2152,11 +2802,18 @@ index 7ae1590152..18f9dd41ee 100644
 +  // Meta Llama -> "/temperature"
 +  // Mistral AI -> "/temperature"
 +  @Nullable
-+  private static String getTemperature(JsonNode jsonBody) {
-+    return findFirstMatchingPath(jsonBody, "/textGenerationConfig/temperature", "/temperature");
++  private static String getTemperature(BedrockJsonParser.LlmJson jsonBody) {
++    Object value =
++        BedrockJsonParser.JsonPathResolver.resolvePath(
++            jsonBody,
++            "/temperature",
++            "/textGenerationConfig/temperature",
++            "/inferenceConfig/temperature");
++    return value != null ? String.valueOf(value) : null;
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/inferenceConfig/top_p"
 +  // Amazon Titan -> "/textGenerationConfig/topP"
 +  // Anthropic Claude -> "/top_p"
 +  // Cohere Command -> "/p"
@@ -2165,11 +2822,15 @@ index 7ae1590152..18f9dd41ee 100644
 +  // Meta Llama -> "/top_p"
 +  // Mistral AI -> "/top_p"
 +  @Nullable
-+  private static String getTopP(JsonNode jsonBody) {
-+    return findFirstMatchingPath(jsonBody, "/textGenerationConfig/topP", "/top_p", "/p");
++  private static String getTopP(BedrockJsonParser.LlmJson jsonBody) {
++    Object value =
++        BedrockJsonParser.JsonPathResolver.resolvePath(
++            jsonBody, "/top_p", "/p", "/textGenerationConfig/topP", "/inferenceConfig/top_p");
++    return value != null ? String.valueOf(value) : null;
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/stopReason"
 +  // Amazon Titan -> "/results/0/completionReason"
 +  // Anthropic Claude -> "/stop_reason"
 +  // Cohere Command -> "/generations/0/finish_reason"
@@ -2178,21 +2839,23 @@ index 7ae1590152..18f9dd41ee 100644
 +  // Meta Llama -> "/stop_reason"
 +  // Mistral AI -> "/outputs/0/stop_reason"
 +  @Nullable
-+  private static String getFinishReasons(JsonNode jsonBody) {
-+    String finishReason =
-+        findFirstMatchingPath(
++  private static String getFinishReasons(BedrockJsonParser.LlmJson jsonBody) {
++    Object value =
++        BedrockJsonParser.JsonPathResolver.resolvePath(
 +            jsonBody,
-+            "/results/0/completionReason",
++            "/stopReason",
++            "/finish_reason",
 +            "/stop_reason",
++            "/results/0/completionReason",
 +            "/generations/0/finish_reason",
 +            "/choices/0/finish_reason",
-+            "/outputs/0/stop_reason",
-+            "/finish_reason");
++            "/outputs/0/stop_reason");
 +
-+    return finishReason != null ? "[" + finishReason + "]" : null;
++    return value != null ? "[" + value + "]" : null;
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/usage/inputTokens"
 +  // Amazon Titan -> "/inputTextTokenCount"
 +  // Anthropic Claude -> "/usage/input_tokens"
 +  // Cohere Command -> "/prompt"
@@ -2201,25 +2864,29 @@ index 7ae1590152..18f9dd41ee 100644
 +  // Meta Llama -> "/prompt_token_count"
 +  // Mistral AI -> "/prompt"
 +  @Nullable
-+  private static String getInputTokens(JsonNode jsonBody) {
++  private static String getInputTokens(BedrockJsonParser.LlmJson jsonBody) {
 +    // Try direct tokens counts first
-+    String directCount =
-+        findFirstMatchingPath(
++    Object directCount =
++        BedrockJsonParser.JsonPathResolver.resolvePath(
 +            jsonBody,
 +            "/inputTextTokenCount",
++            "/prompt_token_count",
 +            "/usage/input_tokens",
 +            "/usage/prompt_tokens",
-+            "/prompt_token_count");
++            "/usage/inputTokens");
 +
 +    if (directCount != null) {
-+      return directCount;
++      return String.valueOf(directCount);
 +    }
 +
 +    // Fall back to token approximation
-+    return approximateTokenCount(jsonBody, "/prompt", "/message");
++    Object approxTokenCount = approximateTokenCount(jsonBody, "/prompt", "/message");
++
++    return approxTokenCount != null ? String.valueOf(approxTokenCount) : null;
 +  }
 +
 +  // Model -> Path Mapping:
++  // Amazon Nova -> "/usage/outputTokens"
 +  // Amazon Titan -> "/results/0/tokenCount"
 +  // Anthropic Claude -> "/usage/output_tokens"
 +  // Cohere Command -> "/generations/0/text"
@@ -2228,26 +2895,29 @@ index 7ae1590152..18f9dd41ee 100644
 +  // Meta Llama -> "/generation_token_count"
 +  // Mistral AI -> "/outputs/0/text"
 +  @Nullable
-+  private static String getOutputTokens(JsonNode jsonBody) {
++  private static String getOutputTokens(BedrockJsonParser.LlmJson jsonBody) {
 +    // Try direct token counts first
-+    String directCount =
-+        findFirstMatchingPath(
++    Object directCount =
++        BedrockJsonParser.JsonPathResolver.resolvePath(
 +            jsonBody,
++            "/generation_token_count",
 +            "/results/0/tokenCount",
 +            "/usage/output_tokens",
 +            "/usage/completion_tokens",
-+            "/generation_token_count");
++            "/usage/outputTokens");
 +
 +    if (directCount != null) {
-+      return directCount;
++      return String.valueOf(directCount);
 +    }
 +
 +    // Fall back to token approximation
-+    return approximateTokenCount(jsonBody, "/outputs/0/text", "/text");
++    Object approxTokenCount = approximateTokenCount(jsonBody, "/text", "/outputs/0/text");
++
++    return approxTokenCount != null ? String.valueOf(approxTokenCount) : null;
 +  }
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
-index 94243d0b11..747620b108 100644
+index 94243d0b11..7b15a1c84b 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
 @@ -5,6 +5,8 @@
@@ -2263,7 +2933,7 @@ index 94243d0b11..747620b108 100644
   * at any time.
   */
  public final class TracingExecutionInterceptor implements ExecutionInterceptor {
-+  private static final String GEN_AI_SYSTEM_BEDROCK = "aws_bedrock";
++  private static final String GEN_AI_SYSTEM_BEDROCK = "aws.bedrock";
  
    // copied from DbIncubatingAttributes
    private static final AttributeKey<String> DB_OPERATION = AttributeKey.stringKey("db.operation");
@@ -2278,6 +2948,119 @@ index 94243d0b11..747620b108 100644
    }
  
    @Override
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockJsonParserTest.groovy b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockJsonParserTest.groovy
+new file mode 100644
+index 0000000000..9dff7aa804
+--- /dev/null
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockJsonParserTest.groovy
+@@ -0,0 +1,107 @@
++/*
++ * Copyright The OpenTelemetry Authors
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++package io.opentelemetry.instrumentation.awssdk.v2_2.internal
++
++import spock.lang.Specification
++
++class BedrockJsonParserTest extends Specification {
++    def "should parse simple JSON object"() {
++        given:
++        String json = '{"key":"value"}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++
++        then:
++        parsedJson.getJsonBody() == [key: "value"]
++    }
++
++    def "should parse nested JSON object"() {
++        given:
++        String json = '{"parent":{"child":"value"}}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++
++        then:
++        def parent = parsedJson.getJsonBody().get("parent")
++        parent instanceof Map
++        parent["child"] == "value"
++    }
++
++    def "should parse JSON array"() {
++        given:
++        String json = '{"array":[1, "two", 1.0]}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++
++        then:
++        def array = parsedJson.getJsonBody().get("array")
++        array instanceof List
++        array == [1, "two", 1.0]
++    }
++
++    def "should parse escape sequences"() {
++        given:
++        String json = '{"escaped":"Line1\\nLine2\\tTabbed\\\"Quoted\\\"\\bBackspace\\fFormfeed\\rCarriageReturn\\\\Backslash\\/Slash\\u0041"}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++
++        then:
++        parsedJson.getJsonBody().get("escaped") ==
++                "Line1\nLine2\tTabbed\"Quoted\"\bBackspace\fFormfeed\rCarriageReturn\\Backslash/SlashA"
++    }
++
++    def "should throw exception for malformed JSON"() {
++        given:
++        String malformedJson = '{"key":value}'
++
++        when:
++        BedrockJsonParser.parse(malformedJson)
++
++        then:
++        def ex = thrown(IllegalArgumentException)
++        ex.message.contains("Unexpected character")
++    }
++
++    def "should resolve path in JSON object"() {
++        given:
++        String json = '{"parent":{"child":{"key":"value"}}}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++        def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/parent/child/key")
++
++        then:
++        resolvedValue == "value"
++    }
++
++    def "should resolve path in JSON array"() {
++        given:
++        String json = '{"array":[{"key":"value1"}, {"key":"value2"}]}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++        def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/array/1/key")
++
++        then:
++        resolvedValue == "value2"
++    }
++
++    def "should return null for invalid path resolution"() {
++        given:
++        String json = '{"parent":{"child":{"key":"value"}}}'
++
++        when:
++        def parsedJson = BedrockJsonParser.parse(json)
++        def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/invalid/path")
++
++        then:
++        resolvedValue == null
++    }
++}
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts b/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
 index 08b000a05c..de0fe82638 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts
@@ -2293,7 +3076,7 @@ index 08b000a05c..de0fe82638 100644
    // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
    implementation("org.elasticmq:elasticmq-rest-sqs_2.13")
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
-index 2533a0202d..c6350d0749 100644
+index 2533a0202d..a275e7e2f7 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
 @@ -37,10 +37,19 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
@@ -2337,7 +3120,7 @@ index 2533a0202d..c6350d0749 100644
 +              "aws.bedrock.data_source.id" "datasourceId"
 +            } else if (service == "BedrockRuntime" && operation == "InvokeModel") {
 +              "gen_ai.request.model" "meta.llama2-13b-chat-v1"
-+              "gen_ai.system" "aws_bedrock"
++              "gen_ai.system" "aws.bedrock"
 +            } else if (service == "Sfn" && operation == "DescribeStateMachine") {
 +              "aws.stepfunctions.state_machine.arn" "stateMachineArn"
 +            } else if (service == "Sfn" && operation == "DescribeActivity") {

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -31,7 +31,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: aws-opentelemetry-agent.jar
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -128,7 +128,7 @@ jobs:
           snapshot-ecr-role: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -95,7 +95,7 @@ jobs:
           snapshot-ecr-role: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar

--- a/licenses/jackson-annotations-2.18.1.jar/META-INF/LICENSE
+++ b/licenses/jackson-annotations-2.18.1.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/jackson-annotations-2.18.1.jar/META-INF/NOTICE
+++ b/licenses/jackson-annotations-2.18.1.jar/META-INF/NOTICE
@@ -1,0 +1,21 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/licenses/jackson-core-2.18.1.jar/META-INF/LICENSE
+++ b/licenses/jackson-core-2.18.1.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/jackson-core-2.18.1.jar/META-INF/NOTICE
+++ b/licenses/jackson-core-2.18.1.jar/META-INF/NOTICE
@@ -1,0 +1,32 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.

--- a/licenses/jackson-databind-2.18.1.jar/META-INF/LICENSE
+++ b/licenses/jackson-databind-2.18.1.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/jackson-databind-2.18.1.jar/META-INF/NOTICE
+++ b/licenses/jackson-databind-2.18.1.jar/META-INF/NOTICE
@@ -1,0 +1,21 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/licenses/jackson-datatype-jdk8-2.18.1.jar/META-INF/LICENSE
+++ b/licenses/jackson-datatype-jdk8-2.18.1.jar/META-INF/LICENSE
@@ -1,0 +1,8 @@
+This copy of Jackson JSON processor Java 8 datatype module is licensed under the
+Apache (Software) License, version 2.0 ("the License").
+See the License for details about distribution rights, and the
+specific rights regarding derivative works.
+
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0

--- a/licenses/jackson-datatype-jdk8-2.18.1.jar/META-INF/NOTICE
+++ b/licenses/jackson-datatype-jdk8-2.18.1.jar/META-INF/NOTICE
@@ -1,0 +1,17 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/licenses/jackson-datatype-jsr310-2.18.1.jar/META-INF/LICENSE
+++ b/licenses/jackson-datatype-jsr310-2.18.1.jar/META-INF/LICENSE
@@ -1,0 +1,8 @@
+This copy of Jackson JSON processor Java 8 Date/Time module is licensed under the
+Apache (Software) License, version 2.0 ("the License").
+See the License for details about distribution rights, and the
+specific rights regarding derivative works.
+
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0

--- a/licenses/jackson-datatype-jsr310-2.18.1.jar/META-INF/NOTICE
+++ b/licenses/jackson-datatype-jsr310-2.18.1.jar/META-INF/NOTICE
@@ -1,0 +1,17 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/licenses/jackson-module-parameter-names-2.18.1.jar/META-INF/LICENSE
+++ b/licenses/jackson-module-parameter-names-2.18.1.jar/META-INF/LICENSE
@@ -1,0 +1,8 @@
+This copy of Jackson JSON processor Java 8 parameter names module is licensed under the
+Apache (Software) License, version 2.0 ("the License").
+See the License for details about distribution rights, and the
+specific rights regarding derivative works.
+
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0

--- a/licenses/jackson-module-parameter-names-2.18.1.jar/META-INF/NOTICE
+++ b/licenses/jackson-module-parameter-names-2.18.1.jar/META-INF/NOTICE
@@ -1,0 +1,17 @@
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Licensing
+
+Jackson components are licensed under Apache (Software) License, version 2.0,
+as per accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.

--- a/licenses/jul-to-slf4j-2.0.16.jar/META-INF/LICENSE.txt
+++ b/licenses/jul-to-slf4j-2.0.16.jar/META-INF/LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+

--- a/licenses/licenses.md
+++ b/licenses/licenses.md
@@ -1,7 +1,7 @@
 
 # aws-otel-java-instrumentation
 ## Dependency License Report
-_2024-12-10 18:19:03 UTC_
+_2025-01-09 18:44:58 UTC_
 ## Apache 2
 
 **1** **Group:** `joda-time` **Name:** `joda-time` **Version:** `2.8.1` 
@@ -176,1151 +176,1298 @@ _2024-12-10 18:19:03 UTC_
 > - **Embedded license files**: [jackson-core-2.17.2.jar/META-INF/LICENSE](jackson-core-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-core-2.17.2.jar/META-INF/NOTICE](jackson-core-2.17.2.jar/META-INF/NOTICE)
 
-**40** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.16.0` 
+**40** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.18.1` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-core-2.18.1.jar/META-INF/LICENSE](jackson-core-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-core-2.18.1.jar/META-INF/NOTICE](jackson-core-2.18.1.jar/META-INF/NOTICE)
+
+**41** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.16.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-databind-2.16.0.jar/META-INF/LICENSE](jackson-databind-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-databind-2.16.0.jar/META-INF/NOTICE](jackson-databind-2.16.0.jar/META-INF/NOTICE)
 
-**41** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.17.2` 
+**42** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.17.2` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-databind-2.17.2.jar/META-INF/LICENSE](jackson-databind-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-databind-2.17.2.jar/META-INF/NOTICE](jackson-databind-2.17.2.jar/META-INF/NOTICE)
 
-**42** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.16.0` 
+**43** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.1` 
+> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-databind-2.18.1.jar/META-INF/LICENSE](jackson-databind-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.18.1.jar/META-INF/NOTICE](jackson-databind-2.18.1.jar/META-INF/NOTICE)
+
+**44** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.16.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-binary](https://github.com/FasterXML/jackson-dataformats-binary)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-dataformat-cbor-2.16.0.jar/META-INF/LICENSE](jackson-dataformat-cbor-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-dataformat-cbor-2.16.0.jar/META-INF/NOTICE](jackson-dataformat-cbor-2.16.0.jar/META-INF/NOTICE)
 
-**43** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.17.2` 
+**45** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.17.2` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-binary](https://github.com/FasterXML/jackson-dataformats-binary)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-dataformat-cbor-2.17.2.jar/META-INF/LICENSE](jackson-dataformat-cbor-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-dataformat-cbor-2.17.2.jar/META-INF/NOTICE](jackson-dataformat-cbor-2.17.2.jar/META-INF/NOTICE)
 
-**44** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jdk8` **Version:** `2.16.0` 
+**46** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jdk8` **Version:** `2.16.0` 
 > - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-datatype-jdk8-2.16.0.jar/META-INF/LICENSE](jackson-datatype-jdk8-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-datatype-jdk8-2.16.0.jar/META-INF/NOTICE](jackson-datatype-jdk8-2.16.0.jar/META-INF/NOTICE)
 
-**45** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jsr310` **Version:** `2.16.0` 
+**47** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jdk8` **Version:** `2.18.1` 
+> - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-datatype-jdk8-2.18.1.jar/META-INF/LICENSE](jackson-datatype-jdk8-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-datatype-jdk8-2.18.1.jar/META-INF/NOTICE](jackson-datatype-jdk8-2.18.1.jar/META-INF/NOTICE)
+
+**48** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jsr310` **Version:** `2.16.0` 
 > - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-datatype-jsr310-2.16.0.jar/META-INF/LICENSE](jackson-datatype-jsr310-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-datatype-jsr310-2.16.0.jar/META-INF/NOTICE](jackson-datatype-jsr310-2.16.0.jar/META-INF/NOTICE)
 
-**46** **Group:** `com.fasterxml.jackson.module` **Name:** `jackson-module-parameter-names` **Version:** `2.16.0` 
+**49** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jsr310` **Version:** `2.18.1` 
+> - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-datatype-jsr310-2.18.1.jar/META-INF/LICENSE](jackson-datatype-jsr310-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-datatype-jsr310-2.18.1.jar/META-INF/NOTICE](jackson-datatype-jsr310-2.18.1.jar/META-INF/NOTICE)
+
+**50** **Group:** `com.fasterxml.jackson.module` **Name:** `jackson-module-parameter-names` **Version:** `2.16.0` 
 > - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-module-parameter-names-2.16.0.jar/META-INF/LICENSE](jackson-module-parameter-names-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-module-parameter-names-2.16.0.jar/META-INF/NOTICE](jackson-module-parameter-names-2.16.0.jar/META-INF/NOTICE)
 
-**47** **Group:** `com.google.guava` **Name:** `guava` **Version:** `33.0.0-jre` 
+**51** **Group:** `com.fasterxml.jackson.module` **Name:** `jackson-module-parameter-names` **Version:** `2.18.1` 
+> - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-module-parameter-names-2.18.1.jar/META-INF/LICENSE](jackson-module-parameter-names-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-module-parameter-names-2.18.1.jar/META-INF/NOTICE](jackson-module-parameter-names-2.18.1.jar/META-INF/NOTICE)
+
+**52** **Group:** `com.google.guava` **Name:** `guava` **Version:** `33.0.0-jre` 
 > - **Manifest Project URL**: [https://github.com/google/guava/](https://github.com/google/guava/)
 > - **POM Project URL**: [https://github.com/google/guava](https://github.com/google/guava)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [guava-33.0.0-jre.jar/META-INF/LICENSE](guava-33.0.0-jre.jar/META-INF/LICENSE)
 
-**48** **Group:** `com.google.j2objc` **Name:** `j2objc-annotations` **Version:** `2.8` 
+**53** **Group:** `com.google.j2objc` **Name:** `j2objc-annotations` **Version:** `2.8` 
 > - **POM Project URL**: [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**49** **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.15` 
+**54** **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.15` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-codec-1.15.jar/META-INF/LICENSE.txt](commons-codec-1.15.jar/META-INF/LICENSE.txt) 
     - [commons-codec-1.15.jar/META-INF/NOTICE.txt](commons-codec-1.15.jar/META-INF/NOTICE.txt)
 
-**50** **Group:** `io.netty` **Name:** `netty-all` **Version:** `4.1.100.Final` 
+**55** **Group:** `io.netty` **Name:** `netty-all` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM Project URL**: [https://netty.io/netty-all/](https://netty.io/netty-all/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**51** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.100.Final` 
+**56** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**52** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.111.Final` 
+**57** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**53** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.115.Final` 
+**58** **Group:** `io.netty` **Name:** `netty-buffer` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**54** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.100.Final` 
+**59** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**55** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.111.Final` 
+**60** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**56** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.115.Final` 
+**61** **Group:** `io.netty` **Name:** `netty-codec` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**57** **Group:** `io.netty` **Name:** `netty-codec-dns` **Version:** `4.1.100.Final` 
+**62** **Group:** `io.netty` **Name:** `netty-codec-dns` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**58** **Group:** `io.netty` **Name:** `netty-codec-haproxy` **Version:** `4.1.100.Final` 
+**63** **Group:** `io.netty` **Name:** `netty-codec-haproxy` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**59** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.100.Final` 
+**64** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**60** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.111.Final` 
+**65** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**61** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.115.Final` 
+**66** **Group:** `io.netty` **Name:** `netty-codec-http` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**62** **Group:** `io.netty` **Name:** `netty-codec-http2` **Version:** `4.1.100.Final` 
+**67** **Group:** `io.netty` **Name:** `netty-codec-http2` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**63** **Group:** `io.netty` **Name:** `netty-codec-http2` **Version:** `4.1.111.Final` 
+**68** **Group:** `io.netty` **Name:** `netty-codec-http2` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**64** **Group:** `io.netty` **Name:** `netty-codec-http2` **Version:** `4.1.115.Final` 
+**69** **Group:** `io.netty` **Name:** `netty-codec-http2` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**65** **Group:** `io.netty` **Name:** `netty-codec-memcache` **Version:** `4.1.100.Final` 
+**70** **Group:** `io.netty` **Name:** `netty-codec-memcache` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**66** **Group:** `io.netty` **Name:** `netty-codec-mqtt` **Version:** `4.1.100.Final` 
+**71** **Group:** `io.netty` **Name:** `netty-codec-mqtt` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**67** **Group:** `io.netty` **Name:** `netty-codec-redis` **Version:** `4.1.100.Final` 
+**72** **Group:** `io.netty` **Name:** `netty-codec-redis` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**68** **Group:** `io.netty` **Name:** `netty-codec-smtp` **Version:** `4.1.100.Final` 
+**73** **Group:** `io.netty` **Name:** `netty-codec-smtp` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**69** **Group:** `io.netty` **Name:** `netty-codec-socks` **Version:** `4.1.100.Final` 
+**74** **Group:** `io.netty` **Name:** `netty-codec-socks` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**70** **Group:** `io.netty` **Name:** `netty-codec-stomp` **Version:** `4.1.100.Final` 
+**75** **Group:** `io.netty` **Name:** `netty-codec-stomp` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**71** **Group:** `io.netty` **Name:** `netty-codec-xml` **Version:** `4.1.100.Final` 
+**76** **Group:** `io.netty` **Name:** `netty-codec-xml` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**72** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.100.Final` 
+**77** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**73** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.111.Final` 
+**78** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**74** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.115.Final` 
+**79** **Group:** `io.netty` **Name:** `netty-common` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**75** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.100.Final` 
+**80** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**76** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.111.Final` 
+**81** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**77** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.115.Final` 
+**82** **Group:** `io.netty` **Name:** `netty-handler` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**78** **Group:** `io.netty` **Name:** `netty-handler-proxy` **Version:** `4.1.100.Final` 
+**83** **Group:** `io.netty` **Name:** `netty-handler-proxy` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**79** **Group:** `io.netty` **Name:** `netty-handler-ssl-ocsp` **Version:** `4.1.100.Final` 
+**84** **Group:** `io.netty` **Name:** `netty-handler-ssl-ocsp` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**80** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.100.Final` 
+**85** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**81** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.111.Final` 
+**86** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**82** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.115.Final` 
+**87** **Group:** `io.netty` **Name:** `netty-resolver` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**83** **Group:** `io.netty` **Name:** `netty-resolver-dns` **Version:** `4.1.100.Final` 
+**88** **Group:** `io.netty` **Name:** `netty-resolver-dns` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**84** **Group:** `io.netty` **Name:** `netty-resolver-dns-classes-macos` **Version:** `4.1.100.Final` 
+**89** **Group:** `io.netty` **Name:** `netty-resolver-dns-classes-macos` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**85** **Group:** `io.netty` **Name:** `netty-resolver-dns-native-macos` **Version:** `4.1.100.Final` 
+**90** **Group:** `io.netty` **Name:** `netty-resolver-dns-native-macos` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**86** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.100.Final` 
+**91** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**87** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.111.Final` 
+**92** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**88** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.115.Final` 
+**93** **Group:** `io.netty` **Name:** `netty-transport` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**89** **Group:** `io.netty` **Name:** `netty-transport-classes-epoll` **Version:** `4.1.100.Final` 
+**94** **Group:** `io.netty` **Name:** `netty-transport-classes-epoll` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**90** **Group:** `io.netty` **Name:** `netty-transport-classes-epoll` **Version:** `4.1.111.Final` 
+**95** **Group:** `io.netty` **Name:** `netty-transport-classes-epoll` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**91** **Group:** `io.netty` **Name:** `netty-transport-classes-epoll` **Version:** `4.1.115.Final` 
+**96** **Group:** `io.netty` **Name:** `netty-transport-classes-epoll` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**92** **Group:** `io.netty` **Name:** `netty-transport-classes-kqueue` **Version:** `4.1.100.Final` 
+**97** **Group:** `io.netty` **Name:** `netty-transport-classes-kqueue` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**93** **Group:** `io.netty` **Name:** `netty-transport-native-epoll` **Version:** `4.1.100.Final` 
+**98** **Group:** `io.netty` **Name:** `netty-transport-native-epoll` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**94** **Group:** `io.netty` **Name:** `netty-transport-native-kqueue` **Version:** `4.1.100.Final` 
+**99** **Group:** `io.netty` **Name:** `netty-transport-native-kqueue` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**95** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.100.Final` 
+**100** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**96** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.111.Final` 
+**101** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.111.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**97** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.115.Final` 
+**102** **Group:** `io.netty` **Name:** `netty-transport-native-unix-common` **Version:** `4.1.115.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**98** **Group:** `io.netty` **Name:** `netty-transport-rxtx` **Version:** `4.1.100.Final` 
+**103** **Group:** `io.netty` **Name:** `netty-transport-rxtx` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**99** **Group:** `io.netty` **Name:** `netty-transport-sctp` **Version:** `4.1.100.Final` 
+**104** **Group:** `io.netty` **Name:** `netty-transport-sctp` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**100** **Group:** `io.netty` **Name:** `netty-transport-udt` **Version:** `4.1.100.Final` 
+**105** **Group:** `io.netty` **Name:** `netty-transport-udt` **Version:** `4.1.100.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**101** **Group:** `joda-time` **Name:** `joda-time` **Version:** `2.12.7` 
+**106** **Group:** `joda-time` **Name:** `joda-time` **Version:** `2.12.7` 
 > - **Project URL**: [https://www.joda.org/joda-time/](https://www.joda.org/joda-time/)
 > - **Manifest License**: Apache 2.0 (Not Packaged)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [joda-time-2.12.7.jar/META-INF/LICENSE.txt](joda-time-2.12.7.jar/META-INF/LICENSE.txt) 
     - [joda-time-2.12.7.jar/META-INF/NOTICE.txt](joda-time-2.12.7.jar/META-INF/NOTICE.txt)
 
-**102** **Group:** `net.bytebuddy` **Name:** `byte-buddy` **Version:** `1.14.10` 
+**107** **Group:** `net.bytebuddy` **Name:** `byte-buddy` **Version:** `1.14.10` 
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [byte-buddy-1.14.10.jar/META-INF/LICENSE](byte-buddy-1.14.10.jar/META-INF/LICENSE) 
     - [byte-buddy-1.14.10.jar/META-INF/NOTICE](byte-buddy-1.14.10.jar/META-INF/NOTICE)
 
-**103** **Group:** `org.apache.httpcomponents` **Name:** `httpclient` **Version:** `4.5.14` 
+**108** **Group:** `org.apache.httpcomponents` **Name:** `httpclient` **Version:** `4.5.14` 
 > - **POM Project URL**: [http://hc.apache.org/httpcomponents-client-ga](http://hc.apache.org/httpcomponents-client-ga)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [httpclient-4.5.14.jar/META-INF/LICENSE](httpclient-4.5.14.jar/META-INF/LICENSE) 
     - [httpclient-4.5.14.jar/META-INF/NOTICE](httpclient-4.5.14.jar/META-INF/NOTICE)
 
-**104** **Group:** `org.apache.httpcomponents` **Name:** `httpcore` **Version:** `4.4.16` 
+**109** **Group:** `org.apache.httpcomponents` **Name:** `httpcore` **Version:** `4.4.16` 
 > - **POM Project URL**: [http://hc.apache.org/httpcomponents-core-ga](http://hc.apache.org/httpcomponents-core-ga)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [httpcore-4.4.16.jar/META-INF/LICENSE](httpcore-4.4.16.jar/META-INF/LICENSE) 
     - [httpcore-4.4.16.jar/META-INF/NOTICE](httpcore-4.4.16.jar/META-INF/NOTICE)
 
-**105** **Group:** `org.apache.httpcomponents.client5` **Name:** `httpclient5` **Version:** `5.2.1` 
+**110** **Group:** `org.apache.httpcomponents.client5` **Name:** `httpclient5` **Version:** `5.2.1` 
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [httpclient5-5.2.1.jar/META-INF/LICENSE](httpclient5-5.2.1.jar/META-INF/LICENSE) 
     - [httpclient5-5.2.1.jar/META-INF/NOTICE](httpclient5-5.2.1.jar/META-INF/NOTICE)
 
-**106** **Group:** `org.apache.httpcomponents.core5` **Name:** `httpcore5` **Version:** `5.2` 
+**111** **Group:** `org.apache.httpcomponents.core5` **Name:** `httpcore5` **Version:** `5.2` 
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [httpcore5-5.2.jar/META-INF/LICENSE](httpcore5-5.2.jar/META-INF/LICENSE) 
     - [httpcore5-5.2.jar/META-INF/NOTICE](httpcore5-5.2.jar/META-INF/NOTICE)
 
-**107** **Group:** `org.apache.httpcomponents.core5` **Name:** `httpcore5-h2` **Version:** `5.2` 
+**112** **Group:** `org.apache.httpcomponents.core5` **Name:** `httpcore5-h2` **Version:** `5.2` 
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [httpcore5-h2-5.2.jar/META-INF/LICENSE](httpcore5-h2-5.2.jar/META-INF/LICENSE) 
     - [httpcore5-h2-5.2.jar/META-INF/NOTICE](httpcore5-h2-5.2.jar/META-INF/NOTICE)
 
-**108** **Group:** `org.apache.tomcat` **Name:** `tomcat-annotations-api` **Version:** `10.1.10` 
+**113** **Group:** `org.apache.tomcat` **Name:** `tomcat-annotations-api` **Version:** `10.1.10` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-annotations-api-10.1.10.jar/META-INF/LICENSE](tomcat-annotations-api-10.1.10.jar/META-INF/LICENSE) 
     - [tomcat-annotations-api-10.1.10.jar/META-INF/NOTICE](tomcat-annotations-api-10.1.10.jar/META-INF/NOTICE)
 
-**109** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-core` **Version:** `10.1.10` 
+**114** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-core` **Version:** `10.1.10` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-embed-core-10.1.10.jar/META-INF/LICENSE](tomcat-embed-core-10.1.10.jar/META-INF/LICENSE) 
     - [tomcat-embed-core-10.1.10.jar/META-INF/NOTICE](tomcat-embed-core-10.1.10.jar/META-INF/NOTICE)
 
-**110** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-core` **Version:** `9.0.82` 
+**115** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-core` **Version:** `10.1.33` 
+> - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [tomcat-embed-core-10.1.33.jar/META-INF/LICENSE](tomcat-embed-core-10.1.33.jar/META-INF/LICENSE) 
+    - [tomcat-embed-core-10.1.33.jar/META-INF/NOTICE](tomcat-embed-core-10.1.33.jar/META-INF/NOTICE)
+
+**116** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-core` **Version:** `9.0.82` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-embed-core-9.0.82.jar/META-INF/LICENSE](tomcat-embed-core-9.0.82.jar/META-INF/LICENSE) 
     - [tomcat-embed-core-9.0.82.jar/META-INF/NOTICE](tomcat-embed-core-9.0.82.jar/META-INF/NOTICE)
 
-**111** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-el` **Version:** `10.1.10` 
+**117** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-el` **Version:** `10.1.10` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-embed-el-10.1.10.jar/META-INF/LICENSE](tomcat-embed-el-10.1.10.jar/META-INF/LICENSE) 
     - [tomcat-embed-el-10.1.10.jar/META-INF/NOTICE](tomcat-embed-el-10.1.10.jar/META-INF/NOTICE)
 
-**112** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-el` **Version:** `9.0.82` 
+**118** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-el` **Version:** `10.1.33` 
+> - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [tomcat-embed-el-10.1.33.jar/META-INF/LICENSE](tomcat-embed-el-10.1.33.jar/META-INF/LICENSE) 
+    - [tomcat-embed-el-10.1.33.jar/META-INF/NOTICE](tomcat-embed-el-10.1.33.jar/META-INF/NOTICE)
+
+**119** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-el` **Version:** `9.0.82` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-embed-el-9.0.82.jar/META-INF/LICENSE](tomcat-embed-el-9.0.82.jar/META-INF/LICENSE) 
     - [tomcat-embed-el-9.0.82.jar/META-INF/NOTICE](tomcat-embed-el-9.0.82.jar/META-INF/NOTICE)
 
-**113** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-websocket` **Version:** `10.1.10` 
+**120** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-websocket` **Version:** `10.1.10` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-embed-websocket-10.1.10.jar/META-INF/LICENSE](tomcat-embed-websocket-10.1.10.jar/META-INF/LICENSE) 
     - [tomcat-embed-websocket-10.1.10.jar/META-INF/NOTICE](tomcat-embed-websocket-10.1.10.jar/META-INF/NOTICE)
 
-**114** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-websocket` **Version:** `9.0.82` 
+**121** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-websocket` **Version:** `10.1.33` 
+> - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [tomcat-embed-websocket-10.1.33.jar/META-INF/LICENSE](tomcat-embed-websocket-10.1.33.jar/META-INF/LICENSE) 
+    - [tomcat-embed-websocket-10.1.33.jar/META-INF/NOTICE](tomcat-embed-websocket-10.1.33.jar/META-INF/NOTICE)
+
+**122** **Group:** `org.apache.tomcat.embed` **Name:** `tomcat-embed-websocket` **Version:** `9.0.82` 
 > - **POM Project URL**: [https://tomcat.apache.org/](https://tomcat.apache.org/)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [tomcat-embed-websocket-9.0.82.jar/META-INF/LICENSE](tomcat-embed-websocket-9.0.82.jar/META-INF/LICENSE) 
     - [tomcat-embed-websocket-9.0.82.jar/META-INF/NOTICE](tomcat-embed-websocket-9.0.82.jar/META-INF/NOTICE)
 
-**115** **Group:** `org.slf4j` **Name:** `jcl-over-slf4j` **Version:** `2.0.16` 
+**123** **Group:** `org.slf4j` **Name:** `jcl-over-slf4j` **Version:** `2.0.16` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [jcl-over-slf4j-2.0.16.jar/META-INF/LICENSE.txt](jcl-over-slf4j-2.0.16.jar/META-INF/LICENSE.txt)
 
-**116** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `5.3.30` 
+**124** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-aop-5.3.30.jar/META-INF/license.txt](spring-aop-5.3.30.jar/META-INF/license.txt) 
     - [spring-aop-5.3.30.jar/META-INF/notice.txt](spring-aop-5.3.30.jar/META-INF/notice.txt)
 
-**117** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.0.10` 
+**125** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-aop-6.0.10.jar/META-INF/license.txt](spring-aop-6.0.10.jar/META-INF/license.txt) 
     - [spring-aop-6.0.10.jar/META-INF/notice.txt](spring-aop-6.0.10.jar/META-INF/notice.txt)
 
-**118** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.0.12` 
+**126** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-aop-6.0.12.jar/META-INF/license.txt](spring-aop-6.0.12.jar/META-INF/license.txt) 
     - [spring-aop-6.0.12.jar/META-INF/notice.txt](spring-aop-6.0.12.jar/META-INF/notice.txt)
 
-**119** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `5.3.30` 
+**127** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-aop-6.2.0.jar/META-INF/license.txt](spring-aop-6.2.0.jar/META-INF/license.txt) 
+    - [spring-aop-6.2.0.jar/META-INF/notice.txt](spring-aop-6.2.0.jar/META-INF/notice.txt)
+
+**128** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-beans-5.3.30.jar/META-INF/license.txt](spring-beans-5.3.30.jar/META-INF/license.txt) 
     - [spring-beans-5.3.30.jar/META-INF/notice.txt](spring-beans-5.3.30.jar/META-INF/notice.txt)
 
-**120** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.0.10` 
+**129** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-beans-6.0.10.jar/META-INF/license.txt](spring-beans-6.0.10.jar/META-INF/license.txt) 
     - [spring-beans-6.0.10.jar/META-INF/notice.txt](spring-beans-6.0.10.jar/META-INF/notice.txt)
 
-**121** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.0.12` 
+**130** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-beans-6.0.12.jar/META-INF/license.txt](spring-beans-6.0.12.jar/META-INF/license.txt) 
     - [spring-beans-6.0.12.jar/META-INF/notice.txt](spring-beans-6.0.12.jar/META-INF/notice.txt)
 
-**122** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `5.3.30` 
+**131** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-beans-6.2.0.jar/META-INF/license.txt](spring-beans-6.2.0.jar/META-INF/license.txt) 
+    - [spring-beans-6.2.0.jar/META-INF/notice.txt](spring-beans-6.2.0.jar/META-INF/notice.txt)
+
+**132** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-context-5.3.30.jar/META-INF/license.txt](spring-context-5.3.30.jar/META-INF/license.txt) 
     - [spring-context-5.3.30.jar/META-INF/notice.txt](spring-context-5.3.30.jar/META-INF/notice.txt)
 
-**123** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.0.10` 
+**133** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-context-6.0.10.jar/META-INF/license.txt](spring-context-6.0.10.jar/META-INF/license.txt) 
     - [spring-context-6.0.10.jar/META-INF/notice.txt](spring-context-6.0.10.jar/META-INF/notice.txt)
 
-**124** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.0.12` 
+**134** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-context-6.0.12.jar/META-INF/license.txt](spring-context-6.0.12.jar/META-INF/license.txt) 
     - [spring-context-6.0.12.jar/META-INF/notice.txt](spring-context-6.0.12.jar/META-INF/notice.txt)
 
-**125** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `5.3.30` 
+**135** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-context-6.2.0.jar/META-INF/license.txt](spring-context-6.2.0.jar/META-INF/license.txt) 
+    - [spring-context-6.2.0.jar/META-INF/notice.txt](spring-context-6.2.0.jar/META-INF/notice.txt)
+
+**136** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-core-5.3.30.jar/META-INF/license.txt](spring-core-5.3.30.jar/META-INF/license.txt) 
     - [spring-core-5.3.30.jar/META-INF/notice.txt](spring-core-5.3.30.jar/META-INF/notice.txt)
 
-**126** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.0.10` 
+**137** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-core-6.0.10.jar/META-INF/license.txt](spring-core-6.0.10.jar/META-INF/license.txt) 
     - [spring-core-6.0.10.jar/META-INF/notice.txt](spring-core-6.0.10.jar/META-INF/notice.txt)
 
-**127** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.0.12` 
+**138** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-core-6.0.12.jar/META-INF/license.txt](spring-core-6.0.12.jar/META-INF/license.txt) 
     - [spring-core-6.0.12.jar/META-INF/notice.txt](spring-core-6.0.12.jar/META-INF/notice.txt)
 
-**128** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `5.3.30` 
+**139** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-core-6.2.0.jar/META-INF/license.txt](spring-core-6.2.0.jar/META-INF/license.txt) 
+    - [spring-core-6.2.0.jar/META-INF/notice.txt](spring-core-6.2.0.jar/META-INF/notice.txt)
+
+**140** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-expression-5.3.30.jar/META-INF/license.txt](spring-expression-5.3.30.jar/META-INF/license.txt) 
     - [spring-expression-5.3.30.jar/META-INF/notice.txt](spring-expression-5.3.30.jar/META-INF/notice.txt)
 
-**129** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.0.10` 
+**141** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-expression-6.0.10.jar/META-INF/license.txt](spring-expression-6.0.10.jar/META-INF/license.txt) 
     - [spring-expression-6.0.10.jar/META-INF/notice.txt](spring-expression-6.0.10.jar/META-INF/notice.txt)
 
-**130** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.0.12` 
+**142** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-expression-6.0.12.jar/META-INF/license.txt](spring-expression-6.0.12.jar/META-INF/license.txt) 
     - [spring-expression-6.0.12.jar/META-INF/notice.txt](spring-expression-6.0.12.jar/META-INF/notice.txt)
 
-**131** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `5.3.30` 
+**143** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-expression-6.2.0.jar/META-INF/license.txt](spring-expression-6.2.0.jar/META-INF/license.txt) 
+    - [spring-expression-6.2.0.jar/META-INF/notice.txt](spring-expression-6.2.0.jar/META-INF/notice.txt)
+
+**144** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-jcl-5.3.30.jar/META-INF/license.txt](spring-jcl-5.3.30.jar/META-INF/license.txt) 
     - [spring-jcl-5.3.30.jar/META-INF/notice.txt](spring-jcl-5.3.30.jar/META-INF/notice.txt)
 
-**132** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.0.10` 
+**145** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-jcl-6.0.10.jar/META-INF/license.txt](spring-jcl-6.0.10.jar/META-INF/license.txt) 
     - [spring-jcl-6.0.10.jar/META-INF/notice.txt](spring-jcl-6.0.10.jar/META-INF/notice.txt)
 
-**133** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.0.12` 
+**146** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-jcl-6.0.12.jar/META-INF/license.txt](spring-jcl-6.0.12.jar/META-INF/license.txt) 
     - [spring-jcl-6.0.12.jar/META-INF/notice.txt](spring-jcl-6.0.12.jar/META-INF/notice.txt)
 
-**134** **Group:** `org.springframework` **Name:** `spring-jdbc` **Version:** `6.0.12` 
+**147** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-jcl-6.2.0.jar/META-INF/license.txt](spring-jcl-6.2.0.jar/META-INF/license.txt) 
+    - [spring-jcl-6.2.0.jar/META-INF/notice.txt](spring-jcl-6.2.0.jar/META-INF/notice.txt)
+
+**148** **Group:** `org.springframework` **Name:** `spring-jdbc` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-jdbc-6.0.12.jar/META-INF/license.txt](spring-jdbc-6.0.12.jar/META-INF/license.txt) 
     - [spring-jdbc-6.0.12.jar/META-INF/notice.txt](spring-jdbc-6.0.12.jar/META-INF/notice.txt)
 
-**135** **Group:** `org.springframework` **Name:** `spring-tx` **Version:** `6.0.12` 
+**149** **Group:** `org.springframework` **Name:** `spring-tx` **Version:** `6.0.12` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-tx-6.0.12.jar/META-INF/license.txt](spring-tx-6.0.12.jar/META-INF/license.txt) 
     - [spring-tx-6.0.12.jar/META-INF/notice.txt](spring-tx-6.0.12.jar/META-INF/notice.txt)
 
-**136** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `5.3.30` 
+**150** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-web-5.3.30.jar/META-INF/license.txt](spring-web-5.3.30.jar/META-INF/license.txt) 
     - [spring-web-5.3.30.jar/META-INF/notice.txt](spring-web-5.3.30.jar/META-INF/notice.txt)
 
-**137** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `6.0.10` 
+**151** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-web-6.0.10.jar/META-INF/license.txt](spring-web-6.0.10.jar/META-INF/license.txt) 
     - [spring-web-6.0.10.jar/META-INF/notice.txt](spring-web-6.0.10.jar/META-INF/notice.txt)
 
-**138** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `5.3.30` 
+**152** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-web-6.2.0.jar/META-INF/license.txt](spring-web-6.2.0.jar/META-INF/license.txt) 
+    - [spring-web-6.2.0.jar/META-INF/notice.txt](spring-web-6.2.0.jar/META-INF/notice.txt)
+
+**153** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `5.3.30` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-webmvc-5.3.30.jar/META-INF/license.txt](spring-webmvc-5.3.30.jar/META-INF/license.txt) 
     - [spring-webmvc-5.3.30.jar/META-INF/notice.txt](spring-webmvc-5.3.30.jar/META-INF/notice.txt)
 
-**139** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `6.0.10` 
+**154** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `6.0.10` 
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-webmvc-6.0.10.jar/META-INF/license.txt](spring-webmvc-6.0.10.jar/META-INF/license.txt) 
     - [spring-webmvc-6.0.10.jar/META-INF/notice.txt](spring-webmvc-6.0.10.jar/META-INF/notice.txt)
 
-**140** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `2.7.17` 
+**155** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `6.2.0` 
+> - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-webmvc-6.2.0.jar/META-INF/license.txt](spring-webmvc-6.2.0.jar/META-INF/license.txt) 
+    - [spring-webmvc-6.2.0.jar/META-INF/notice.txt](spring-webmvc-6.2.0.jar/META-INF/notice.txt)
+
+**156** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-2.7.17.jar/META-INF/NOTICE.txt)
 
-**141** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.1.1` 
+**157** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-3.1.1.jar/META-INF/NOTICE.txt)
 
-**142** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.1.4` 
+**158** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.1.4` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-3.1.4.jar/META-INF/LICENSE.txt](spring-boot-3.1.4.jar/META-INF/LICENSE.txt) 
     - [spring-boot-3.1.4.jar/META-INF/NOTICE.txt](spring-boot-3.1.4.jar/META-INF/NOTICE.txt)
 
-**143** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `2.7.17` 
+**159** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-3.4.0.jar/META-INF/NOTICE.txt)
+
+**160** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-autoconfigure-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-autoconfigure-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-autoconfigure-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-autoconfigure-2.7.17.jar/META-INF/NOTICE.txt)
 
-**144** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.1.1` 
+**161** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-autoconfigure-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-autoconfigure-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-autoconfigure-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-autoconfigure-3.1.1.jar/META-INF/NOTICE.txt)
 
-**145** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.1.4` 
+**162** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.1.4` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-autoconfigure-3.1.4.jar/META-INF/LICENSE.txt](spring-boot-autoconfigure-3.1.4.jar/META-INF/LICENSE.txt) 
     - [spring-boot-autoconfigure-3.1.4.jar/META-INF/NOTICE.txt](spring-boot-autoconfigure-3.1.4.jar/META-INF/NOTICE.txt)
 
-**146** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `2.7.17` 
+**163** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-autoconfigure-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-autoconfigure-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-autoconfigure-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-autoconfigure-3.4.0.jar/META-INF/NOTICE.txt)
+
+**164** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-starter-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-starter-2.7.17.jar/META-INF/NOTICE.txt)
 
-**147** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.1.1` 
+**165** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-starter-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-starter-3.1.1.jar/META-INF/NOTICE.txt)
 
-**148** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.1.4` 
+**166** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.1.4` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-3.1.4.jar/META-INF/LICENSE.txt](spring-boot-starter-3.1.4.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-3.1.4.jar/META-INF/NOTICE.txt](spring-boot-starter-3.1.4.jar/META-INF/NOTICE.txt)
 
-**149** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-jdbc` **Version:** `3.1.4` 
+**167** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-starter-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-starter-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-starter-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-starter-3.4.0.jar/META-INF/NOTICE.txt)
+
+**168** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-jdbc` **Version:** `3.1.4` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-jdbc-3.1.4.jar/META-INF/LICENSE.txt](spring-boot-starter-jdbc-3.1.4.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-jdbc-3.1.4.jar/META-INF/NOTICE.txt](spring-boot-starter-jdbc-3.1.4.jar/META-INF/NOTICE.txt)
 
-**150** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `2.7.17` 
+**169** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-json-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-starter-json-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-json-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-starter-json-2.7.17.jar/META-INF/NOTICE.txt)
 
-**151** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `3.1.1` 
+**170** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-json-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-starter-json-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-json-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-starter-json-3.1.1.jar/META-INF/NOTICE.txt)
 
-**152** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `2.7.17` 
+**171** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-starter-json-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-starter-json-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-starter-json-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-starter-json-3.4.0.jar/META-INF/NOTICE.txt)
+
+**172** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-logging-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-starter-logging-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-logging-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-starter-logging-2.7.17.jar/META-INF/NOTICE.txt)
 
-**153** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.1.1` 
+**173** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-logging-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-starter-logging-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-logging-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-starter-logging-3.1.1.jar/META-INF/NOTICE.txt)
 
-**154** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.1.4` 
+**174** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.1.4` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-logging-3.1.4.jar/META-INF/LICENSE.txt](spring-boot-starter-logging-3.1.4.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-logging-3.1.4.jar/META-INF/NOTICE.txt](spring-boot-starter-logging-3.1.4.jar/META-INF/NOTICE.txt)
 
-**155** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `2.7.17` 
+**175** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-starter-logging-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-starter-logging-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-starter-logging-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-starter-logging-3.4.0.jar/META-INF/NOTICE.txt)
+
+**176** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-tomcat-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-starter-tomcat-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-tomcat-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-starter-tomcat-2.7.17.jar/META-INF/NOTICE.txt)
 
-**156** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `3.1.1` 
+**177** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-tomcat-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-starter-tomcat-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-tomcat-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-starter-tomcat-3.1.1.jar/META-INF/NOTICE.txt)
 
-**157** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `2.7.17` 
+**178** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-starter-tomcat-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-starter-tomcat-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-starter-tomcat-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-starter-tomcat-3.4.0.jar/META-INF/NOTICE.txt)
+
+**179** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `2.7.17` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-web-2.7.17.jar/META-INF/LICENSE.txt](spring-boot-starter-web-2.7.17.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-web-2.7.17.jar/META-INF/NOTICE.txt](spring-boot-starter-web-2.7.17.jar/META-INF/NOTICE.txt)
 
-**158** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `3.1.1` 
+**180** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `3.1.1` 
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-web-3.1.1.jar/META-INF/LICENSE.txt](spring-boot-starter-web-3.1.1.jar/META-INF/LICENSE.txt) 
     - [spring-boot-starter-web-3.1.1.jar/META-INF/NOTICE.txt](spring-boot-starter-web-3.1.1.jar/META-INF/NOTICE.txt)
 
-**159** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `1.30` 
+**181** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `3.4.0` 
+> - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [spring-boot-starter-web-3.4.0.jar/META-INF/LICENSE.txt](spring-boot-starter-web-3.4.0.jar/META-INF/LICENSE.txt) 
+    - [spring-boot-starter-web-3.4.0.jar/META-INF/NOTICE.txt](spring-boot-starter-web-3.4.0.jar/META-INF/NOTICE.txt)
+
+**182** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `1.30` 
 > - **POM Project URL**: [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**160** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `1.33` 
+**183** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `1.33` 
 > - **POM Project URL**: [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**161** **Group:** `software.amazon.awssdk` **Name:** `annotations` **Version:** `2.21.33` 
+**184** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `2.3` 
+> - **POM Project URL**: [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+**185** **Group:** `software.amazon.awssdk` **Name:** `annotations` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [annotations-2.21.33.jar/META-INF/LICENSE.txt](annotations-2.21.33.jar/META-INF/LICENSE.txt) 
     - [annotations-2.21.33.jar/META-INF/NOTICE.txt](annotations-2.21.33.jar/META-INF/NOTICE.txt)
 
-**162** **Group:** `software.amazon.awssdk` **Name:** `annotations` **Version:** `2.26.20` 
+**186** **Group:** `software.amazon.awssdk` **Name:** `annotations` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [annotations-2.26.20.jar/META-INF/LICENSE.txt](annotations-2.26.20.jar/META-INF/LICENSE.txt) 
     - [annotations-2.26.20.jar/META-INF/NOTICE.txt](annotations-2.26.20.jar/META-INF/NOTICE.txt)
 
-**163** **Group:** `software.amazon.awssdk` **Name:** `annotations` **Version:** `2.29.23` 
+**187** **Group:** `software.amazon.awssdk` **Name:** `annotations` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [annotations-2.29.23.jar/META-INF/LICENSE.txt](annotations-2.29.23.jar/META-INF/LICENSE.txt) 
     - [annotations-2.29.23.jar/META-INF/NOTICE.txt](annotations-2.29.23.jar/META-INF/NOTICE.txt)
 
-**164** **Group:** `software.amazon.awssdk` **Name:** `apache-client` **Version:** `2.21.33` 
+**188** **Group:** `software.amazon.awssdk` **Name:** `apache-client` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [apache-client-2.21.33.jar/META-INF/LICENSE.txt](apache-client-2.21.33.jar/META-INF/LICENSE.txt) 
     - [apache-client-2.21.33.jar/META-INF/NOTICE.txt](apache-client-2.21.33.jar/META-INF/NOTICE.txt)
 
-**165** **Group:** `software.amazon.awssdk` **Name:** `apache-client` **Version:** `2.26.20` 
+**189** **Group:** `software.amazon.awssdk` **Name:** `apache-client` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [apache-client-2.26.20.jar/META-INF/LICENSE.txt](apache-client-2.26.20.jar/META-INF/LICENSE.txt) 
     - [apache-client-2.26.20.jar/META-INF/NOTICE.txt](apache-client-2.26.20.jar/META-INF/NOTICE.txt)
 
-**166** **Group:** `software.amazon.awssdk` **Name:** `apache-client` **Version:** `2.29.23` 
+**190** **Group:** `software.amazon.awssdk` **Name:** `apache-client` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [apache-client-2.29.23.jar/META-INF/LICENSE.txt](apache-client-2.29.23.jar/META-INF/LICENSE.txt) 
     - [apache-client-2.29.23.jar/META-INF/NOTICE.txt](apache-client-2.29.23.jar/META-INF/NOTICE.txt)
 
-**167** **Group:** `software.amazon.awssdk` **Name:** `arns` **Version:** `2.21.33` 
+**191** **Group:** `software.amazon.awssdk` **Name:** `arns` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [arns-2.21.33.jar/META-INF/LICENSE.txt](arns-2.21.33.jar/META-INF/LICENSE.txt) 
     - [arns-2.21.33.jar/META-INF/NOTICE.txt](arns-2.21.33.jar/META-INF/NOTICE.txt)
 
-**168** **Group:** `software.amazon.awssdk` **Name:** `arns` **Version:** `2.26.20` 
+**192** **Group:** `software.amazon.awssdk` **Name:** `arns` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [arns-2.26.20.jar/META-INF/LICENSE.txt](arns-2.26.20.jar/META-INF/LICENSE.txt) 
     - [arns-2.26.20.jar/META-INF/NOTICE.txt](arns-2.26.20.jar/META-INF/NOTICE.txt)
 
-**169** **Group:** `software.amazon.awssdk` **Name:** `arns` **Version:** `2.29.23` 
+**193** **Group:** `software.amazon.awssdk` **Name:** `arns` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [arns-2.29.23.jar/META-INF/LICENSE.txt](arns-2.29.23.jar/META-INF/LICENSE.txt) 
     - [arns-2.29.23.jar/META-INF/NOTICE.txt](arns-2.29.23.jar/META-INF/NOTICE.txt)
 
-**170** **Group:** `software.amazon.awssdk` **Name:** `auth` **Version:** `2.21.33` 
+**194** **Group:** `software.amazon.awssdk` **Name:** `auth` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [auth-2.21.33.jar/META-INF/LICENSE.txt](auth-2.21.33.jar/META-INF/LICENSE.txt) 
     - [auth-2.21.33.jar/META-INF/NOTICE.txt](auth-2.21.33.jar/META-INF/NOTICE.txt)
 
-**171** **Group:** `software.amazon.awssdk` **Name:** `auth` **Version:** `2.26.20` 
+**195** **Group:** `software.amazon.awssdk` **Name:** `auth` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [auth-2.26.20.jar/META-INF/LICENSE.txt](auth-2.26.20.jar/META-INF/LICENSE.txt) 
     - [auth-2.26.20.jar/META-INF/NOTICE.txt](auth-2.26.20.jar/META-INF/NOTICE.txt)
 
-**172** **Group:** `software.amazon.awssdk` **Name:** `auth` **Version:** `2.29.23` 
+**196** **Group:** `software.amazon.awssdk` **Name:** `auth` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [auth-2.29.23.jar/META-INF/LICENSE.txt](auth-2.29.23.jar/META-INF/LICENSE.txt) 
     - [auth-2.29.23.jar/META-INF/NOTICE.txt](auth-2.29.23.jar/META-INF/NOTICE.txt)
 
-**173** **Group:** `software.amazon.awssdk` **Name:** `aws-cbor-protocol` **Version:** `2.26.20` 
+**197** **Group:** `software.amazon.awssdk` **Name:** `aws-cbor-protocol` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-cbor-protocol-2.26.20.jar/META-INF/LICENSE.txt](aws-cbor-protocol-2.26.20.jar/META-INF/LICENSE.txt) 
     - [aws-cbor-protocol-2.26.20.jar/META-INF/NOTICE.txt](aws-cbor-protocol-2.26.20.jar/META-INF/NOTICE.txt)
 
-**174** **Group:** `software.amazon.awssdk` **Name:** `aws-core` **Version:** `2.21.33` 
+**198** **Group:** `software.amazon.awssdk` **Name:** `aws-core` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-core-2.21.33.jar/META-INF/LICENSE.txt](aws-core-2.21.33.jar/META-INF/LICENSE.txt) 
     - [aws-core-2.21.33.jar/META-INF/NOTICE.txt](aws-core-2.21.33.jar/META-INF/NOTICE.txt)
 
-**175** **Group:** `software.amazon.awssdk` **Name:** `aws-core` **Version:** `2.26.20` 
+**199** **Group:** `software.amazon.awssdk` **Name:** `aws-core` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-core-2.26.20.jar/META-INF/LICENSE.txt](aws-core-2.26.20.jar/META-INF/LICENSE.txt) 
     - [aws-core-2.26.20.jar/META-INF/NOTICE.txt](aws-core-2.26.20.jar/META-INF/NOTICE.txt)
 
-**176** **Group:** `software.amazon.awssdk` **Name:** `aws-core` **Version:** `2.29.23` 
+**200** **Group:** `software.amazon.awssdk` **Name:** `aws-core` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-core-2.29.23.jar/META-INF/LICENSE.txt](aws-core-2.29.23.jar/META-INF/LICENSE.txt) 
     - [aws-core-2.29.23.jar/META-INF/NOTICE.txt](aws-core-2.29.23.jar/META-INF/NOTICE.txt)
 
-**177** **Group:** `software.amazon.awssdk` **Name:** `aws-json-protocol` **Version:** `2.26.20` 
+**201** **Group:** `software.amazon.awssdk` **Name:** `aws-json-protocol` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-json-protocol-2.26.20.jar/META-INF/LICENSE.txt](aws-json-protocol-2.26.20.jar/META-INF/LICENSE.txt) 
     - [aws-json-protocol-2.26.20.jar/META-INF/NOTICE.txt](aws-json-protocol-2.26.20.jar/META-INF/NOTICE.txt)
 
-**178** **Group:** `software.amazon.awssdk` **Name:** `aws-query-protocol` **Version:** `2.21.33` 
+**202** **Group:** `software.amazon.awssdk` **Name:** `aws-query-protocol` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-query-protocol-2.21.33.jar/META-INF/LICENSE.txt](aws-query-protocol-2.21.33.jar/META-INF/LICENSE.txt) 
     - [aws-query-protocol-2.21.33.jar/META-INF/NOTICE.txt](aws-query-protocol-2.21.33.jar/META-INF/NOTICE.txt)
 
-**179** **Group:** `software.amazon.awssdk` **Name:** `aws-query-protocol` **Version:** `2.26.20` 
+**203** **Group:** `software.amazon.awssdk` **Name:** `aws-query-protocol` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-query-protocol-2.26.20.jar/META-INF/LICENSE.txt](aws-query-protocol-2.26.20.jar/META-INF/LICENSE.txt) 
     - [aws-query-protocol-2.26.20.jar/META-INF/NOTICE.txt](aws-query-protocol-2.26.20.jar/META-INF/NOTICE.txt)
 
-**180** **Group:** `software.amazon.awssdk` **Name:** `aws-query-protocol` **Version:** `2.29.23` 
+**204** **Group:** `software.amazon.awssdk` **Name:** `aws-query-protocol` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-query-protocol-2.29.23.jar/META-INF/LICENSE.txt](aws-query-protocol-2.29.23.jar/META-INF/LICENSE.txt) 
     - [aws-query-protocol-2.29.23.jar/META-INF/NOTICE.txt](aws-query-protocol-2.29.23.jar/META-INF/NOTICE.txt)
 
-**181** **Group:** `software.amazon.awssdk` **Name:** `aws-xml-protocol` **Version:** `2.21.33` 
+**205** **Group:** `software.amazon.awssdk` **Name:** `aws-xml-protocol` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-xml-protocol-2.21.33.jar/META-INF/LICENSE.txt](aws-xml-protocol-2.21.33.jar/META-INF/LICENSE.txt) 
     - [aws-xml-protocol-2.21.33.jar/META-INF/NOTICE.txt](aws-xml-protocol-2.21.33.jar/META-INF/NOTICE.txt)
 
-**182** **Group:** `software.amazon.awssdk` **Name:** `aws-xml-protocol` **Version:** `2.26.20` 
+**206** **Group:** `software.amazon.awssdk` **Name:** `aws-xml-protocol` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-xml-protocol-2.26.20.jar/META-INF/LICENSE.txt](aws-xml-protocol-2.26.20.jar/META-INF/LICENSE.txt) 
     - [aws-xml-protocol-2.26.20.jar/META-INF/NOTICE.txt](aws-xml-protocol-2.26.20.jar/META-INF/NOTICE.txt)
 
-**183** **Group:** `software.amazon.awssdk` **Name:** `aws-xml-protocol` **Version:** `2.29.23` 
+**207** **Group:** `software.amazon.awssdk` **Name:** `aws-xml-protocol` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [aws-xml-protocol-2.29.23.jar/META-INF/LICENSE.txt](aws-xml-protocol-2.29.23.jar/META-INF/LICENSE.txt) 
     - [aws-xml-protocol-2.29.23.jar/META-INF/NOTICE.txt](aws-xml-protocol-2.29.23.jar/META-INF/NOTICE.txt)
 
-**184** **Group:** `software.amazon.awssdk` **Name:** `bedrock` **Version:** `2.26.20` 
+**208** **Group:** `software.amazon.awssdk` **Name:** `bedrock` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [bedrock-2.26.20.jar/META-INF/LICENSE.txt](bedrock-2.26.20.jar/META-INF/LICENSE.txt) 
     - [bedrock-2.26.20.jar/META-INF/NOTICE.txt](bedrock-2.26.20.jar/META-INF/NOTICE.txt)
 
-**185** **Group:** `software.amazon.awssdk` **Name:** `bedrockagent` **Version:** `2.26.20` 
+**209** **Group:** `software.amazon.awssdk` **Name:** `bedrockagent` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [bedrockagent-2.26.20.jar/META-INF/LICENSE.txt](bedrockagent-2.26.20.jar/META-INF/LICENSE.txt) 
     - [bedrockagent-2.26.20.jar/META-INF/NOTICE.txt](bedrockagent-2.26.20.jar/META-INF/NOTICE.txt)
 
-**186** **Group:** `software.amazon.awssdk` **Name:** `bedrockagentruntime` **Version:** `2.26.20` 
+**210** **Group:** `software.amazon.awssdk` **Name:** `bedrockagentruntime` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [bedrockagentruntime-2.26.20.jar/META-INF/LICENSE.txt](bedrockagentruntime-2.26.20.jar/META-INF/LICENSE.txt) 
     - [bedrockagentruntime-2.26.20.jar/META-INF/NOTICE.txt](bedrockagentruntime-2.26.20.jar/META-INF/NOTICE.txt)
 
-**187** **Group:** `software.amazon.awssdk` **Name:** `bedrockruntime` **Version:** `2.26.20` 
+**211** **Group:** `software.amazon.awssdk` **Name:** `bedrockruntime` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [bedrockruntime-2.26.20.jar/META-INF/LICENSE.txt](bedrockruntime-2.26.20.jar/META-INF/LICENSE.txt) 
     - [bedrockruntime-2.26.20.jar/META-INF/NOTICE.txt](bedrockruntime-2.26.20.jar/META-INF/NOTICE.txt)
 
-**188** **Group:** `software.amazon.awssdk` **Name:** `checksums` **Version:** `2.21.33` 
+**212** **Group:** `software.amazon.awssdk` **Name:** `checksums` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [checksums-2.21.33.jar/META-INF/LICENSE.txt](checksums-2.21.33.jar/META-INF/LICENSE.txt) 
     - [checksums-2.21.33.jar/META-INF/NOTICE.txt](checksums-2.21.33.jar/META-INF/NOTICE.txt)
 
-**189** **Group:** `software.amazon.awssdk` **Name:** `checksums` **Version:** `2.26.20` 
+**213** **Group:** `software.amazon.awssdk` **Name:** `checksums` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [checksums-2.26.20.jar/META-INF/LICENSE.txt](checksums-2.26.20.jar/META-INF/LICENSE.txt) 
     - [checksums-2.26.20.jar/META-INF/NOTICE.txt](checksums-2.26.20.jar/META-INF/NOTICE.txt)
 
-**190** **Group:** `software.amazon.awssdk` **Name:** `checksums` **Version:** `2.29.23` 
+**214** **Group:** `software.amazon.awssdk` **Name:** `checksums` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [checksums-2.29.23.jar/META-INF/LICENSE.txt](checksums-2.29.23.jar/META-INF/LICENSE.txt) 
     - [checksums-2.29.23.jar/META-INF/NOTICE.txt](checksums-2.29.23.jar/META-INF/NOTICE.txt)
 
-**191** **Group:** `software.amazon.awssdk` **Name:** `checksums-spi` **Version:** `2.21.33` 
+**215** **Group:** `software.amazon.awssdk` **Name:** `checksums-spi` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [checksums-spi-2.21.33.jar/META-INF/LICENSE.txt](checksums-spi-2.21.33.jar/META-INF/LICENSE.txt) 
     - [checksums-spi-2.21.33.jar/META-INF/NOTICE.txt](checksums-spi-2.21.33.jar/META-INF/NOTICE.txt)
 
-**192** **Group:** `software.amazon.awssdk` **Name:** `checksums-spi` **Version:** `2.26.20` 
+**216** **Group:** `software.amazon.awssdk` **Name:** `checksums-spi` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [checksums-spi-2.26.20.jar/META-INF/LICENSE.txt](checksums-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [checksums-spi-2.26.20.jar/META-INF/NOTICE.txt](checksums-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**193** **Group:** `software.amazon.awssdk` **Name:** `checksums-spi` **Version:** `2.29.23` 
+**217** **Group:** `software.amazon.awssdk` **Name:** `checksums-spi` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [checksums-spi-2.29.23.jar/META-INF/LICENSE.txt](checksums-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [checksums-spi-2.29.23.jar/META-INF/NOTICE.txt](checksums-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**194** **Group:** `software.amazon.awssdk` **Name:** `crt-core` **Version:** `2.21.33` 
+**218** **Group:** `software.amazon.awssdk` **Name:** `crt-core` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [crt-core-2.21.33.jar/META-INF/LICENSE.txt](crt-core-2.21.33.jar/META-INF/LICENSE.txt) 
     - [crt-core-2.21.33.jar/META-INF/NOTICE.txt](crt-core-2.21.33.jar/META-INF/NOTICE.txt)
 
-**195** **Group:** `software.amazon.awssdk` **Name:** `crt-core` **Version:** `2.26.20` 
+**219** **Group:** `software.amazon.awssdk` **Name:** `crt-core` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [crt-core-2.26.20.jar/META-INF/LICENSE.txt](crt-core-2.26.20.jar/META-INF/LICENSE.txt) 
     - [crt-core-2.26.20.jar/META-INF/NOTICE.txt](crt-core-2.26.20.jar/META-INF/NOTICE.txt)
 
-**196** **Group:** `software.amazon.awssdk` **Name:** `crt-core` **Version:** `2.29.23` 
+**220** **Group:** `software.amazon.awssdk` **Name:** `crt-core` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [crt-core-2.29.23.jar/META-INF/LICENSE.txt](crt-core-2.29.23.jar/META-INF/LICENSE.txt) 
     - [crt-core-2.29.23.jar/META-INF/NOTICE.txt](crt-core-2.29.23.jar/META-INF/NOTICE.txt)
 
-**197** **Group:** `software.amazon.awssdk` **Name:** `dynamodb` **Version:** `2.26.20` 
+**221** **Group:** `software.amazon.awssdk` **Name:** `dynamodb` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [dynamodb-2.26.20.jar/META-INF/LICENSE.txt](dynamodb-2.26.20.jar/META-INF/LICENSE.txt) 
     - [dynamodb-2.26.20.jar/META-INF/NOTICE.txt](dynamodb-2.26.20.jar/META-INF/NOTICE.txt)
 
-**198** **Group:** `software.amazon.awssdk` **Name:** `endpoints-spi` **Version:** `2.21.33` 
+**222** **Group:** `software.amazon.awssdk` **Name:** `endpoints-spi` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [endpoints-spi-2.21.33.jar/META-INF/LICENSE.txt](endpoints-spi-2.21.33.jar/META-INF/LICENSE.txt) 
     - [endpoints-spi-2.21.33.jar/META-INF/NOTICE.txt](endpoints-spi-2.21.33.jar/META-INF/NOTICE.txt)
 
-**199** **Group:** `software.amazon.awssdk` **Name:** `endpoints-spi` **Version:** `2.26.20` 
+**223** **Group:** `software.amazon.awssdk` **Name:** `endpoints-spi` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [endpoints-spi-2.26.20.jar/META-INF/LICENSE.txt](endpoints-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [endpoints-spi-2.26.20.jar/META-INF/NOTICE.txt](endpoints-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**200** **Group:** `software.amazon.awssdk` **Name:** `endpoints-spi` **Version:** `2.29.23` 
+**224** **Group:** `software.amazon.awssdk` **Name:** `endpoints-spi` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [endpoints-spi-2.29.23.jar/META-INF/LICENSE.txt](endpoints-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [endpoints-spi-2.29.23.jar/META-INF/NOTICE.txt](endpoints-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**201** **Group:** `software.amazon.awssdk` **Name:** `http-auth` **Version:** `2.21.33` 
+**225** **Group:** `software.amazon.awssdk` **Name:** `http-auth` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-2.21.33.jar/META-INF/LICENSE.txt](http-auth-2.21.33.jar/META-INF/LICENSE.txt) 
     - [http-auth-2.21.33.jar/META-INF/NOTICE.txt](http-auth-2.21.33.jar/META-INF/NOTICE.txt)
 
-**202** **Group:** `software.amazon.awssdk` **Name:** `http-auth` **Version:** `2.26.20` 
+**226** **Group:** `software.amazon.awssdk` **Name:** `http-auth` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-2.26.20.jar/META-INF/LICENSE.txt](http-auth-2.26.20.jar/META-INF/LICENSE.txt) 
     - [http-auth-2.26.20.jar/META-INF/NOTICE.txt](http-auth-2.26.20.jar/META-INF/NOTICE.txt)
 
-**203** **Group:** `software.amazon.awssdk` **Name:** `http-auth` **Version:** `2.29.23` 
+**227** **Group:** `software.amazon.awssdk` **Name:** `http-auth` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-2.29.23.jar/META-INF/LICENSE.txt](http-auth-2.29.23.jar/META-INF/LICENSE.txt) 
     - [http-auth-2.29.23.jar/META-INF/NOTICE.txt](http-auth-2.29.23.jar/META-INF/NOTICE.txt)
 
-**204** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws` **Version:** `2.21.33` 
+**228** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-aws-2.21.33.jar/META-INF/LICENSE.txt](http-auth-aws-2.21.33.jar/META-INF/LICENSE.txt) 
     - [http-auth-aws-2.21.33.jar/META-INF/NOTICE.txt](http-auth-aws-2.21.33.jar/META-INF/NOTICE.txt)
 
-**205** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws` **Version:** `2.26.20` 
+**229** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-aws-2.26.20.jar/META-INF/LICENSE.txt](http-auth-aws-2.26.20.jar/META-INF/LICENSE.txt) 
     - [http-auth-aws-2.26.20.jar/META-INF/NOTICE.txt](http-auth-aws-2.26.20.jar/META-INF/NOTICE.txt)
 
-**206** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws` **Version:** `2.29.23` 
+**230** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-aws-2.29.23.jar/META-INF/LICENSE.txt](http-auth-aws-2.29.23.jar/META-INF/LICENSE.txt) 
     - [http-auth-aws-2.29.23.jar/META-INF/NOTICE.txt](http-auth-aws-2.29.23.jar/META-INF/NOTICE.txt)
 
-**207** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws-eventstream` **Version:** `2.29.23` 
+**231** **Group:** `software.amazon.awssdk` **Name:** `http-auth-aws-eventstream` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-aws-eventstream-2.29.23.jar/META-INF/LICENSE.txt](http-auth-aws-eventstream-2.29.23.jar/META-INF/LICENSE.txt) 
     - [http-auth-aws-eventstream-2.29.23.jar/META-INF/NOTICE.txt](http-auth-aws-eventstream-2.29.23.jar/META-INF/NOTICE.txt)
 
-**208** **Group:** `software.amazon.awssdk` **Name:** `http-auth-spi` **Version:** `2.21.33` 
+**232** **Group:** `software.amazon.awssdk` **Name:** `http-auth-spi` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-spi-2.21.33.jar/META-INF/LICENSE.txt](http-auth-spi-2.21.33.jar/META-INF/LICENSE.txt) 
     - [http-auth-spi-2.21.33.jar/META-INF/NOTICE.txt](http-auth-spi-2.21.33.jar/META-INF/NOTICE.txt)
 
-**209** **Group:** `software.amazon.awssdk` **Name:** `http-auth-spi` **Version:** `2.26.20` 
+**233** **Group:** `software.amazon.awssdk` **Name:** `http-auth-spi` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-spi-2.26.20.jar/META-INF/LICENSE.txt](http-auth-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [http-auth-spi-2.26.20.jar/META-INF/NOTICE.txt](http-auth-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**210** **Group:** `software.amazon.awssdk` **Name:** `http-auth-spi` **Version:** `2.29.23` 
+**234** **Group:** `software.amazon.awssdk` **Name:** `http-auth-spi` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-auth-spi-2.29.23.jar/META-INF/LICENSE.txt](http-auth-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [http-auth-spi-2.29.23.jar/META-INF/NOTICE.txt](http-auth-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**211** **Group:** `software.amazon.awssdk` **Name:** `http-client-spi` **Version:** `2.21.33` 
+**235** **Group:** `software.amazon.awssdk` **Name:** `http-client-spi` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-client-spi-2.21.33.jar/META-INF/LICENSE.txt](http-client-spi-2.21.33.jar/META-INF/LICENSE.txt) 
     - [http-client-spi-2.21.33.jar/META-INF/NOTICE.txt](http-client-spi-2.21.33.jar/META-INF/NOTICE.txt)
 
-**212** **Group:** `software.amazon.awssdk` **Name:** `http-client-spi` **Version:** `2.26.20` 
+**236** **Group:** `software.amazon.awssdk` **Name:** `http-client-spi` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-client-spi-2.26.20.jar/META-INF/LICENSE.txt](http-client-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [http-client-spi-2.26.20.jar/META-INF/NOTICE.txt](http-client-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**213** **Group:** `software.amazon.awssdk` **Name:** `http-client-spi` **Version:** `2.29.23` 
+**237** **Group:** `software.amazon.awssdk` **Name:** `http-client-spi` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [http-client-spi-2.29.23.jar/META-INF/LICENSE.txt](http-client-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [http-client-spi-2.29.23.jar/META-INF/NOTICE.txt](http-client-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**214** **Group:** `software.amazon.awssdk` **Name:** `iam` **Version:** `2.26.20` 
+**238** **Group:** `software.amazon.awssdk` **Name:** `iam` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [iam-2.26.20.jar/META-INF/LICENSE.txt](iam-2.26.20.jar/META-INF/LICENSE.txt) 
     - [iam-2.26.20.jar/META-INF/NOTICE.txt](iam-2.26.20.jar/META-INF/NOTICE.txt)
 
-**215** **Group:** `software.amazon.awssdk` **Name:** `identity-spi` **Version:** `2.21.33` 
+**239** **Group:** `software.amazon.awssdk` **Name:** `identity-spi` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [identity-spi-2.21.33.jar/META-INF/LICENSE.txt](identity-spi-2.21.33.jar/META-INF/LICENSE.txt) 
     - [identity-spi-2.21.33.jar/META-INF/NOTICE.txt](identity-spi-2.21.33.jar/META-INF/NOTICE.txt)
 
-**216** **Group:** `software.amazon.awssdk` **Name:** `identity-spi` **Version:** `2.26.20` 
+**240** **Group:** `software.amazon.awssdk` **Name:** `identity-spi` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [identity-spi-2.26.20.jar/META-INF/LICENSE.txt](identity-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [identity-spi-2.26.20.jar/META-INF/NOTICE.txt](identity-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**217** **Group:** `software.amazon.awssdk` **Name:** `identity-spi` **Version:** `2.29.23` 
+**241** **Group:** `software.amazon.awssdk` **Name:** `identity-spi` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [identity-spi-2.29.23.jar/META-INF/LICENSE.txt](identity-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [identity-spi-2.29.23.jar/META-INF/NOTICE.txt](identity-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**218** **Group:** `software.amazon.awssdk` **Name:** `json-utils` **Version:** `2.21.33` 
+**242** **Group:** `software.amazon.awssdk` **Name:** `json-utils` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [json-utils-2.21.33.jar/META-INF/LICENSE.txt](json-utils-2.21.33.jar/META-INF/LICENSE.txt) 
     - [json-utils-2.21.33.jar/META-INF/NOTICE.txt](json-utils-2.21.33.jar/META-INF/NOTICE.txt)
 
-**219** **Group:** `software.amazon.awssdk` **Name:** `json-utils` **Version:** `2.26.20` 
+**243** **Group:** `software.amazon.awssdk` **Name:** `json-utils` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [json-utils-2.26.20.jar/META-INF/LICENSE.txt](json-utils-2.26.20.jar/META-INF/LICENSE.txt) 
     - [json-utils-2.26.20.jar/META-INF/NOTICE.txt](json-utils-2.26.20.jar/META-INF/NOTICE.txt)
 
-**220** **Group:** `software.amazon.awssdk` **Name:** `json-utils` **Version:** `2.29.23` 
+**244** **Group:** `software.amazon.awssdk` **Name:** `json-utils` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [json-utils-2.29.23.jar/META-INF/LICENSE.txt](json-utils-2.29.23.jar/META-INF/LICENSE.txt) 
     - [json-utils-2.29.23.jar/META-INF/NOTICE.txt](json-utils-2.29.23.jar/META-INF/NOTICE.txt)
 
-**221** **Group:** `software.amazon.awssdk` **Name:** `kinesis` **Version:** `2.26.20` 
+**245** **Group:** `software.amazon.awssdk` **Name:** `kinesis` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [kinesis-2.26.20.jar/META-INF/LICENSE.txt](kinesis-2.26.20.jar/META-INF/LICENSE.txt) 
     - [kinesis-2.26.20.jar/META-INF/NOTICE.txt](kinesis-2.26.20.jar/META-INF/NOTICE.txt)
 
-**222** **Group:** `software.amazon.awssdk` **Name:** `metrics-spi` **Version:** `2.21.33` 
+**246** **Group:** `software.amazon.awssdk` **Name:** `metrics-spi` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [metrics-spi-2.21.33.jar/META-INF/LICENSE.txt](metrics-spi-2.21.33.jar/META-INF/LICENSE.txt) 
     - [metrics-spi-2.21.33.jar/META-INF/NOTICE.txt](metrics-spi-2.21.33.jar/META-INF/NOTICE.txt)
 
-**223** **Group:** `software.amazon.awssdk` **Name:** `metrics-spi` **Version:** `2.26.20` 
+**247** **Group:** `software.amazon.awssdk` **Name:** `metrics-spi` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [metrics-spi-2.26.20.jar/META-INF/LICENSE.txt](metrics-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [metrics-spi-2.26.20.jar/META-INF/NOTICE.txt](metrics-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**224** **Group:** `software.amazon.awssdk` **Name:** `metrics-spi` **Version:** `2.29.23` 
+**248** **Group:** `software.amazon.awssdk` **Name:** `metrics-spi` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [metrics-spi-2.29.23.jar/META-INF/LICENSE.txt](metrics-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [metrics-spi-2.29.23.jar/META-INF/NOTICE.txt](metrics-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**225** **Group:** `software.amazon.awssdk` **Name:** `netty-nio-client` **Version:** `2.21.33` 
+**249** **Group:** `software.amazon.awssdk` **Name:** `netty-nio-client` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [netty-nio-client-2.21.33.jar/META-INF/LICENSE.txt](netty-nio-client-2.21.33.jar/META-INF/LICENSE.txt) 
     - [netty-nio-client-2.21.33.jar/META-INF/NOTICE.txt](netty-nio-client-2.21.33.jar/META-INF/NOTICE.txt)
 
-**226** **Group:** `software.amazon.awssdk` **Name:** `netty-nio-client` **Version:** `2.26.20` 
+**250** **Group:** `software.amazon.awssdk` **Name:** `netty-nio-client` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [netty-nio-client-2.26.20.jar/META-INF/LICENSE.txt](netty-nio-client-2.26.20.jar/META-INF/LICENSE.txt) 
     - [netty-nio-client-2.26.20.jar/META-INF/NOTICE.txt](netty-nio-client-2.26.20.jar/META-INF/NOTICE.txt)
 
-**227** **Group:** `software.amazon.awssdk` **Name:** `netty-nio-client` **Version:** `2.29.23` 
+**251** **Group:** `software.amazon.awssdk` **Name:** `netty-nio-client` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [netty-nio-client-2.29.23.jar/META-INF/LICENSE.txt](netty-nio-client-2.29.23.jar/META-INF/LICENSE.txt) 
     - [netty-nio-client-2.29.23.jar/META-INF/NOTICE.txt](netty-nio-client-2.29.23.jar/META-INF/NOTICE.txt)
 
-**228** **Group:** `software.amazon.awssdk` **Name:** `profiles` **Version:** `2.21.33` 
+**252** **Group:** `software.amazon.awssdk` **Name:** `profiles` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [profiles-2.21.33.jar/META-INF/LICENSE.txt](profiles-2.21.33.jar/META-INF/LICENSE.txt) 
     - [profiles-2.21.33.jar/META-INF/NOTICE.txt](profiles-2.21.33.jar/META-INF/NOTICE.txt)
 
-**229** **Group:** `software.amazon.awssdk` **Name:** `profiles` **Version:** `2.26.20` 
+**253** **Group:** `software.amazon.awssdk` **Name:** `profiles` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [profiles-2.26.20.jar/META-INF/LICENSE.txt](profiles-2.26.20.jar/META-INF/LICENSE.txt) 
     - [profiles-2.26.20.jar/META-INF/NOTICE.txt](profiles-2.26.20.jar/META-INF/NOTICE.txt)
 
-**230** **Group:** `software.amazon.awssdk` **Name:** `profiles` **Version:** `2.29.23` 
+**254** **Group:** `software.amazon.awssdk` **Name:** `profiles` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [profiles-2.29.23.jar/META-INF/LICENSE.txt](profiles-2.29.23.jar/META-INF/LICENSE.txt) 
     - [profiles-2.29.23.jar/META-INF/NOTICE.txt](profiles-2.29.23.jar/META-INF/NOTICE.txt)
 
-**231** **Group:** `software.amazon.awssdk` **Name:** `protocol-core` **Version:** `2.21.33` 
+**255** **Group:** `software.amazon.awssdk` **Name:** `protocol-core` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [protocol-core-2.21.33.jar/META-INF/LICENSE.txt](protocol-core-2.21.33.jar/META-INF/LICENSE.txt) 
     - [protocol-core-2.21.33.jar/META-INF/NOTICE.txt](protocol-core-2.21.33.jar/META-INF/NOTICE.txt)
 
-**232** **Group:** `software.amazon.awssdk` **Name:** `protocol-core` **Version:** `2.26.20` 
+**256** **Group:** `software.amazon.awssdk` **Name:** `protocol-core` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [protocol-core-2.26.20.jar/META-INF/LICENSE.txt](protocol-core-2.26.20.jar/META-INF/LICENSE.txt) 
     - [protocol-core-2.26.20.jar/META-INF/NOTICE.txt](protocol-core-2.26.20.jar/META-INF/NOTICE.txt)
 
-**233** **Group:** `software.amazon.awssdk` **Name:** `protocol-core` **Version:** `2.29.23` 
+**257** **Group:** `software.amazon.awssdk` **Name:** `protocol-core` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [protocol-core-2.29.23.jar/META-INF/LICENSE.txt](protocol-core-2.29.23.jar/META-INF/LICENSE.txt) 
     - [protocol-core-2.29.23.jar/META-INF/NOTICE.txt](protocol-core-2.29.23.jar/META-INF/NOTICE.txt)
 
-**234** **Group:** `software.amazon.awssdk` **Name:** `regions` **Version:** `2.21.33` 
+**258** **Group:** `software.amazon.awssdk` **Name:** `regions` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [regions-2.21.33.jar/META-INF/LICENSE.txt](regions-2.21.33.jar/META-INF/LICENSE.txt) 
     - [regions-2.21.33.jar/META-INF/NOTICE.txt](regions-2.21.33.jar/META-INF/NOTICE.txt)
 
-**235** **Group:** `software.amazon.awssdk` **Name:** `regions` **Version:** `2.26.20` 
+**259** **Group:** `software.amazon.awssdk` **Name:** `regions` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [regions-2.26.20.jar/META-INF/LICENSE.txt](regions-2.26.20.jar/META-INF/LICENSE.txt) 
     - [regions-2.26.20.jar/META-INF/NOTICE.txt](regions-2.26.20.jar/META-INF/NOTICE.txt)
 
-**236** **Group:** `software.amazon.awssdk` **Name:** `regions` **Version:** `2.29.23` 
+**260** **Group:** `software.amazon.awssdk` **Name:** `regions` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [regions-2.29.23.jar/META-INF/LICENSE.txt](regions-2.29.23.jar/META-INF/LICENSE.txt) 
     - [regions-2.29.23.jar/META-INF/NOTICE.txt](regions-2.29.23.jar/META-INF/NOTICE.txt)
 
-**237** **Group:** `software.amazon.awssdk` **Name:** `retries` **Version:** `2.26.20` 
+**261** **Group:** `software.amazon.awssdk` **Name:** `retries` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [retries-2.26.20.jar/META-INF/LICENSE.txt](retries-2.26.20.jar/META-INF/LICENSE.txt) 
     - [retries-2.26.20.jar/META-INF/NOTICE.txt](retries-2.26.20.jar/META-INF/NOTICE.txt)
 
-**238** **Group:** `software.amazon.awssdk` **Name:** `retries` **Version:** `2.29.23` 
+**262** **Group:** `software.amazon.awssdk` **Name:** `retries` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [retries-2.29.23.jar/META-INF/LICENSE.txt](retries-2.29.23.jar/META-INF/LICENSE.txt) 
     - [retries-2.29.23.jar/META-INF/NOTICE.txt](retries-2.29.23.jar/META-INF/NOTICE.txt)
 
-**239** **Group:** `software.amazon.awssdk` **Name:** `retries-spi` **Version:** `2.26.20` 
+**263** **Group:** `software.amazon.awssdk` **Name:** `retries-spi` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [retries-spi-2.26.20.jar/META-INF/LICENSE.txt](retries-spi-2.26.20.jar/META-INF/LICENSE.txt) 
     - [retries-spi-2.26.20.jar/META-INF/NOTICE.txt](retries-spi-2.26.20.jar/META-INF/NOTICE.txt)
 
-**240** **Group:** `software.amazon.awssdk` **Name:** `retries-spi` **Version:** `2.29.23` 
+**264** **Group:** `software.amazon.awssdk` **Name:** `retries-spi` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [retries-spi-2.29.23.jar/META-INF/LICENSE.txt](retries-spi-2.29.23.jar/META-INF/LICENSE.txt) 
     - [retries-spi-2.29.23.jar/META-INF/NOTICE.txt](retries-spi-2.29.23.jar/META-INF/NOTICE.txt)
 
-**241** **Group:** `software.amazon.awssdk` **Name:** `s3` **Version:** `2.21.33` 
+**265** **Group:** `software.amazon.awssdk` **Name:** `s3` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [s3-2.21.33.jar/META-INF/LICENSE.txt](s3-2.21.33.jar/META-INF/LICENSE.txt) 
     - [s3-2.21.33.jar/META-INF/NOTICE.txt](s3-2.21.33.jar/META-INF/NOTICE.txt)
 
-**242** **Group:** `software.amazon.awssdk` **Name:** `s3` **Version:** `2.26.20` 
+**266** **Group:** `software.amazon.awssdk` **Name:** `s3` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [s3-2.26.20.jar/META-INF/LICENSE.txt](s3-2.26.20.jar/META-INF/LICENSE.txt) 
     - [s3-2.26.20.jar/META-INF/NOTICE.txt](s3-2.26.20.jar/META-INF/NOTICE.txt)
 
-**243** **Group:** `software.amazon.awssdk` **Name:** `s3` **Version:** `2.29.23` 
+**267** **Group:** `software.amazon.awssdk` **Name:** `s3` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [s3-2.29.23.jar/META-INF/LICENSE.txt](s3-2.29.23.jar/META-INF/LICENSE.txt) 
     - [s3-2.29.23.jar/META-INF/NOTICE.txt](s3-2.29.23.jar/META-INF/NOTICE.txt)
 
-**244** **Group:** `software.amazon.awssdk` **Name:** `sdk-core` **Version:** `2.21.33` 
+**268** **Group:** `software.amazon.awssdk` **Name:** `sdk-core` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sdk-core-2.21.33.jar/META-INF/LICENSE.txt](sdk-core-2.21.33.jar/META-INF/LICENSE.txt) 
     - [sdk-core-2.21.33.jar/META-INF/NOTICE.txt](sdk-core-2.21.33.jar/META-INF/NOTICE.txt)
 
-**245** **Group:** `software.amazon.awssdk` **Name:** `sdk-core` **Version:** `2.26.20` 
+**269** **Group:** `software.amazon.awssdk` **Name:** `sdk-core` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sdk-core-2.26.20.jar/META-INF/LICENSE.txt](sdk-core-2.26.20.jar/META-INF/LICENSE.txt) 
     - [sdk-core-2.26.20.jar/META-INF/NOTICE.txt](sdk-core-2.26.20.jar/META-INF/NOTICE.txt)
 
-**246** **Group:** `software.amazon.awssdk` **Name:** `sdk-core` **Version:** `2.29.23` 
+**270** **Group:** `software.amazon.awssdk` **Name:** `sdk-core` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sdk-core-2.29.23.jar/META-INF/LICENSE.txt](sdk-core-2.29.23.jar/META-INF/LICENSE.txt) 
     - [sdk-core-2.29.23.jar/META-INF/NOTICE.txt](sdk-core-2.29.23.jar/META-INF/NOTICE.txt)
 
-**247** **Group:** `software.amazon.awssdk` **Name:** `secretsmanager` **Version:** `2.26.20` 
+**271** **Group:** `software.amazon.awssdk` **Name:** `secretsmanager` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [secretsmanager-2.26.20.jar/META-INF/LICENSE.txt](secretsmanager-2.26.20.jar/META-INF/LICENSE.txt) 
     - [secretsmanager-2.26.20.jar/META-INF/NOTICE.txt](secretsmanager-2.26.20.jar/META-INF/NOTICE.txt)
 
-**248** **Group:** `software.amazon.awssdk` **Name:** `sfn` **Version:** `2.26.20` 
+**272** **Group:** `software.amazon.awssdk` **Name:** `sfn` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sfn-2.26.20.jar/META-INF/LICENSE.txt](sfn-2.26.20.jar/META-INF/LICENSE.txt) 
     - [sfn-2.26.20.jar/META-INF/NOTICE.txt](sfn-2.26.20.jar/META-INF/NOTICE.txt)
 
-**249** **Group:** `software.amazon.awssdk` **Name:** `sns` **Version:** `2.26.20` 
+**273** **Group:** `software.amazon.awssdk` **Name:** `sns` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sns-2.26.20.jar/META-INF/LICENSE.txt](sns-2.26.20.jar/META-INF/LICENSE.txt) 
     - [sns-2.26.20.jar/META-INF/NOTICE.txt](sns-2.26.20.jar/META-INF/NOTICE.txt)
 
-**250** **Group:** `software.amazon.awssdk` **Name:** `sqs` **Version:** `2.26.20` 
+**274** **Group:** `software.amazon.awssdk` **Name:** `sqs` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sqs-2.26.20.jar/META-INF/LICENSE.txt](sqs-2.26.20.jar/META-INF/LICENSE.txt) 
     - [sqs-2.26.20.jar/META-INF/NOTICE.txt](sqs-2.26.20.jar/META-INF/NOTICE.txt)
 
-**251** **Group:** `software.amazon.awssdk` **Name:** `sts` **Version:** `2.21.33` 
+**275** **Group:** `software.amazon.awssdk` **Name:** `sts` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [sts-2.21.33.jar/META-INF/LICENSE.txt](sts-2.21.33.jar/META-INF/LICENSE.txt) 
     - [sts-2.21.33.jar/META-INF/NOTICE.txt](sts-2.21.33.jar/META-INF/NOTICE.txt)
 
-**252** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-core` **Version:** `2.21.33` 
+**276** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-core` **Version:** `2.21.33` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [third-party-jackson-core-2.21.33.jar/META-INF/LICENSE](third-party-jackson-core-2.21.33.jar/META-INF/LICENSE) 
@@ -1328,7 +1475,7 @@ _2024-12-10 18:19:03 UTC_
     - [third-party-jackson-core-2.21.33.jar/META-INF/NOTICE](third-party-jackson-core-2.21.33.jar/META-INF/NOTICE) 
     - [third-party-jackson-core-2.21.33.jar/META-INF/NOTICE.txt](third-party-jackson-core-2.21.33.jar/META-INF/NOTICE.txt)
 
-**253** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-core` **Version:** `2.26.20` 
+**277** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-core` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [third-party-jackson-core-2.26.20.jar/META-INF/LICENSE](third-party-jackson-core-2.26.20.jar/META-INF/LICENSE) 
@@ -1336,7 +1483,7 @@ _2024-12-10 18:19:03 UTC_
     - [third-party-jackson-core-2.26.20.jar/META-INF/NOTICE](third-party-jackson-core-2.26.20.jar/META-INF/NOTICE) 
     - [third-party-jackson-core-2.26.20.jar/META-INF/NOTICE.txt](third-party-jackson-core-2.26.20.jar/META-INF/NOTICE.txt)
 
-**254** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-core` **Version:** `2.29.23` 
+**278** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-core` **Version:** `2.29.23` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [third-party-jackson-core-2.29.23.jar/META-INF/LICENSE](third-party-jackson-core-2.29.23.jar/META-INF/LICENSE) 
@@ -1344,7 +1491,7 @@ _2024-12-10 18:19:03 UTC_
     - [third-party-jackson-core-2.29.23.jar/META-INF/NOTICE](third-party-jackson-core-2.29.23.jar/META-INF/NOTICE) 
     - [third-party-jackson-core-2.29.23.jar/META-INF/NOTICE.txt](third-party-jackson-core-2.29.23.jar/META-INF/NOTICE.txt)
 
-**255** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-dataformat-cbor` **Version:** `2.26.20` 
+**279** **Group:** `software.amazon.awssdk` **Name:** `third-party-jackson-dataformat-cbor` **Version:** `2.26.20` 
 > - **POM Project URL**: [https://aws.amazon.com/sdkforjava](https://aws.amazon.com/sdkforjava)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [third-party-jackson-dataformat-cbor-2.26.20.jar/META-INF/LICENSE](third-party-jackson-dataformat-cbor-2.26.20.jar/META-INF/LICENSE) 
@@ -1352,28 +1499,28 @@ _2024-12-10 18:19:03 UTC_
     - [third-party-jackson-dataformat-cbor-2.26.20.jar/META-INF/NOTICE](third-party-jackson-dataformat-cbor-2.26.20.jar/META-INF/NOTICE) 
     - [third-party-jackson-dataformat-cbor-2.26.20.jar/META-INF/NOTICE.txt](third-party-jackson-dataformat-cbor-2.26.20.jar/META-INF/NOTICE.txt)
 
-**256** **Group:** `software.amazon.awssdk` **Name:** `utils` **Version:** `2.21.33` 
+**280** **Group:** `software.amazon.awssdk` **Name:** `utils` **Version:** `2.21.33` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [utils-2.21.33.jar/META-INF/LICENSE.txt](utils-2.21.33.jar/META-INF/LICENSE.txt) 
     - [utils-2.21.33.jar/META-INF/NOTICE.txt](utils-2.21.33.jar/META-INF/NOTICE.txt)
 
-**257** **Group:** `software.amazon.awssdk` **Name:** `utils` **Version:** `2.26.20` 
+**281** **Group:** `software.amazon.awssdk` **Name:** `utils` **Version:** `2.26.20` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [utils-2.26.20.jar/META-INF/LICENSE.txt](utils-2.26.20.jar/META-INF/LICENSE.txt) 
     - [utils-2.26.20.jar/META-INF/NOTICE.txt](utils-2.26.20.jar/META-INF/NOTICE.txt)
 
-**258** **Group:** `software.amazon.awssdk` **Name:** `utils` **Version:** `2.29.23` 
+**282** **Group:** `software.amazon.awssdk` **Name:** `utils` **Version:** `2.29.23` 
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 > - **Embedded license files**: [utils-2.29.23.jar/META-INF/LICENSE.txt](utils-2.29.23.jar/META-INF/LICENSE.txt) 
     - [utils-2.29.23.jar/META-INF/NOTICE.txt](utils-2.29.23.jar/META-INF/NOTICE.txt)
 
-**259** **Group:** `software.amazon.eventstream` **Name:** `eventstream` **Version:** `1.0.1` 
+**283** **Group:** `software.amazon.eventstream` **Name:** `eventstream` **Version:** `1.0.1` 
 > - **POM Project URL**: [https://github.com/awslabs/aws-eventstream-java](https://github.com/awslabs/aws-eventstream-java)
 > - **POM License**: Apache License, Version 2.0 - [https://aws.amazon.com/apache2.0](https://aws.amazon.com/apache2.0)
 
 ## Apache Software License - Version 2.0
 
-**260** **Group:** `org.eclipse.jetty` **Name:** `jetty-client` **Version:** `9.4.53.v20231009` 
+**284** **Group:** `org.eclipse.jetty` **Name:** `jetty-client` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1381,7 +1528,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-client-9.4.53.v20231009.jar/about.html](jetty-client-9.4.53.v20231009.jar/about.html)
 
-**261** **Group:** `org.eclipse.jetty` **Name:** `jetty-http` **Version:** `9.4.53.v20231009` 
+**285** **Group:** `org.eclipse.jetty` **Name:** `jetty-http` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1389,7 +1536,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-http-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-http-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-http-9.4.53.v20231009.jar/about.html](jetty-http-9.4.53.v20231009.jar/about.html)
 
-**262** **Group:** `org.eclipse.jetty` **Name:** `jetty-io` **Version:** `9.4.53.v20231009` 
+**286** **Group:** `org.eclipse.jetty` **Name:** `jetty-io` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1397,7 +1544,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-io-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-io-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-io-9.4.53.v20231009.jar/about.html](jetty-io-9.4.53.v20231009.jar/about.html)
 
-**263** **Group:** `org.eclipse.jetty` **Name:** `jetty-security` **Version:** `9.4.53.v20231009` 
+**287** **Group:** `org.eclipse.jetty` **Name:** `jetty-security` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1405,7 +1552,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-security-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-security-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-security-9.4.53.v20231009.jar/about.html](jetty-security-9.4.53.v20231009.jar/about.html)
 
-**264** **Group:** `org.eclipse.jetty` **Name:** `jetty-server` **Version:** `9.4.53.v20231009` 
+**288** **Group:** `org.eclipse.jetty` **Name:** `jetty-server` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1413,7 +1560,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-server-9.4.53.v20231009.jar/about.html](jetty-server-9.4.53.v20231009.jar/about.html)
 
-**265** **Group:** `org.eclipse.jetty` **Name:** `jetty-servlet` **Version:** `9.4.53.v20231009` 
+**289** **Group:** `org.eclipse.jetty` **Name:** `jetty-servlet` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1421,7 +1568,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-servlet-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-servlet-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-servlet-9.4.53.v20231009.jar/about.html](jetty-servlet-9.4.53.v20231009.jar/about.html)
 
-**266** **Group:** `org.eclipse.jetty` **Name:** `jetty-util` **Version:** `9.4.53.v20231009` 
+**290** **Group:** `org.eclipse.jetty` **Name:** `jetty-util` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1429,7 +1576,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-util-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-util-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-util-9.4.53.v20231009.jar/about.html](jetty-util-9.4.53.v20231009.jar/about.html)
 
-**267** **Group:** `org.eclipse.jetty` **Name:** `jetty-util-ajax` **Version:** `9.4.53.v20231009` 
+**291** **Group:** `org.eclipse.jetty` **Name:** `jetty-util-ajax` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1437,7 +1584,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-util-ajax-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-util-ajax-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-util-ajax-9.4.53.v20231009.jar/about.html](jetty-util-ajax-9.4.53.v20231009.jar/about.html)
 
-**268** **Group:** `org.eclipse.jetty` **Name:** `jetty-webapp` **Version:** `9.4.53.v20231009` 
+**292** **Group:** `org.eclipse.jetty` **Name:** `jetty-webapp` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1445,7 +1592,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-webapp-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-webapp-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-webapp-9.4.53.v20231009.jar/about.html](jetty-webapp-9.4.53.v20231009.jar/about.html)
 
-**269** **Group:** `org.eclipse.jetty` **Name:** `jetty-xml` **Version:** `9.4.53.v20231009` 
+**293** **Group:** `org.eclipse.jetty` **Name:** `jetty-xml` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1453,7 +1600,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-xml-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-xml-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-xml-9.4.53.v20231009.jar/about.html](jetty-xml-9.4.53.v20231009.jar/about.html)
 
-**270** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-api` **Version:** `9.4.53.v20231009` 
+**294** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-api` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1461,7 +1608,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-api-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-api-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-api-9.4.53.v20231009.jar/about.html](websocket-api-9.4.53.v20231009.jar/about.html)
 
-**271** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-client` **Version:** `9.4.53.v20231009` 
+**295** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-client` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1469,7 +1616,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-client-9.4.53.v20231009.jar/about.html](websocket-client-9.4.53.v20231009.jar/about.html)
 
-**272** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-common` **Version:** `9.4.53.v20231009` 
+**296** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-common` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1477,7 +1624,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-common-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-common-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-common-9.4.53.v20231009.jar/about.html](websocket-common-9.4.53.v20231009.jar/about.html)
 
-**273** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-server` **Version:** `9.4.53.v20231009` 
+**297** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-server` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1485,7 +1632,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-server-9.4.53.v20231009.jar/about.html](websocket-server-9.4.53.v20231009.jar/about.html)
 
-**274** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-servlet` **Version:** `9.4.53.v20231009` 
+**298** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-servlet` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1495,46 +1642,58 @@ _2024-12-10 18:19:03 UTC_
 
 ## Apache-2.0
 
-**275** **Group:** `com.google.api.grpc` **Name:** `proto-google-common-protos` **Version:** `2.22.0` 
+**299** **Group:** `com.google.api.grpc` **Name:** `proto-google-common-protos` **Version:** `2.22.0` 
 > - **POM Project URL**: [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**276** **Group:** `com.google.code.gson` **Name:** `gson` **Version:** `2.10.1` 
+**300** **Group:** `com.google.code.gson` **Name:** `gson` **Version:** `2.10.1` 
 > - **Manifest Project URL**: [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
 > - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**277** **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.17.1` 
+**301** **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.17.1` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-codec-1.17.1.jar/META-INF/LICENSE.txt](commons-codec-1.17.1.jar/META-INF/LICENSE.txt) 
     - [commons-codec-1.17.1.jar/META-INF/NOTICE.txt](commons-codec-1.17.1.jar/META-INF/NOTICE.txt)
 
-**278** **Group:** `org.apache.logging.log4j` **Name:** `log4j-api` **Version:** `2.21.1` 
+**302** **Group:** `org.apache.logging.log4j` **Name:** `log4j-api` **Version:** `2.21.1` 
 > - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [log4j-api-2.21.1.jar/META-INF/LICENSE](log4j-api-2.21.1.jar/META-INF/LICENSE) 
     - [log4j-api-2.21.1.jar/META-INF/NOTICE](log4j-api-2.21.1.jar/META-INF/NOTICE)
 
-**279** **Group:** `org.apache.logging.log4j` **Name:** `log4j-core` **Version:** `2.21.1` 
+**303** **Group:** `org.apache.logging.log4j` **Name:** `log4j-api` **Version:** `2.24.1` 
+> - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
+> - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [log4j-api-2.24.1.jar/META-INF/LICENSE](log4j-api-2.24.1.jar/META-INF/LICENSE) 
+    - [log4j-api-2.24.1.jar/META-INF/NOTICE](log4j-api-2.24.1.jar/META-INF/NOTICE)
+
+**304** **Group:** `org.apache.logging.log4j` **Name:** `log4j-core` **Version:** `2.21.1` 
 > - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [log4j-core-2.21.1.jar/META-INF/LICENSE](log4j-core-2.21.1.jar/META-INF/LICENSE) 
     - [log4j-core-2.21.1.jar/META-INF/NOTICE](log4j-core-2.21.1.jar/META-INF/NOTICE)
 
-**280** **Group:** `org.apache.logging.log4j` **Name:** `log4j-slf4j-impl` **Version:** `2.21.1` 
+**305** **Group:** `org.apache.logging.log4j` **Name:** `log4j-slf4j-impl` **Version:** `2.21.1` 
 > - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [log4j-slf4j-impl-2.21.1.jar/META-INF/LICENSE](log4j-slf4j-impl-2.21.1.jar/META-INF/LICENSE) 
     - [log4j-slf4j-impl-2.21.1.jar/META-INF/NOTICE](log4j-slf4j-impl-2.21.1.jar/META-INF/NOTICE)
 
-**281** **Group:** `org.apache.logging.log4j` **Name:** `log4j-to-slf4j` **Version:** `2.21.1` 
+**306** **Group:** `org.apache.logging.log4j` **Name:** `log4j-to-slf4j` **Version:** `2.21.1` 
 > - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [log4j-to-slf4j-2.21.1.jar/META-INF/LICENSE](log4j-to-slf4j-2.21.1.jar/META-INF/LICENSE) 
     - [log4j-to-slf4j-2.21.1.jar/META-INF/NOTICE](log4j-to-slf4j-2.21.1.jar/META-INF/NOTICE)
 
-**282** **Group:** `org.xerial.snappy` **Name:** `snappy-java` **Version:** `1.1.10.5` 
+**307** **Group:** `org.apache.logging.log4j` **Name:** `log4j-to-slf4j` **Version:** `2.24.1` 
+> - **Manifest License**: "Apache-2.0";link="https://www.apache.org/licenses/LICENSE-2.0.txt" (Not Packaged)
+> - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [log4j-to-slf4j-2.24.1.jar/META-INF/LICENSE](log4j-to-slf4j-2.24.1.jar/META-INF/LICENSE) 
+    - [log4j-to-slf4j-2.24.1.jar/META-INF/NOTICE](log4j-to-slf4j-2.24.1.jar/META-INF/NOTICE)
+
+**308** **Group:** `org.xerial.snappy` **Name:** `snappy-java` **Version:** `1.1.10.5` 
 > - **Manifest Project URL**: [http://www.xerial.org/](http://www.xerial.org/)
 > - **POM Project URL**: [https://github.com/xerial/snappy-java](https://github.com/xerial/snappy-java)
 > - **POM License**: Apache-2.0 - [https://www.apache.org/licenses/LICENSE-2.0.html](https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -1542,19 +1701,19 @@ _2024-12-10 18:19:03 UTC_
 
 ## BSD 2-Clause License
 
-**283** **Group:** `com.github.luben` **Name:** `zstd-jni` **Version:** `1.5.5-1` 
+**309** **Group:** `com.github.luben` **Name:** `zstd-jni` **Version:** `1.5.5-1` 
 > - **Manifest License**: BSD 2-Clause License (Not Packaged)
 > - **POM Project URL**: [https://github.com/luben/zstd-jni](https://github.com/luben/zstd-jni)
 > - **POM License**: BSD 2-Clause License - [https://opensource.org/licenses/BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)
 
 ## BSD-2-Clause
 
-**284** **Group:** `org.hdrhistogram` **Name:** `HdrHistogram` **Version:** `2.1.12` 
+**310** **Group:** `org.hdrhistogram` **Name:** `HdrHistogram` **Version:** `2.1.12` 
 > - **POM Project URL**: [http://hdrhistogram.github.io/HdrHistogram/](http://hdrhistogram.github.io/HdrHistogram/)
 > - **POM License**: BSD-2-Clause - [https://opensource.org/licenses/BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)
 > - **POM License**: Public Domain, per Creative Commons CC0 - [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)
 
-**285** **Group:** `org.postgresql` **Name:** `postgresql` **Version:** `42.3.8` 
+**311** **Group:** `org.postgresql` **Name:** `postgresql` **Version:** `42.3.8` 
 > - **Manifest Project URL**: [https://jdbc.postgresql.org/](https://jdbc.postgresql.org/)
 > - **Manifest License**: BSD-2-Clause (Not Packaged)
 > - **POM Project URL**: [https://jdbc.postgresql.org](https://jdbc.postgresql.org)
@@ -1567,23 +1726,23 @@ _2024-12-10 18:19:03 UTC_
 
 ## BSD-3-Clause
 
-**286** **Group:** `com.google.protobuf` **Name:** `protobuf-java` **Version:** `3.25.1` 
+**312** **Group:** `com.google.protobuf` **Name:** `protobuf-java` **Version:** `3.25.1` 
 > - **Manifest Project URL**: [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
 > - **POM License**: BSD-3-Clause - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-**287** **Group:** `com.google.protobuf` **Name:** `protobuf-java-util` **Version:** `3.25.1` 
+**313** **Group:** `com.google.protobuf` **Name:** `protobuf-java-util` **Version:** `3.25.1` 
 > - **Manifest Project URL**: [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
 > - **POM License**: BSD-3-Clause - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 ## CDDL + GPLv2 with classpath exception
 
-**288** **Group:** `javax.annotation` **Name:** `javax.annotation-api` **Version:** `1.3.2` 
+**314** **Group:** `javax.annotation` **Name:** `javax.annotation-api` **Version:** `1.3.2` 
 > - **Manifest Project URL**: [https://javaee.github.io/glassfish](https://javaee.github.io/glassfish)
 > - **POM Project URL**: [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
 > - **POM License**: CDDL + GPLv2 with classpath exception - [https://github.com/javaee/javax.annotation/blob/master/LICENSE](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 > - **Embedded license files**: [javax.annotation-api-1.3.2.jar/META-INF/LICENSE.txt](javax.annotation-api-1.3.2.jar/META-INF/LICENSE.txt)
 
-**289** **Group:** `javax.servlet` **Name:** `javax.servlet-api` **Version:** `4.0.1` 
+**315** **Group:** `javax.servlet` **Name:** `javax.servlet-api` **Version:** `4.0.1` 
 > - **Manifest Project URL**: [https://javaee.github.io](https://javaee.github.io)
 > - **POM Project URL**: [https://javaee.github.io/servlet-spec/](https://javaee.github.io/servlet-spec/)
 > - **POM License**: CDDL + GPLv2 with classpath exception - [https://oss.oracle.com/licenses/CDDL+GPL-1.1](https://oss.oracle.com/licenses/CDDL+GPL-1.1)
@@ -1591,14 +1750,14 @@ _2024-12-10 18:19:03 UTC_
 
 ## EPL 1.0
 
-**290** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.2.224` 
+**316** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.2.224` 
 > - **POM Project URL**: [https://h2database.com](https://h2database.com)
 > - **POM License**: EPL 1.0 - [https://opensource.org/licenses/eclipse-1.0.php](https://opensource.org/licenses/eclipse-1.0.php)
 > - **POM License**: MPL 2.0 - [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/)
 
 ## EPL 2.0
 
-**291** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
+**317** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1608,7 +1767,7 @@ _2024-12-10 18:19:03 UTC_
 > - **Embedded license files**: [jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md](jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md) 
     - [jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md](jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md)
 
-**292** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
+**318** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1620,7 +1779,7 @@ _2024-12-10 18:19:03 UTC_
 
 ## Eclipse Public License - Version 1.0
 
-**293** **Group:** `org.eclipse.jetty` **Name:** `jetty-client` **Version:** `9.4.53.v20231009` 
+**319** **Group:** `org.eclipse.jetty` **Name:** `jetty-client` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1628,7 +1787,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-client-9.4.53.v20231009.jar/about.html](jetty-client-9.4.53.v20231009.jar/about.html)
 
-**294** **Group:** `org.eclipse.jetty` **Name:** `jetty-http` **Version:** `9.4.53.v20231009` 
+**320** **Group:** `org.eclipse.jetty` **Name:** `jetty-http` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1636,7 +1795,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-http-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-http-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-http-9.4.53.v20231009.jar/about.html](jetty-http-9.4.53.v20231009.jar/about.html)
 
-**295** **Group:** `org.eclipse.jetty` **Name:** `jetty-io` **Version:** `9.4.53.v20231009` 
+**321** **Group:** `org.eclipse.jetty` **Name:** `jetty-io` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1644,7 +1803,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-io-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-io-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-io-9.4.53.v20231009.jar/about.html](jetty-io-9.4.53.v20231009.jar/about.html)
 
-**296** **Group:** `org.eclipse.jetty` **Name:** `jetty-security` **Version:** `9.4.53.v20231009` 
+**322** **Group:** `org.eclipse.jetty` **Name:** `jetty-security` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1652,7 +1811,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-security-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-security-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-security-9.4.53.v20231009.jar/about.html](jetty-security-9.4.53.v20231009.jar/about.html)
 
-**297** **Group:** `org.eclipse.jetty` **Name:** `jetty-server` **Version:** `9.4.53.v20231009` 
+**323** **Group:** `org.eclipse.jetty` **Name:** `jetty-server` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1660,7 +1819,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-server-9.4.53.v20231009.jar/about.html](jetty-server-9.4.53.v20231009.jar/about.html)
 
-**298** **Group:** `org.eclipse.jetty` **Name:** `jetty-servlet` **Version:** `9.4.53.v20231009` 
+**324** **Group:** `org.eclipse.jetty` **Name:** `jetty-servlet` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1668,7 +1827,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-servlet-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-servlet-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-servlet-9.4.53.v20231009.jar/about.html](jetty-servlet-9.4.53.v20231009.jar/about.html)
 
-**299** **Group:** `org.eclipse.jetty` **Name:** `jetty-util` **Version:** `9.4.53.v20231009` 
+**325** **Group:** `org.eclipse.jetty` **Name:** `jetty-util` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1676,7 +1835,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-util-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-util-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-util-9.4.53.v20231009.jar/about.html](jetty-util-9.4.53.v20231009.jar/about.html)
 
-**300** **Group:** `org.eclipse.jetty` **Name:** `jetty-util-ajax` **Version:** `9.4.53.v20231009` 
+**326** **Group:** `org.eclipse.jetty` **Name:** `jetty-util-ajax` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1684,7 +1843,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-util-ajax-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-util-ajax-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-util-ajax-9.4.53.v20231009.jar/about.html](jetty-util-ajax-9.4.53.v20231009.jar/about.html)
 
-**301** **Group:** `org.eclipse.jetty` **Name:** `jetty-webapp` **Version:** `9.4.53.v20231009` 
+**327** **Group:** `org.eclipse.jetty` **Name:** `jetty-webapp` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1692,7 +1851,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-webapp-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-webapp-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-webapp-9.4.53.v20231009.jar/about.html](jetty-webapp-9.4.53.v20231009.jar/about.html)
 
-**302** **Group:** `org.eclipse.jetty` **Name:** `jetty-xml` **Version:** `9.4.53.v20231009` 
+**328** **Group:** `org.eclipse.jetty` **Name:** `jetty-xml` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1700,7 +1859,7 @@ _2024-12-10 18:19:03 UTC_
     - [jetty-xml-9.4.53.v20231009.jar/META-INF/NOTICE.txt](jetty-xml-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [jetty-xml-9.4.53.v20231009.jar/about.html](jetty-xml-9.4.53.v20231009.jar/about.html)
 
-**303** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-api` **Version:** `9.4.53.v20231009` 
+**329** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-api` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1708,7 +1867,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-api-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-api-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-api-9.4.53.v20231009.jar/about.html](websocket-api-9.4.53.v20231009.jar/about.html)
 
-**304** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-client` **Version:** `9.4.53.v20231009` 
+**330** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-client` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1716,7 +1875,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-client-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-client-9.4.53.v20231009.jar/about.html](websocket-client-9.4.53.v20231009.jar/about.html)
 
-**305** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-common` **Version:** `9.4.53.v20231009` 
+**331** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-common` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1724,7 +1883,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-common-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-common-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-common-9.4.53.v20231009.jar/about.html](websocket-common-9.4.53.v20231009.jar/about.html)
 
-**306** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-server` **Version:** `9.4.53.v20231009` 
+**332** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-server` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1732,7 +1891,7 @@ _2024-12-10 18:19:03 UTC_
     - [websocket-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt](websocket-server-9.4.53.v20231009.jar/META-INF/NOTICE.txt) 
     - [websocket-server-9.4.53.v20231009.jar/about.html](websocket-server-9.4.53.v20231009.jar/about.html)
 
-**307** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-servlet` **Version:** `9.4.53.v20231009` 
+**333** **Group:** `org.eclipse.jetty.websocket` **Name:** `websocket-servlet` **Version:** `9.4.53.v20231009` 
 > - **Manifest Project URL**: [https://eclipse.org/jetty](https://eclipse.org/jetty)
 > - **POM License**: Apache Software License - Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 > - **POM License**: Eclipse Public License - Version 1.0 - [https://www.eclipse.org/org/documents/epl-v10.php](https://www.eclipse.org/org/documents/epl-v10.php)
@@ -1742,39 +1901,49 @@ _2024-12-10 18:19:03 UTC_
 
 ## Eclipse Public License - v 1.0
 
-**308** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.2.12` 
+**334** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.2.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**309** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.11` 
+**335** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.11` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**310** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.8` 
+**336** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.8` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**311** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.2.12` 
+**337** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.5.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**312** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.11` 
+**338** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.2.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**313** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.8` 
+**339** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.11` 
+> - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+> - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+**340** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.8` 
+> - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+> - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+**341** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.5.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
 ## Eclipse Public License v. 2.0
 
-**314** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
+**342** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1784,7 +1953,7 @@ _2024-12-10 18:19:03 UTC_
 > - **Embedded license files**: [jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md](jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md) 
     - [jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md](jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md)
 
-**315** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
+**343** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1796,7 +1965,7 @@ _2024-12-10 18:19:03 UTC_
 
 ## GNU General Public License, version 2 with the GNU Classpath Exception
 
-**316** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
+**344** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1806,7 +1975,7 @@ _2024-12-10 18:19:03 UTC_
 > - **Embedded license files**: [jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md](jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md) 
     - [jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md](jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md)
 
-**317** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
+**345** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1818,39 +1987,49 @@ _2024-12-10 18:19:03 UTC_
 
 ## GNU Lesser General Public License
 
-**318** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.2.12` 
+**346** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.2.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**319** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.11` 
+**347** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.11` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**320** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.8` 
+**348** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.4.8` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**321** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.2.12` 
+**349** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.5.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**322** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.11` 
+**350** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.2.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-**323** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.8` 
+**351** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.11` 
+> - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+> - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+**352** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.4.8` 
+> - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
+> - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
+> - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+**353** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.5.12` 
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU Lesser General Public License - [http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
 ## GPL2 w/ CPE
 
-**324** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
+**354** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `1.3.5` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1860,7 +2039,7 @@ _2024-12-10 18:19:03 UTC_
 > - **Embedded license files**: [jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md](jakarta.annotation-api-1.3.5.jar/META-INF/LICENSE.md) 
     - [jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md](jakarta.annotation-api-1.3.5.jar/META-INF/NOTICE.md)
 
-**325** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
+**355** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1` 
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
 > - **POM License**: EPL 2.0 - [http://www.eclipse.org/legal/epl-2.0](http://www.eclipse.org/legal/epl-2.0)
@@ -1872,389 +2051,431 @@ _2024-12-10 18:19:03 UTC_
 
 ## MIT License
 
-**326** **Group:** `org.curioswitch.curiostack` **Name:** `protobuf-jackson` **Version:** `2.2.0` 
+**356** **Group:** `org.curioswitch.curiostack` **Name:** `protobuf-jackson` **Version:** `2.2.0` 
 > - **POM Project URL**: [https://github.com/curioswitch/protobuf-jackson](https://github.com/curioswitch/protobuf-jackson)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 
-**327** **Group:** `org.slf4j` **Name:** `jcl-over-slf4j` **Version:** `2.0.16` 
+**357** **Group:** `org.slf4j` **Name:** `jcl-over-slf4j` **Version:** `2.0.16` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [jcl-over-slf4j-2.0.16.jar/META-INF/LICENSE.txt](jcl-over-slf4j-2.0.16.jar/META-INF/LICENSE.txt)
 
-**328** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `1.7.36` 
+**358** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `1.7.36` 
 > - **POM Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-**329** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.7` 
+**359** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.16` 
+> - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
+> - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
+> - **Embedded license files**: [jul-to-slf4j-2.0.16.jar/META-INF/LICENSE.txt](jul-to-slf4j-2.0.16.jar/META-INF/LICENSE.txt)
+
+**360** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.7` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [jul-to-slf4j-2.0.7.jar/META-INF/LICENSE.txt](jul-to-slf4j-2.0.7.jar/META-INF/LICENSE.txt)
 
-**330** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.9` 
+**361** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.9` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [jul-to-slf4j-2.0.9.jar/META-INF/LICENSE.txt](jul-to-slf4j-2.0.9.jar/META-INF/LICENSE.txt)
 
-**331** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `1.7.36` 
+**362** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `1.7.36` 
 > - **POM Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-**332** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.16` 
+**363** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.16` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [slf4j-api-2.0.16.jar/META-INF/LICENSE.txt](slf4j-api-2.0.16.jar/META-INF/LICENSE.txt)
 
-**333** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.7` 
+**364** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.7` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [slf4j-api-2.0.7.jar/META-INF/LICENSE.txt](slf4j-api-2.0.7.jar/META-INF/LICENSE.txt)
 
-**334** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.9` 
+**365** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.9` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [slf4j-api-2.0.9.jar/META-INF/LICENSE.txt](slf4j-api-2.0.9.jar/META-INF/LICENSE.txt)
 
-**335** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `1.7.36` 
+**366** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `1.7.36` 
 > - **POM Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-**336** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.9` 
+**367** **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `2.0.9` 
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 > - **Embedded license files**: [slf4j-simple-2.0.9.jar/META-INF/LICENSE.txt](slf4j-simple-2.0.9.jar/META-INF/LICENSE.txt)
 
 ## MIT license
 
-**337** **Group:** `org.codehaus.mojo` **Name:** `animal-sniffer-annotations` **Version:** `1.23` 
+**368** **Group:** `org.codehaus.mojo` **Name:** `animal-sniffer-annotations` **Version:** `1.23` 
 > - **POM License**: MIT license - [https://spdx.org/licenses/MIT.txt](https://spdx.org/licenses/MIT.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## MIT-0
 
-**338** **Group:** `org.reactivestreams` **Name:** `reactive-streams` **Version:** `1.0.4` 
+**369** **Group:** `org.reactivestreams` **Name:** `reactive-streams` **Version:** `1.0.4` 
 > - **Manifest Project URL**: [http://reactive-streams.org](http://reactive-streams.org)
 > - **POM Project URL**: [http://www.reactive-streams.org/](http://www.reactive-streams.org/)
 > - **POM License**: MIT-0 - [https://spdx.org/licenses/MIT-0.html](https://spdx.org/licenses/MIT-0.html)
 
 ## MPL 2.0
 
-**339** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.2.224` 
+**370** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.2.224` 
 > - **POM Project URL**: [https://h2database.com](https://h2database.com)
 > - **POM License**: EPL 1.0 - [https://opensource.org/licenses/eclipse-1.0.php](https://opensource.org/licenses/eclipse-1.0.php)
 > - **POM License**: MPL 2.0 - [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/)
 
 ## Public Domain
 
-**340** **Group:** `org.json` **Name:** `json` **Version:** `20240303` 
+**371** **Group:** `org.json` **Name:** `json` **Version:** `20240303` 
 > - **POM Project URL**: [https://github.com/douglascrockford/JSON-java](https://github.com/douglascrockford/JSON-java)
 > - **POM License**: Public Domain - [https://github.com/stleary/JSON-java/blob/master/LICENSE](https://github.com/stleary/JSON-java/blob/master/LICENSE)
 
 ## Public Domain, per Creative Commons CC0
 
-**341** **Group:** `org.hdrhistogram` **Name:** `HdrHistogram` **Version:** `2.1.12` 
+**372** **Group:** `org.hdrhistogram` **Name:** `HdrHistogram` **Version:** `2.1.12` 
 > - **POM Project URL**: [http://hdrhistogram.github.io/HdrHistogram/](http://hdrhistogram.github.io/HdrHistogram/)
 > - **POM License**: BSD-2-Clause - [https://opensource.org/licenses/BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)
 > - **POM License**: Public Domain, per Creative Commons CC0 - [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)
 
-**342** **Group:** `org.latencyutils` **Name:** `LatencyUtils` **Version:** `2.0.3` 
+**373** **Group:** `org.latencyutils` **Name:** `LatencyUtils` **Version:** `2.0.3` 
 > - **POM Project URL**: [http://latencyutils.github.io/LatencyUtils/](http://latencyutils.github.io/LatencyUtils/)
 > - **POM License**: Public Domain, per Creative Commons CC0 - [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)
 
 ## The Apache License, Version 2.0
 
-**343** **Group:** `com.linecorp.armeria` **Name:** `armeria` **Version:** `1.26.4` 
+**374** **Group:** `com.linecorp.armeria` **Name:** `armeria` **Version:** `1.26.4` 
 > - **POM Project URL**: [https://armeria.dev/](https://armeria.dev/)
 > - **POM License**: The Apache License, Version 2.0 - [https://www.apache.org/license/LICENSE-2.0.txt](https://www.apache.org/license/LICENSE-2.0.txt)
 > - **Embedded license files**: [armeria-1.26.4.jar/META-INF/LICENSE](armeria-1.26.4.jar/META-INF/LICENSE)
 
-**344** **Group:** `com.linecorp.armeria` **Name:** `armeria-grpc` **Version:** `1.26.4` 
+**375** **Group:** `com.linecorp.armeria` **Name:** `armeria-grpc` **Version:** `1.26.4` 
 > - **POM Project URL**: [https://armeria.dev/](https://armeria.dev/)
 > - **POM License**: The Apache License, Version 2.0 - [https://www.apache.org/license/LICENSE-2.0.txt](https://www.apache.org/license/LICENSE-2.0.txt)
 
-**345** **Group:** `com.linecorp.armeria` **Name:** `armeria-grpc-protocol` **Version:** `1.26.4` 
+**376** **Group:** `com.linecorp.armeria` **Name:** `armeria-grpc-protocol` **Version:** `1.26.4` 
 > - **POM Project URL**: [https://armeria.dev/](https://armeria.dev/)
 > - **POM License**: The Apache License, Version 2.0 - [https://www.apache.org/license/LICENSE-2.0.txt](https://www.apache.org/license/LICENSE-2.0.txt)
 
-**346** **Group:** `com.linecorp.armeria` **Name:** `armeria-protobuf` **Version:** `1.26.4` 
+**377** **Group:** `com.linecorp.armeria` **Name:** `armeria-protobuf` **Version:** `1.26.4` 
 > - **POM Project URL**: [https://armeria.dev/](https://armeria.dev/)
 > - **POM License**: The Apache License, Version 2.0 - [https://www.apache.org/license/LICENSE-2.0.txt](https://www.apache.org/license/LICENSE-2.0.txt)
 
-**347** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api` **Version:** `1.34.1` 
+**378** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**348** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api-events` **Version:** `1.34.1-alpha` 
+**379** **Group:** `io.opentelemetry` **Name:** `opentelemetry-api-incubator` **Version:** `1.44.1-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**349** **Group:** `io.opentelemetry` **Name:** `opentelemetry-context` **Version:** `1.34.1` 
+**380** **Group:** `io.opentelemetry` **Name:** `opentelemetry-context` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**350** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-aws` **Version:** `1.20.1` 
+**381** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-aws` **Version:** `1.20.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**351** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-incubator` **Version:** `1.34.1-alpha` 
+**382** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-trace-propagators` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**352** **Group:** `io.opentelemetry` **Name:** `opentelemetry-extension-trace-propagators` **Version:** `1.34.1` 
+**383** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**353** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk` **Version:** `1.34.1` 
+**384** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-common` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**354** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-common` **Version:** `1.34.1` 
+**385** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-logs` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**355** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-logs` **Version:** `1.34.1` 
+**386** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-metrics` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**356** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-metrics` **Version:** `1.34.1` 
+**387** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-trace` **Version:** `1.44.1` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**357** **Group:** `io.opentelemetry` **Name:** `opentelemetry-sdk-trace` **Version:** `1.34.1` 
+**388** **Group:** `io.opentelemetry` **Name:** `opentelemetry-semconv` **Version:** `1.28.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**358** **Group:** `io.opentelemetry` **Name:** `opentelemetry-semconv` **Version:** `1.28.0-alpha` 
-> - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)
-> - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-**359** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-resources` **Version:** `1.32.0-alpha` 
+**389** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-resources` **Version:** `1.39.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**360** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-xray` **Version:** `1.32.0` 
+**390** **Group:** `io.opentelemetry.contrib` **Name:** `opentelemetry-aws-xray` **Version:** `1.39.0` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**361** **Group:** `io.opentelemetry.proto` **Name:** `opentelemetry-proto` **Version:** `1.0.0-alpha` 
+**391** **Group:** `io.opentelemetry.proto` **Name:** `opentelemetry-proto` **Version:** `1.0.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/opentelemetry-proto-java](https://github.com/open-telemetry/opentelemetry-proto-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**362** **Group:** `io.opentelemetry.semconv` **Name:** `opentelemetry-semconv` **Version:** `1.21.0-alpha` 
+**392** **Group:** `io.opentelemetry.semconv` **Name:** `opentelemetry-semconv` **Version:** `1.28.0-alpha` 
 > - **POM Project URL**: [https://github.com/open-telemetry/semantic-conventions-java](https://github.com/open-telemetry/semantic-conventions-java)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**363** **Group:** `org.apache.kafka` **Name:** `kafka-clients` **Version:** `3.6.1` 
+**393** **Group:** `org.apache.kafka` **Name:** `kafka-clients` **Version:** `3.6.1` 
 > - **POM Project URL**: [https://kafka.apache.org](https://kafka.apache.org)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [kafka-clients-3.6.1.jar/LICENSE](kafka-clients-3.6.1.jar/LICENSE) 
     - [kafka-clients-3.6.1.jar/NOTICE](kafka-clients-3.6.1.jar/NOTICE) 
     - [kafka-clients-3.6.1.jar/common/message/README.md](kafka-clients-3.6.1.jar/common/message/README.md)
 
-**364** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `1.8.22` 
+**394** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `1.9.10` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**365** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `1.9.10` 
+**395** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib` **Version:** `2.1.0-RC2` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**366** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-common` **Version:** `1.8.22` 
+**396** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-common` **Version:** `1.9.10` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**367** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-common` **Version:** `1.9.10` 
+**397** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk7` **Version:** `1.9.10` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**368** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk7` **Version:** `1.8.22` 
+**398** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk8` **Version:** `1.9.10` 
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**369** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk7` **Version:** `1.9.10` 
-> - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
-> - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-**370** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk8` **Version:** `1.8.22` 
-> - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
-> - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-**371** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk8` **Version:** `1.9.10` 
-> - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
-> - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-**372** **Group:** `software.amazon.ion` **Name:** `ion-java` **Version:** `1.0.2` 
+**399** **Group:** `software.amazon.ion` **Name:** `ion-java` **Version:** `1.0.2` 
 > - **POM Project URL**: [https://github.com/amznlabs/ion-java/](https://github.com/amznlabs/ion-java/)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## The Apache Software License, Version 2.0
 
-**373** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.16.0` 
+**400** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.16.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-annotations-2.16.0.jar/META-INF/LICENSE](jackson-annotations-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-annotations-2.16.0.jar/META-INF/NOTICE](jackson-annotations-2.16.0.jar/META-INF/NOTICE)
 
-**374** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.17.2` 
+**401** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.17.2` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-annotations-2.17.2.jar/META-INF/LICENSE](jackson-annotations-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-annotations-2.17.2.jar/META-INF/NOTICE](jackson-annotations-2.17.2.jar/META-INF/NOTICE)
 
-**375** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.16.0` 
+**402** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.18.1` 
+> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-annotations-2.18.1.jar/META-INF/LICENSE](jackson-annotations-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-annotations-2.18.1.jar/META-INF/NOTICE](jackson-annotations-2.18.1.jar/META-INF/NOTICE)
+
+**403** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.16.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-core-2.16.0.jar/META-INF/LICENSE](jackson-core-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-core-2.16.0.jar/META-INF/NOTICE](jackson-core-2.16.0.jar/META-INF/NOTICE)
 
-**376** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.17.2` 
+**404** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.17.2` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-core-2.17.2.jar/META-INF/LICENSE](jackson-core-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-core-2.17.2.jar/META-INF/NOTICE](jackson-core-2.17.2.jar/META-INF/NOTICE)
 
-**377** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.16.0` 
+**405** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-core` **Version:** `2.18.1` 
+> - **Project URL**: [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-core-2.18.1.jar/META-INF/LICENSE](jackson-core-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-core-2.18.1.jar/META-INF/NOTICE](jackson-core-2.18.1.jar/META-INF/NOTICE)
+
+**406** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.16.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-databind-2.16.0.jar/META-INF/LICENSE](jackson-databind-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-databind-2.16.0.jar/META-INF/NOTICE](jackson-databind-2.16.0.jar/META-INF/NOTICE)
 
-**378** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.17.2` 
+**407** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.17.2` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-databind-2.17.2.jar/META-INF/LICENSE](jackson-databind-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-databind-2.17.2.jar/META-INF/NOTICE](jackson-databind-2.17.2.jar/META-INF/NOTICE)
 
-**379** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.16.0` 
+**408** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.1` 
+> - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-databind-2.18.1.jar/META-INF/LICENSE](jackson-databind-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.18.1.jar/META-INF/NOTICE](jackson-databind-2.18.1.jar/META-INF/NOTICE)
+
+**409** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.16.0` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-binary](https://github.com/FasterXML/jackson-dataformats-binary)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-dataformat-cbor-2.16.0.jar/META-INF/LICENSE](jackson-dataformat-cbor-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-dataformat-cbor-2.16.0.jar/META-INF/NOTICE](jackson-dataformat-cbor-2.16.0.jar/META-INF/NOTICE)
 
-**380** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.17.2` 
+**410** **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-cbor` **Version:** `2.17.2` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-binary](https://github.com/FasterXML/jackson-dataformats-binary)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-dataformat-cbor-2.17.2.jar/META-INF/LICENSE](jackson-dataformat-cbor-2.17.2.jar/META-INF/LICENSE) 
     - [jackson-dataformat-cbor-2.17.2.jar/META-INF/NOTICE](jackson-dataformat-cbor-2.17.2.jar/META-INF/NOTICE)
 
-**381** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jdk8` **Version:** `2.16.0` 
+**411** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jdk8` **Version:** `2.16.0` 
 > - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-datatype-jdk8-2.16.0.jar/META-INF/LICENSE](jackson-datatype-jdk8-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-datatype-jdk8-2.16.0.jar/META-INF/NOTICE](jackson-datatype-jdk8-2.16.0.jar/META-INF/NOTICE)
 
-**382** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jsr310` **Version:** `2.16.0` 
+**412** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jdk8` **Version:** `2.18.1` 
+> - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-datatype-jdk8-2.18.1.jar/META-INF/LICENSE](jackson-datatype-jdk8-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-datatype-jdk8-2.18.1.jar/META-INF/NOTICE](jackson-datatype-jdk8-2.18.1.jar/META-INF/NOTICE)
+
+**413** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jsr310` **Version:** `2.16.0` 
 > - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-datatype-jsr310-2.16.0.jar/META-INF/LICENSE](jackson-datatype-jsr310-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-datatype-jsr310-2.16.0.jar/META-INF/NOTICE](jackson-datatype-jsr310-2.16.0.jar/META-INF/NOTICE)
 
-**383** **Group:** `com.fasterxml.jackson.module` **Name:** `jackson-module-parameter-names` **Version:** `2.16.0` 
+**414** **Group:** `com.fasterxml.jackson.datatype` **Name:** `jackson-datatype-jsr310` **Version:** `2.18.1` 
+> - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-datatype-jsr310-2.18.1.jar/META-INF/LICENSE](jackson-datatype-jsr310-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-datatype-jsr310-2.18.1.jar/META-INF/NOTICE](jackson-datatype-jsr310-2.18.1.jar/META-INF/NOTICE)
+
+**415** **Group:** `com.fasterxml.jackson.module` **Name:** `jackson-module-parameter-names` **Version:** `2.16.0` 
 > - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-module-parameter-names-2.16.0.jar/META-INF/LICENSE](jackson-module-parameter-names-2.16.0.jar/META-INF/LICENSE) 
     - [jackson-module-parameter-names-2.16.0.jar/META-INF/NOTICE](jackson-module-parameter-names-2.16.0.jar/META-INF/NOTICE)
 
-**384** **Group:** `com.google.code.findbugs` **Name:** `jsr305` **Version:** `3.0.2` 
+**416** **Group:** `com.fasterxml.jackson.module` **Name:** `jackson-module-parameter-names` **Version:** `2.18.1` 
+> - **Manifest Project URL**: [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
+> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [jackson-module-parameter-names-2.18.1.jar/META-INF/LICENSE](jackson-module-parameter-names-2.18.1.jar/META-INF/LICENSE) 
+    - [jackson-module-parameter-names-2.18.1.jar/META-INF/NOTICE](jackson-module-parameter-names-2.18.1.jar/META-INF/NOTICE)
+
+**417** **Group:** `com.google.code.findbugs` **Name:** `jsr305` **Version:** `3.0.2` 
 > - **POM Project URL**: [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**385** **Group:** `com.google.guava` **Name:** `failureaccess` **Version:** `1.0.2` 
+**418** **Group:** `com.google.guava` **Name:** `failureaccess` **Version:** `1.0.2` 
 > - **Manifest Project URL**: [https://github.com/google/guava/](https://github.com/google/guava/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**386** **Group:** `com.google.guava` **Name:** `listenablefuture` **Version:** `9999.0-empty-to-avoid-conflict-with-guava` 
+**419** **Group:** `com.google.guava` **Name:** `listenablefuture` **Version:** `9999.0-empty-to-avoid-conflict-with-guava` 
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**387** **Group:** `com.sparkjava` **Name:** `spark-core` **Version:** `2.9.4` 
+**420** **Group:** `com.sparkjava` **Name:** `spark-core` **Version:** `2.9.4` 
 > - **POM Project URL**: [http://www.sparkjava.com](http://www.sparkjava.com)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**388** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.12.0` 
+**421** **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.12.0` 
 > - **POM Project URL**: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [okhttp-4.12.0.jar/okhttp3/internal/publicsuffix/NOTICE](okhttp-4.12.0.jar/okhttp3/internal/publicsuffix/NOTICE)
 
-**389** **Group:** `com.squareup.okio` **Name:** `okio-jvm` **Version:** `3.6.0` 
+**422** **Group:** `com.squareup.okio` **Name:** `okio-jvm` **Version:** `3.6.0` 
 > - **POM Project URL**: [https://github.com/square/okio/](https://github.com/square/okio/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**390** **Group:** `com.zaxxer` **Name:** `HikariCP` **Version:** `5.0.1` 
+**423** **Group:** `com.zaxxer` **Name:** `HikariCP` **Version:** `5.0.1` 
 > - **Manifest Project URL**: [https://github.com/brettwooldridge](https://github.com/brettwooldridge)
 > - **POM Project URL**: [https://github.com/brettwooldridge/HikariCP](https://github.com/brettwooldridge/HikariCP)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**391** **Group:** `commons-logging` **Name:** `commons-logging` **Version:** `1.2` 
+**424** **Group:** `commons-logging` **Name:** `commons-logging` **Version:** `1.2` 
 > - **Project URL**: [http://commons.apache.org/proper/commons-logging/](http://commons.apache.org/proper/commons-logging/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-logging-1.2.jar/META-INF/LICENSE.txt](commons-logging-1.2.jar/META-INF/LICENSE.txt) 
     - [commons-logging-1.2.jar/META-INF/NOTICE.txt](commons-logging-1.2.jar/META-INF/NOTICE.txt)
 
-**392** **Group:** `io.micrometer` **Name:** `micrometer-commons` **Version:** `1.10.8` 
+**425** **Group:** `io.micrometer` **Name:** `micrometer-commons` **Version:** `1.10.8` 
 > - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [micrometer-commons-1.10.8.jar/META-INF/LICENSE](micrometer-commons-1.10.8.jar/META-INF/LICENSE) 
     - [micrometer-commons-1.10.8.jar/META-INF/NOTICE](micrometer-commons-1.10.8.jar/META-INF/NOTICE)
 
-**393** **Group:** `io.micrometer` **Name:** `micrometer-commons` **Version:** `1.11.5` 
+**426** **Group:** `io.micrometer` **Name:** `micrometer-commons` **Version:** `1.11.5` 
 > - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [micrometer-commons-1.11.5.jar/META-INF/LICENSE](micrometer-commons-1.11.5.jar/META-INF/LICENSE) 
     - [micrometer-commons-1.11.5.jar/META-INF/NOTICE](micrometer-commons-1.11.5.jar/META-INF/NOTICE)
 
-**394** **Group:** `io.micrometer` **Name:** `micrometer-core` **Version:** `1.11.5` 
+**427** **Group:** `io.micrometer` **Name:** `micrometer-commons` **Version:** `1.14.0` 
+> - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [micrometer-commons-1.14.0.jar/META-INF/LICENSE](micrometer-commons-1.14.0.jar/META-INF/LICENSE) 
+    - [micrometer-commons-1.14.0.jar/META-INF/NOTICE](micrometer-commons-1.14.0.jar/META-INF/NOTICE)
+
+**428** **Group:** `io.micrometer` **Name:** `micrometer-core` **Version:** `1.11.5` 
 > - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [micrometer-core-1.11.5.jar/META-INF/LICENSE](micrometer-core-1.11.5.jar/META-INF/LICENSE) 
     - [micrometer-core-1.11.5.jar/META-INF/NOTICE](micrometer-core-1.11.5.jar/META-INF/NOTICE)
 
-**395** **Group:** `io.micrometer` **Name:** `micrometer-observation` **Version:** `1.10.8` 
+**429** **Group:** `io.micrometer` **Name:** `micrometer-observation` **Version:** `1.10.8` 
 > - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [micrometer-observation-1.10.8.jar/META-INF/LICENSE](micrometer-observation-1.10.8.jar/META-INF/LICENSE) 
     - [micrometer-observation-1.10.8.jar/META-INF/NOTICE](micrometer-observation-1.10.8.jar/META-INF/NOTICE)
 
-**396** **Group:** `io.micrometer` **Name:** `micrometer-observation` **Version:** `1.11.5` 
+**430** **Group:** `io.micrometer` **Name:** `micrometer-observation` **Version:** `1.11.5` 
 > - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [micrometer-observation-1.11.5.jar/META-INF/LICENSE](micrometer-observation-1.11.5.jar/META-INF/LICENSE) 
     - [micrometer-observation-1.11.5.jar/META-INF/NOTICE](micrometer-observation-1.11.5.jar/META-INF/NOTICE)
 
-**397** **Group:** `io.netty` **Name:** `netty-tcnative-boringssl-static` **Version:** `2.0.61.Final` 
+**431** **Group:** `io.micrometer` **Name:** `micrometer-observation` **Version:** `1.14.0` 
+> - **POM Project URL**: [https://github.com/micrometer-metrics/micrometer](https://github.com/micrometer-metrics/micrometer)
+> - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+> - **Embedded license files**: [micrometer-observation-1.14.0.jar/META-INF/LICENSE](micrometer-observation-1.14.0.jar/META-INF/LICENSE) 
+    - [micrometer-observation-1.14.0.jar/META-INF/NOTICE](micrometer-observation-1.14.0.jar/META-INF/NOTICE)
+
+**432** **Group:** `io.netty` **Name:** `netty-tcnative-boringssl-static` **Version:** `2.0.61.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM Project URL**: [https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/](https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar/META-INF/LICENSE.txt](netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar/META-INF/LICENSE.txt) 
     - [netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar/META-INF/NOTICE.txt](netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar/META-INF/NOTICE.txt)
 
-**398** **Group:** `io.netty` **Name:** `netty-tcnative-classes` **Version:** `2.0.61.Final` 
+**433** **Group:** `io.netty` **Name:** `netty-tcnative-classes` **Version:** `2.0.61.Final` 
 > - **Manifest Project URL**: [https://netty.io/](https://netty.io/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**399** **Group:** `org.codehaus.mojo` **Name:** `animal-sniffer-annotations` **Version:** `1.23` 
+**434** **Group:** `org.codehaus.mojo` **Name:** `animal-sniffer-annotations` **Version:** `1.23` 
 > - **POM License**: MIT license - [https://spdx.org/licenses/MIT.txt](https://spdx.org/licenses/MIT.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**400** **Group:** `org.jetbrains` **Name:** `annotations` **Version:** `13.0` 
+**435** **Group:** `org.jetbrains` **Name:** `annotations` **Version:** `13.0` 
 > - **POM Project URL**: [http://www.jetbrains.org](http://www.jetbrains.org)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**401** **Group:** `org.lz4` **Name:** `lz4-java` **Version:** `1.8.0` 
+**436** **Group:** `org.lz4` **Name:** `lz4-java` **Version:** `1.8.0` 
 > - **POM Project URL**: [https://github.com/lz4/lz4-java](https://github.com/lz4/lz4-java)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## The GNU General Public License, v2 with Universal FOSS Exception, v1.0
 
-**402** **Group:** `com.mysql` **Name:** `mysql-connector-j` **Version:** `8.4.0` 
+**437** **Group:** `com.mysql` **Name:** `mysql-connector-j` **Version:** `8.4.0` 
 > - **POM Project URL**: [http://dev.mysql.com/doc/connector-j/en/](http://dev.mysql.com/doc/connector-j/en/)
 > - **POM License**: The GNU General Public License, v2 with Universal FOSS Exception, v1.0
 > - **Embedded license files**: [mysql-connector-j-8.4.0.jar/LICENSE](mysql-connector-j-8.4.0.jar/LICENSE) 
@@ -2262,13 +2483,13 @@ _2024-12-10 18:19:03 UTC_
 
 ## The MIT License
 
-**403** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.41.0` 
+**438** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.41.0` 
 > - **Manifest License**: MIT (Not Packaged)
 > - **POM Project URL**: [https://checkerframework.org/](https://checkerframework.org/)
 > - **POM License**: The MIT License - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 > - **Embedded license files**: [checker-qual-3.41.0.jar/META-INF/LICENSE.txt](checker-qual-3.41.0.jar/META-INF/LICENSE.txt)
 
-**404** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.5.0` 
+**439** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.5.0` 
 > - **Manifest License**: MIT (Not Packaged)
 > - **POM Project URL**: [https://checkerframework.org](https://checkerframework.org)
 > - **POM License**: The MIT License - [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
@@ -2276,12 +2497,12 @@ _2024-12-10 18:19:03 UTC_
 
 ## Unknown
 
-**405** **Group:** `com.squareup.okio` **Name:** `okio` **Version:** `3.6.0` 
+**440** **Group:** `com.squareup.okio` **Name:** `okio` **Version:** `3.6.0` 
 
-**406** **Group:** `io.opentelemetry` **Name:** `opentelemetry-bom` **Version:** `1.34.1` 
+**441** **Group:** `io.opentelemetry` **Name:** `opentelemetry-bom` **Version:** `1.44.1` 
 
-**407** **Group:** `io.opentelemetry` **Name:** `opentelemetry-bom-alpha` **Version:** `1.34.1-alpha` 
+**442** **Group:** `io.opentelemetry` **Name:** `opentelemetry-bom-alpha` **Version:** `1.44.1-alpha` 
 
-**408** **Group:** `io.opentelemetry.instrumentation` **Name:** `opentelemetry-instrumentation-bom` **Version:** `1.32.1-adot2` 
+**443** **Group:** `io.opentelemetry.instrumentation` **Name:** `opentelemetry-instrumentation-bom` **Version:** `2.10.0-adot1` 
 
 

--- a/licenses/log4j-api-2.24.1.jar/META-INF/LICENSE
+++ b/licenses/log4j-api-2.24.1.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/log4j-api-2.24.1.jar/META-INF/NOTICE
+++ b/licenses/log4j-api-2.24.1.jar/META-INF/NOTICE
@@ -1,0 +1,6 @@
+Apache Log4j API
+Copyright 1999-2024 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/licenses/log4j-to-slf4j-2.24.1.jar/META-INF/LICENSE
+++ b/licenses/log4j-to-slf4j-2.24.1.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/log4j-to-slf4j-2.24.1.jar/META-INF/NOTICE
+++ b/licenses/log4j-to-slf4j-2.24.1.jar/META-INF/NOTICE
@@ -1,0 +1,6 @@
+Log4j API to SLF4J Adapter
+Copyright 1999-2024 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/licenses/micrometer-commons-1.14.0.jar/META-INF/LICENSE
+++ b/licenses/micrometer-commons-1.14.0.jar/META-INF/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/micrometer-commons-1.14.0.jar/META-INF/NOTICE
+++ b/licenses/micrometer-commons-1.14.0.jar/META-INF/NOTICE
@@ -1,0 +1,45 @@
+Micrometer
+
+Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-------------------------------------------------------------------------------
+
+This product contains a modified portion of 'io.netty.util.internal.logging',
+in the Netty/Common library distributed by The Netty Project:
+
+  * Copyright 2013 The Netty Project
+  * License: Apache License v2.0
+  * Homepage: https://netty.io
+
+This product contains a modified portion of 'StringUtils.isBlank()',
+in the Commons Lang library distributed by The Apache Software Foundation:
+
+  * Copyright 2001-2019 The Apache Software Foundation
+  * License: Apache License v2.0
+  * Homepage: https://commons.apache.org/proper/commons-lang/
+
+This product contains a modified portion of 'JsonUtf8Writer',
+in the Moshi library distributed by Square, Inc:
+
+  * Copyright 2010 Google Inc.
+  * License: Apache License v2.0
+  * Homepage: https://github.com/square/moshi
+
+This product contains a modified portion of the 'org.springframework.lang'
+package in the Spring Framework library, distributed by VMware, Inc:
+
+  * Copyright 2002-2019 the original author or authors.
+  * License: Apache License v2.0
+  * Homepage: https://spring.io/projects/spring-framework

--- a/licenses/micrometer-observation-1.14.0.jar/META-INF/LICENSE
+++ b/licenses/micrometer-observation-1.14.0.jar/META-INF/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/micrometer-observation-1.14.0.jar/META-INF/NOTICE
+++ b/licenses/micrometer-observation-1.14.0.jar/META-INF/NOTICE
@@ -1,0 +1,45 @@
+Micrometer
+
+Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-------------------------------------------------------------------------------
+
+This product contains a modified portion of 'io.netty.util.internal.logging',
+in the Netty/Common library distributed by The Netty Project:
+
+  * Copyright 2013 The Netty Project
+  * License: Apache License v2.0
+  * Homepage: https://netty.io
+
+This product contains a modified portion of 'StringUtils.isBlank()',
+in the Commons Lang library distributed by The Apache Software Foundation:
+
+  * Copyright 2001-2019 The Apache Software Foundation
+  * License: Apache License v2.0
+  * Homepage: https://commons.apache.org/proper/commons-lang/
+
+This product contains a modified portion of 'JsonUtf8Writer',
+in the Moshi library distributed by Square, Inc:
+
+  * Copyright 2010 Google Inc.
+  * License: Apache License v2.0
+  * Homepage: https://github.com/square/moshi
+
+This product contains a modified portion of the 'org.springframework.lang'
+package in the Spring Framework library, distributed by VMware, Inc:
+
+  * Copyright 2002-2019 the original author or authors.
+  * License: Apache License v2.0
+  * Homepage: https://spring.io/projects/spring-framework

--- a/licenses/spring-aop-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-aop-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-aop-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-aop-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-beans-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-beans-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-beans-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-beans-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-boot-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-boot-autoconfigure-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-autoconfigure-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-autoconfigure-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-autoconfigure-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-boot-starter-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-starter-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-starter-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-starter-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-boot-starter-json-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-starter-json-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-starter-json-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-starter-json-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-boot-starter-logging-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-starter-logging-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-starter-logging-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-starter-logging-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-boot-starter-tomcat-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-starter-tomcat-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-starter-tomcat-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-starter-tomcat-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-boot-starter-web-3.4.0.jar/META-INF/LICENSE.txt
+++ b/licenses/spring-boot-starter-web-3.4.0.jar/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/spring-boot-starter-web-3.4.0.jar/META-INF/NOTICE.txt
+++ b/licenses/spring-boot-starter-web-3.4.0.jar/META-INF/NOTICE.txt
@@ -1,0 +1,6 @@
+Spring Boot 3.4.0
+Copyright (c) 2012-2024 VMware, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/licenses/spring-context-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-context-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-context-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-context-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-core-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-core-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-core-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-core-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-expression-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-expression-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-expression-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-expression-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-jcl-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-jcl-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-jcl-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-jcl-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-web-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-web-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-web-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-web-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/spring-webmvc-6.2.0.jar/META-INF/license.txt
+++ b/licenses/spring-webmvc-6.2.0.jar/META-INF/license.txt
@@ -1,0 +1,297 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=======================================================================
+
+SPRING FRAMEWORK 6.2.0 SUBCOMPONENTS:
+
+Spring Framework 6.2.0 includes a number of subcomponents
+with separate copyright notices and license terms. The product that
+includes this file does not necessarily use all the open source
+subcomponents referred to below. Your use of the source
+code for these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+>>> ASM 9.1 (org.ow2.asm:asm:9.1, org.ow2.asm:asm-commons:9.1):
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
+
+
+>>> CGLIB 3.3 (cglib:cglib:3.3):
+
+Per the LICENSE file in the CGLIB JAR distribution downloaded from
+https://github.com/cglib/cglib/releases/download/RELEASE_3_3_0/cglib-3.3.0.jar,
+CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
+is included above.
+
+
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
+
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+Per the NOTICE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html and corresponding to section 4d of the
+Apache License, Version 2.0, in this case for Objenesis:
+
+Objenesis
+Copyright 2006-2019 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
+other similar licenses that require the source code and/or modifications to
+source code to be made available (as would be noted above), you may obtain a
+copy of the source code corresponding to the binaries for such open source
+components and modifications thereto, if any, (the "Source Files"), by
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
+
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/licenses/spring-webmvc-6.2.0.jar/META-INF/notice.txt
+++ b/licenses/spring-webmvc-6.2.0.jar/META-INF/notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 6.2.0
+Copyright (c) 2002-2024 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/licenses/tomcat-embed-core-10.1.33.jar/META-INF/LICENSE
+++ b/licenses/tomcat-embed-core-10.1.33.jar/META-INF/LICENSE
@@ -1,0 +1,858 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+APACHE TOMCAT SUBCOMPONENTS:
+
+Apache Tomcat includes a number of subcomponents with separate copyright notices
+and license terms. Your use of these subcomponents is subject to the terms and
+conditions of the following licenses.
+
+
+For the following XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+
+1. Definitions.
+
+   1.1. Contributor. means each individual or entity that creates or contributes
+        to the creation of Modifications.
+
+   1.2. Contributor Version. means the combination of the Original Software,
+        prior Modifications used by a Contributor (if any), and the
+        Modifications made by that particular Contributor.
+
+   1.3. Covered Software. means (a) the Original Software, or (b) Modifications,
+        or (c) the combination of files containing Original Software with files
+        containing Modifications, in each case including portions thereof.
+
+   1.4. Executable. means the Covered Software in any form other than Source
+        Code.
+
+   1.5. Initial Developer. means the individual or entity that first makes
+        Original Software available under this License.
+
+   1.6. Larger Work. means a work which combines Covered Software or portions
+        thereof with code not governed by the terms of this License.
+
+   1.7. License. means this document.
+
+   1.8. Licensable. means having the right to grant, to the maximum extent
+        possible, whether at the time of the initial grant or subsequently
+        acquired, any and all of the rights conveyed herein.
+
+   1.9. Modifications. means the Source Code and Executable form of any of the
+        following:
+
+        A. Any file that results from an addition to, deletion from or
+           modification of the contents of a file containing Original Software
+           or previous Modifications;
+
+        B. Any new file that contains any part of the Original Software or
+           previous Modification; or
+
+        C. Any new file that is contributed or otherwise made available under
+           the terms of this License.
+
+   1.10. Original Software. means the Source Code and Executable form of
+         computer software code that is originally released under this License.
+
+   1.11. Patent Claims. means any patent claim(s), now owned or hereafter
+         acquired, including without limitation, method, process, and apparatus
+         claims, in any patent Licensable by grantor.
+
+   1.12. Source Code. means (a) the common form of computer software code in
+         which modifications are made and (b) associated documentation included
+         in or with such code.
+
+   1.13. You. (or .Your.) means an individual or a legal entity exercising
+         rights under, and complying with all of the terms of, this License. For
+         legal entities, .You. includes any entity which controls, is controlled
+         by, or is under common control with You. For purposes of this
+         definition, .control. means (a) the power, direct or indirect, to cause
+         the direction or management of such entity, whether by contract or
+         otherwise, or (b) ownership of more than fifty percent (50%) of the
+         outstanding shares or beneficial ownership of such entity.
+
+2. License Grants.
+
+      2.1. The Initial Developer Grant.
+
+      Conditioned upon Your compliance with Section 3.1 below and subject to
+      third party intellectual property claims, the Initial Developer hereby
+      grants You a world-wide, royalty-free, non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or trademark)
+            Licensable by Initial Developer, to use, reproduce, modify, display,
+            perform, sublicense and distribute the Original Software (or
+            portions thereof), with or without Modifications, and/or as part of
+            a Larger Work; and
+
+        (b) under Patent Claims infringed by the making, using or selling of
+            Original Software, to make, have made, use, practice, sell, and
+            offer for sale, and/or otherwise dispose of the Original Software
+            (or portions thereof).
+
+        (c) The licenses granted in Sections 2.1(a) and (b) are effective on the
+            date Initial Developer first distributes or otherwise makes the
+            Original Software available to a third party under the terms of this
+            License.
+
+        (d) Notwithstanding Section 2.1(b) above, no patent license is granted:
+            (1) for code that You delete from the Original Software, or (2) for
+            infringements caused by: (i) the modification of the Original
+            Software, or (ii) the combination of the Original Software with
+            other software or devices.
+
+    2.2. Contributor Grant.
+
+    Conditioned upon Your compliance with Section 3.1 below and subject to third
+    party intellectual property claims, each Contributor hereby grants You a
+    world-wide, royalty-free, non-exclusive license:
+
+        (a) under intellectual property rights (other than patent or trademark)
+            Licensable by Contributor to use, reproduce, modify, display,
+            perform, sublicense and distribute the Modifications created by such
+            Contributor (or portions thereof), either on an unmodified basis,
+            with other Modifications, as Covered Software and/or as part of a
+            Larger Work; and
+
+        (b) under Patent Claims infringed by the making, using, or selling of
+            Modifications made by that Contributor either alone and/or in
+            combination with its Contributor Version (or portions of such
+            combination), to make, use, sell, offer for sale, have made, and/or
+            otherwise dispose of: (1) Modifications made by that Contributor (or
+            portions thereof); and (2) the combination of Modifications made by
+            that Contributor with its Contributor Version (or portions of such
+            combination).
+
+        (c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on
+            the date Contributor first distributes or otherwise makes the
+            Modifications available to a third party.
+
+        (d) Notwithstanding Section 2.2(b) above, no patent license is granted:
+            (1) for any code that Contributor has deleted from the Contributor
+            Version; (2) for infringements caused by: (i) third party
+            modifications of Contributor Version, or (ii) the combination of
+            Modifications made by that Contributor with other software (except
+            as part of the Contributor Version) or other devices; or (3) under
+            Patent Claims infringed by Covered Software in the absence of
+            Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+      3.1. Availability of Source Code.
+      Any Covered Software that You distribute or otherwise make available in
+      Executable form must also be made available in Source Code form and that
+      Source Code form must be distributed only under the terms of this License.
+      You must include a copy of this License with every copy of the Source Code
+      form of the Covered Software You distribute or otherwise make available.
+      You must inform recipients of any such Covered Software in Executable form
+      as to how they can obtain such Covered Software in Source Code form in a
+      reasonable manner on or through a medium customarily used for software
+      exchange.
+
+      3.2. Modifications.
+      The Modifications that You create or to which You contribute are governed
+      by the terms of this License. You represent that You believe Your
+      Modifications are Your original creation(s) and/or You have sufficient
+      rights to grant the rights conveyed by this License.
+
+      3.3. Required Notices.
+      You must include a notice in each of Your Modifications that identifies
+      You as the Contributor of the Modification. You may not remove or alter
+      any copyright, patent or trademark notices contained within the Covered
+      Software, or any notices of licensing or any descriptive text giving
+      attribution to any Contributor or the Initial Developer.
+
+      3.4. Application of Additional Terms.
+      You may not offer or impose any terms on any Covered Software in Source
+      Code form that alters or restricts the applicable version of this License
+      or the recipients. rights hereunder. You may choose to offer, and to
+      charge a fee for, warranty, support, indemnity or liability obligations to
+      one or more recipients of Covered Software. However, you may do so only on
+      Your own behalf, and not on behalf of the Initial Developer or any
+      Contributor. You must make it absolutely clear that any such warranty,
+      support, indemnity or liability obligation is offered by You alone, and
+      You hereby agree to indemnify the Initial Developer and every Contributor
+      for any liability incurred by the Initial Developer or such Contributor as
+      a result of warranty, support, indemnity or liability terms You offer.
+
+      3.5. Distribution of Executable Versions.
+      You may distribute the Executable form of the Covered Software under the
+      terms of this License or under the terms of a license of Your choice,
+      which may contain terms different from this License, provided that You are
+      in compliance with the terms of this License and that the license for the
+      Executable form does not attempt to limit or alter the recipient.s rights
+      in the Source Code form from the rights set forth in this License. If You
+      distribute the Covered Software in Executable form under a different
+      license, You must make it absolutely clear that any terms which differ
+      from this License are offered by You alone, not by the Initial Developer
+      or Contributor. You hereby agree to indemnify the Initial Developer and
+      every Contributor for any liability incurred by the Initial Developer or
+      such Contributor as a result of any such terms You offer.
+
+      3.6. Larger Works.
+      You may create a Larger Work by combining Covered Software with other code
+      not governed by the terms of this License and distribute the Larger Work
+      as a single product. In such a case, You must make sure the requirements
+      of this License are fulfilled for the Covered Software.
+
+4. Versions of the License.
+
+      4.1. New Versions.
+      Sun Microsystems, Inc. is the initial license steward and may publish
+      revised and/or new versions of this License from time to time. Each
+      version will be given a distinguishing version number. Except as provided
+      in Section 4.3, no one other than the license steward has the right to
+      modify this License.
+
+      4.2. Effect of New Versions.
+      You may always continue to use, distribute or otherwise make the Covered
+      Software available under the terms of the version of the License under
+      which You originally received the Covered Software. If the Initial
+      Developer includes a notice in the Original Software prohibiting it from
+      being distributed or otherwise made available under any subsequent version
+      of the License, You must distribute and make the Covered Software
+      available under the terms of the version of the License under which You
+      originally received the Covered Software. Otherwise, You may also choose
+      to use, distribute or otherwise make the Covered Software available under
+      the terms of any subsequent version of the License published by the
+      license steward.
+
+      4.3. Modified Versions.
+      When You are an Initial Developer and You want to create a new license for
+      Your Original Software, You may create and use a modified version of this
+      License if You: (a) rename the license and remove any references to the
+      name of the license steward (except to note that the license differs from
+      this License); and (b) otherwise make it clear that the license contains
+      terms which differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+   COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN .AS IS. BASIS, WITHOUT
+   WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT
+   LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS,
+   MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK
+   AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD
+   ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL
+   DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+   SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN
+   ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED
+   HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+6. TERMINATION.
+
+      6.1. This License and the rights granted hereunder will terminate
+           automatically if You fail to comply with terms herein and fail to
+           cure such breach within 30 days of becoming aware of the breach.
+           Provisions which, by their nature, must remain in effect beyond the
+           termination of this License shall survive.
+
+      6.2. If You assert a patent infringement claim (excluding declaratory
+           judgment actions) against Initial Developer or a Contributor (the
+           Initial Developer or Contributor against whom You assert such claim
+           is referred to as .Participant.) alleging that the Participant
+           Software (meaning the Contributor Version where the Participant is a
+           Contributor or the Original Software where the Participant is the
+           Initial Developer) directly or indirectly infringes any patent, then
+           any and all rights granted directly or indirectly to You by such
+           Participant, the Initial Developer (if the Initial Developer is not
+           the Participant) and all Contributors under Sections 2.1 and/or 2.2
+           of this License shall, upon 60 days notice from Participant terminate
+           prospectively and automatically at the expiration of such 60 day
+           notice period, unless if within such 60 day period You withdraw Your
+           claim with respect to the Participant Software against such
+           Participant either unilaterally or pursuant to a written agreement
+           with Participant.
+
+      6.3. In the event of termination under Sections 6.1 or 6.2 above, all end
+           user licenses that have been validly granted by You or any
+           distributor hereunder prior to termination (excluding licenses
+           granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+   UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING
+   NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY
+   OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF
+   ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL,
+   INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+   LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK STOPPAGE,
+   COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR
+   LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF
+   SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR
+   DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY.S NEGLIGENCE TO THE EXTENT
+   APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE
+   EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS
+   EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+   The Covered Software is a .commercial item,. as that term is defined in 48
+   C.F.R. 2.101 (Oct. 1995), consisting of .commercial computer software. (as
+   that term is defined at 48 C.F.R. ? 252.227-7014(a)(1)) and commercial
+   computer software documentation. as such terms are used in 48 C.F.R. 12.212
+   (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1
+   through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered
+   Software with only those rights set forth herein. This U.S. Government Rights
+   clause is in lieu of, and supersedes, any other FAR, DFAR, or other clause or
+   provision that addresses Government rights in computer software under this
+   License.
+
+9. MISCELLANEOUS.
+
+   This License represents the complete agreement concerning subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. This License shall be governed by the law of the jurisdiction
+   specified in a notice contained within the Original Software (except to the
+   extent applicable law, if any, provides otherwise), excluding such
+   jurisdiction's conflict-of-law provisions. Any litigation relating to this
+   License shall be subject to the jurisdiction of the courts located in the
+   jurisdiction and venue specified in a notice contained within the Original
+   Software, with the losing party responsible for costs, including, without
+   limitation, court costs and reasonable attorneys. fees and expenses. The
+   application of the United Nations Convention on Contracts for the
+   International Sale of Goods is expressly excluded. Any law or regulation
+   which provides that the language of a contract shall be construed against
+   the drafter shall not apply to this License. You agree that You alone are
+   responsible for compliance with the United States export administration
+   regulations (and the export control laws and regulation of any other
+   countries) when You use, distribute or otherwise make available any Covered
+   Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+   As between Initial Developer and the Contributors, each party is responsible
+   for claims and damages arising, directly or indirectly, out of its
+   utilization of rights under this License and You agree to work with Initial
+   Developer and Contributors to distribute such responsibility on an equitable
+   basis. Nothing herein is intended or shall be deemed to constitute any
+   admission of liability.
+
+   NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION
+   LICENSE (CDDL)
+
+   The code released under the CDDL shall be governed by the laws of the State
+   of California (excluding conflict-of-law provisions). Any litigation relating
+   to this License shall be subject to the jurisdiction of the Federal Courts of
+   the Northern District of California and the state courts of the State of
+   California, with venue lying in Santa Clara County, California.
+
+
+For the following Jakarta EE Schemas:
+- jakartaee_9.xsd
+- jakartaee_10.xsd
+- jakarta_web-services_2_0.xsd
+- jakarta_web-services_client_2_0.xsd
+- jsp_3_0.xsd
+- jsp_3_1.xsd
+- web-app_5_0.xsd
+- web-app_6_0.xsd
+- web-commonn_5_0.xsd
+- web-commonn_6_0.xsd
+- web-fragment_5_0.xsd
+- web-fragment_6_0.xsd
+- web-jsptaglibrary_3_0.xsd
+- web-jsptaglibrary_3_1.xsd
+
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/licenses/tomcat-embed-core-10.1.33.jar/META-INF/NOTICE
+++ b/licenses/tomcat-embed-core-10.1.33.jar/META-INF/NOTICE
@@ -1,0 +1,31 @@
+Apache Tomcat
+Copyright 1999-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The original XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+may be obtained from:
+http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html

--- a/licenses/tomcat-embed-el-10.1.33.jar/META-INF/LICENSE
+++ b/licenses/tomcat-embed-el-10.1.33.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/tomcat-embed-el-10.1.33.jar/META-INF/NOTICE
+++ b/licenses/tomcat-embed-el-10.1.33.jar/META-INF/NOTICE
@@ -1,0 +1,5 @@
+Apache Tomcat
+Copyright 1999-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/licenses/tomcat-embed-websocket-10.1.33.jar/META-INF/LICENSE
+++ b/licenses/tomcat-embed-websocket-10.1.33.jar/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/tomcat-embed-websocket-10.1.33.jar/META-INF/NOTICE
+++ b/licenses/tomcat-embed-websocket-10.1.33.jar/META-INF/NOTICE
@@ -1,0 +1,5 @@
+Apache Tomcat
+Copyright 1999-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update dependencies and Otel to v2.10.0.
2. Ipdate actions/upload-artifact and actions/download-artifact to v4 as v3 is marking as deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
