### PR TITLE
decouple apigw-lambda sample app from adot project build

### DIFF
--- a/sample-apps/apigateway-lambda/settings.gradle.kts
+++ b/sample-apps/apigateway-lambda/settings.gradle.kts
@@ -1,0 +1,16 @@
+pluginManagement {
+  plugins {
+    id("com.diffplug.spotless") version "6.13.0"
+    id("com.github.ben-manes.versions") version "0.50.0"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+    mavenLocal()
+  }
+}
+
+rootProject.name = "sample-app-apigw-lambda"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,7 +51,6 @@ include(":smoke-tests:spring-boot")
 include(":sample-apps:springboot")
 include(":sample-apps:spark")
 include(":sample-apps:spark-awssdkv1")
-include(":sample-apps:apigateway-lambda")
 
 // Used for contract tests
 include("appsignals-tests:images:mock-collector")


### PR DESCRIPTION
The sample app doesn't need ADOT Javaagent instrumentation, rather it depends on instrumentaiton via lambda layer. SO it makes sense to not depend on adot javaagent build for building this sample app.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
