### PR TITLE
add lambda release workflow - v1.33.x branch

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -1,0 +1,218 @@
+name: Release Java Lambda layer
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the lambda release with, e.g., 1.2.0
+        required: true
+      aws_region:
+        description: 'Deploy to aws regions'
+        required: true
+        default: 'us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1, af-south-1, ap-east-1, ap-south-2, ap-southeast-3, ap-southeast-4, eu-central-2, eu-south-1, eu-south-2, il-central-1, me-central-1, me-south-1'
+
+env:
+  COMMERCIAL_REGIONS: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
+  LAYER_NAME: AWSOpenTelemetryDistroJava
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  build-layer:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_regions_json: ${{ steps.set-matrix.outputs.aws_regions_json }}
+    steps:
+      - name: Set up regions matrix
+        id: set-matrix
+        run: |
+          IFS=',' read -ra REGIONS <<< "${{ github.event.inputs.aws_region }}"
+          MATRIX="["
+          for region in "${REGIONS[@]}"; do
+            trimmed_region=$(echo "$region" | xargs)
+            MATRIX+="\"$trimmed_region\","
+          done
+          MATRIX="${MATRIX%,}]"
+          echo ${MATRIX}
+          echo "aws_regions_json=${MATRIX}" >> $GITHUB_OUTPUT
+
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Build layers
+        working-directory: lambda-layer
+        run: |
+          ./build-layer.sh
+
+      - name: Upload layer
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-opentelemetry-java-layer.zip
+          path: lambda-layer/build/distributions/aws-opentelemetry-java-layer.zip
+
+  publish-prod:
+    runs-on: ubuntu-latest
+    needs: build-layer
+    strategy:
+      matrix:
+        aws_region: ${{ fromJson(needs.build-layer.outputs.aws_regions_json) }}
+    steps:
+      - name: role arn
+        env:
+          COMMERCIAL_REGIONS: ${{ env.COMMERCIAL_REGIONS }}
+        run: |
+          COMMERCIAL_REGIONS_ARRAY=(${COMMERCIAL_REGIONS//,/ })
+          FOUND=false
+          for REGION in "${COMMERCIAL_REGIONS_ARRAY[@]}"; do
+            if [[ "$REGION" == "${{ matrix.aws_region }}" ]]; then
+              FOUND=true
+              break
+            fi
+          done
+          if [ "$FOUND" = true ]; then
+            echo "Found ${{ matrix.aws_region }} in COMMERCIAL_REGIONS"
+            SECRET_KEY="LAMBDA_LAYER_RELEASE"
+          else
+            echo "Not found ${{ matrix.aws_region }} in COMMERCIAL_REGIONS"
+            SECRET_KEY="${{ matrix.aws_region }}_LAMBDA_LAYER_RELEASE"
+          fi
+          SECRET_KEY=${SECRET_KEY//-/_}
+          echo "SECRET_KEY=${SECRET_KEY}" >> $GITHUB_ENV
+
+      - uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ secrets[env.SECRET_KEY] }}
+          role-duration-seconds: 1200
+          aws-region: ${{ matrix.aws_region }}
+
+      - name: Get s3 bucket name for release
+        run: |
+          echo BUCKET_NAME=java-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
+
+      - name: download layer.zip
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-opentelemetry-java-layer.zip
+
+      - name: publish
+        run: |
+          aws s3 mb s3://${{ env.BUCKET_NAME }}
+          aws s3 cp aws-opentelemetry-java-layer.zip s3://${{ env.BUCKET_NAME }}
+          layerARN=$(
+            aws lambda publish-layer-version \
+              --layer-name ${{ env.LAYER_NAME }} \
+              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=aws-opentelemetry-java-layer.zip \
+              --compatible-runtimes java17 java21 \
+              --compatible-architectures "arm64" "x86_64" \
+              --license-info "Apache-2.0" \
+              --description "AWS Distro of OpenTelemetry Lambda Layer for Java Runtime" \
+              --query 'LayerVersionArn' \
+              --output text
+          )
+          echo $layerARN
+          echo "LAYER_ARN=${layerARN}" >> $GITHUB_ENV
+          mkdir ${{ env.LAYER_NAME }}
+          echo $layerARN > ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+          cat ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+
+      - name: public layer
+        run: |
+          layerVersion=$(
+            aws lambda list-layer-versions \
+              --layer-name ${{ env.LAYER_NAME }} \
+              --query 'max_by(LayerVersions, &Version).Version'
+          )
+          aws lambda add-layer-version-permission \
+            --layer-name ${{ env.LAYER_NAME }} \
+            --version-number $layerVersion \
+            --principal "*" \
+            --statement-id publish \
+            --action lambda:GetLayerVersion
+
+      - name: upload layer arn artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.LAYER_NAME }}
+          path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+
+      - name: clean s3
+        if: always()
+        run: |
+          aws s3 rb --force s3://${{ env.BUCKET_NAME }}
+
+  generate-release-note:
+    runs-on: ubuntu-latest
+    needs: publish-prod
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v2
+
+      - name: download layerARNs
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.LAYER_NAME }}
+          path: ${{ env.LAYER_NAME }}
+
+      - name: show layerARNs
+        run: |
+          for file in ${{ env.LAYER_NAME }}/*
+          do
+          echo $file
+          cat $file
+          done
+
+      - name: generate layer-note
+        working-directory: ${{ env.LAYER_NAME }}
+        run: |
+          echo "| Region | Layer ARN |" >> ../layer-note
+          echo "|  ----  | ----  |" >> ../layer-note
+          for file in *
+          do
+          read arn < $file
+          echo "| " $file " | " $arn " |" >> ../layer-note
+          done
+          cd ..
+          cat layer-note
+
+      - name: generate tf layer
+        working-directory: ${{ env.LAYER_NAME }}
+        run: |
+          echo "locals {" >> ../layer.tf
+          echo "  sdk_layer_arns = {" >> ../layer.tf
+          for file in *
+          do
+          read arn < $file
+          echo "    \""$file"\" = \""$arn"\"" >> ../layer.tf
+          done
+          cd ..
+          echo "  }" >> layer.tf
+          echo "}" >> layer.tf
+          terraform fmt layer.tf
+          cat layer.tf
+
+      - name: upload layer tf file
+        uses: actions/upload-artifact@v3
+        with:
+          name: layer.tf
+          path: layer.tf
+
+      - name: Create GH release
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          gh release create --target "$GITHUB_REF_NAME" \
+             --title "Release lambda-v${{ github.event.inputs.version }}" \
+             --draft \
+             "lambda-v${{ github.event.inputs.version }}" \
+             layer.tf


### PR DESCRIPTION
Same as https://github.com/aws-observability/aws-otel-java-instrumentation/pull/994 but for the 1.33.x branch where we will be doing the release for ADOT v1 lambda layer from.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
