### PR TITLE
bump up the upload-download artifact action to v4

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -31,7 +31,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: aws-opentelemetry-agent.jar
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -128,7 +128,7 @@ jobs:
           snapshot-ecr-role: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar

--- a/.github/workflows/nightly-upstream-snapshot-build.yml
+++ b/.github/workflows/nightly-upstream-snapshot-build.yml
@@ -95,7 +95,7 @@ jobs:
           snapshot-ecr-role: ${{ secrets.JAVA_INSTRUMENTATION_SNAPSHOT_ECR }}
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-agent.jar
           path: otelagent/build/libs/aws-opentelemetry-agent-*.jar

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -52,7 +52,7 @@ jobs:
           ./build-layer.sh
 
       - name: Upload layer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-java-layer.zip
           path: lambda-layer/build/distributions/aws-opentelemetry-java-layer.zip
@@ -138,7 +138,7 @@ jobs:
 
       - name: upload layer arn artifact
         if: ${{ success() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
@@ -201,7 +201,7 @@ jobs:
           cat layer.tf
 
       - name: upload layer tf file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: layer.tf
           path: layer.tf

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -97,7 +97,7 @@ jobs:
           echo BUCKET_NAME=java-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
 
       - name: download layer.zip
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-opentelemetry-java-layer.zip
 
@@ -158,7 +158,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
 
       - name: download layerARNs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}


### PR DESCRIPTION
*Issue #, if available:*
The `upload-artifacts` and the `download-artifacts` v3 are deprecated and causing the workflows to be stopped. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
