### PR TITLE
bump up the upload/download artifact action to v4

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           ./build-layer.sh
       - name: Upload layer zip to GitHub Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-java-layer.zip
           path: lambda-layer/build/distributions/aws-opentelemetry-java-layer.zip

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -52,7 +52,7 @@ jobs:
           ./build-layer.sh
 
       - name: Upload layer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: aws-opentelemetry-java-layer.zip
           path: lambda-layer/build/distributions/aws-opentelemetry-java-layer.zip
@@ -97,7 +97,7 @@ jobs:
           echo BUCKET_NAME=java-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
 
       - name: download layer.zip
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: aws-opentelemetry-java-layer.zip
 
@@ -138,7 +138,7 @@ jobs:
 
       - name: upload layer arn artifact
         if: ${{ success() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
@@ -158,7 +158,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
 
       - name: download layerARNs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}
@@ -201,7 +201,7 @@ jobs:
           cat layer.tf
 
       - name: upload layer tf file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: layer.tf
           path: layer.tf


### PR DESCRIPTION
*Issue #, if available:*
Same as https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1012 but for the release 1.33.x branch.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
