### PR TITLE
Update Lambda sample app - switch to native http client +switch to ListBuckets API call

### DIFF
--- a/sample-apps/apigateway-lambda/build.gradle.kts
+++ b/sample-apps/apigateway-lambda/build.gradle.kts
@@ -15,7 +15,6 @@ java {
 
 dependencies {
   implementation("com.amazonaws:aws-lambda-java-core:1.2.2")
-  implementation("com.squareup.okhttp3:okhttp:4.11.0")
   implementation("software.amazon.awssdk:s3:2.29.23")
   implementation("org.json:json:20240303")
   implementation("org.slf4j:jcl-over-slf4j:2.0.16")

--- a/sample-apps/apigateway-lambda/terraform/main.tf
+++ b/sample-apps/apigateway-lambda/terraform/main.tf
@@ -16,13 +16,13 @@ resource "aws_iam_role" "lambda_role" {
 }
 
 resource "aws_iam_policy" "s3_access" {
-  name        = "S3ListBucketPolicy"
-  description = "Allow Lambda to check a given S3 bucket exists"
+  name        = "S3ListBucketsPolicy"
+  description = "Allow Lambda to list buckets"
   policy      = jsonencode({
     Version = "2012-10-17",
     Statement = [{
       Effect   = "Allow",
-      Action   = ["s3:ListBucket"],
+      Action   = ["s3:ListAllMyBuckets"],
       Resource = "*"
     }]
   })


### PR DESCRIPTION
Related to https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1002, we want to use native Java Http Client instead of OkHttp in the sample app.

Also, I noticed that the other language sample apps ([Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/lambda-layer/sample-apps/function/lambda_function.py#L15)) does a `ListBuckets` call whereas this sample app is doing `ListBucket` call. So updating that to be consistent with others.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
