### PR TITLE
Unique artifact names for upload and merge for download

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -140,7 +140,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}
+          name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
 
       - name: clean s3
@@ -160,8 +160,9 @@ jobs:
       - name: download layerARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}
+          pattern: ${{ env.LAYER_NAME }}-*
           path: ${{ env.LAYER_NAME }}
+          merge-multiple: true
 
       - name: show layerARNs
         run: |


### PR DESCRIPTION
*Issue*: The `upload-artifact@v4` action no longer allows uploading artifacts with same name. Thus the release lambda workflow fails: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/13146172757

*Description of changes:*
- Taking the [fix that was done for the Application Signals .Net Lambda Layer](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/commit/d75276960b465ae22af23282ed34eaf90cf5779b):
  - Appending region to the artifact name for making it unique
  - While downloading these artifacts we will just merge.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
