### PR TITLE
Exclude opentelemetry-extension-incubator

### DIFF
--- a/otelagent/build.gradle.kts
+++ b/otelagent/build.gradle.kts
@@ -41,6 +41,7 @@ val javaagentLibs by configurations.creating {
   exclude("io.opentelemetry", "opentelemetry-sdk")
   exclude("io.opentelemetry", "opentelemetry-sdk-common")
   exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
+  exclude("io.opentelemetry", "opentelemetry-api-incubator")
 }
 
 val shadowClasspath by configurations.creating {


### PR DESCRIPTION
## Issue ##
HTTP metric is disabled with the following error message.
`
[otel.javaagent 2025-03-04 19:21:31:397 +0000] [http-nio-8080-exec-1] WARN io.opentelemetry.javaagent.shaded.instrumentation.api.internal.OperationMetricsUtil - Disabling http server metrics because io.opentelemetry.sdk.metrics.SdkDoubleHistogram$SdkDoubleHistogramBuilder does not implement io.opentelemetry.javaagent.shaded.io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder. This prevents using metrics advice, which could result in http server metrics having high cardinality attributes.
`

From the dependency tree, it is introduced by `io.opentelemetry:opentelemetry-exporter-otlp`.
```
|    +--- io.opentelemetry:opentelemetry-exporter-otlp -> 1.44.1
|    |    +--- io.opentelemetry:opentelemetry-exporter-otlp-common:1.44.1
|    |    |    +--- io.opentelemetry:opentelemetry-api-incubator:1.44.1-alpha
|    |    |    \--- io.opentelemetry:opentelemetry-exporter-common:1.44.1
```

The upstream makes it excluded in an distro agent example [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/8fcb6b86cbbd3d383e40742369872b569005acd3/examples/distro/agent/build.gradle#L80):
```
// exclude known bootstrap dependencies - they can't appear in the inst/ directory
    dependencies {
      exclude("io.opentelemetry:opentelemetry-api")
      exclude("io.opentelemetry:opentelemetry-context")
      // events API and metrics advice API
      exclude("io.opentelemetry:opentelemetry-api-incubator")
    }
```

## Description of changes: ##
Exclude `opentelemetry-extension-incubator`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
