### PR TITLE
Fixed toString for OtlpAwsSpanExporter

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpAwsSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/OtlpAwsSpanExporter.java
@@ -103,7 +103,7 @@ public class OtlpAwsSpanExporter implements SpanExporter {
 
   @Override
   public String toString() {
-    return this.parentExporter.toString();
+    return this.parentExporter.toString().replace("OtlpHttpSpanExporter", "OtlpAwsSpanExporter");
   }
 
   private final class SigV4AuthHeaderSupplier implements Supplier<Map<String, String>> {


### PR DESCRIPTION
*Description of changes:*
Modified the toString method for the SigV4 exporter to say OtlpAwsSpanExporter instead of OtlpHttpSpanExporter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
