### PR TITLE
Port upstream fix (PR#10736) to downstream v1 Lambda stream handler

### DIFF
--- a/lambda-layer/patches/StreamHandlerInstrumentation.patch
+++ b/lambda-layer/patches/StreamHandlerInstrumentation.patch
@@ -34,10 +34,10 @@ index 35d6b70ed6..b6a305178e 100644
  }
 diff --git a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestStreamHandlerInstrumentation.java b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestStreamHandlerInstrumentation.java
 new file mode 100644
-index 0000000000..73b82a62a2
+index 0000000000..1c4ef1ac07
 --- /dev/null
 +++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestStreamHandlerInstrumentation.java
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,98 @@
 +/*
 + * Copyright The OpenTelemetry Authors
 + * SPDX-License-Identifier: Apache-2.0
@@ -50,7 +50,9 @@ index 0000000000..73b82a62a2
 +import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.functionInstrumenter;
 +import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 +import static net.bytebuddy.matcher.ElementMatchers.isPublic;
++import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 +import static net.bytebuddy.matcher.ElementMatchers.named;
++import static net.bytebuddy.matcher.ElementMatchers.not;
 +import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 +
 +import com.amazonaws.services.lambda.runtime.Context;
@@ -76,7 +78,13 @@ index 0000000000..73b82a62a2
 +
 +  @Override
 +  public ElementMatcher<TypeDescription> typeMatcher() {
-+    return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestStreamHandler"));
++    return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestStreamHandler"))
++        .and(not(nameStartsWith("com.amazonaws.services.lambda.runtime.api.client")))
++        // In Java 8 and Java 11 runtimes,
++        // AWS Lambda runtime is packaged under `lambdainternal` package.
++        // But it is `com.amazonaws.services.lambda.runtime.api.client`
++        // for new runtime likes Java 17 and Java 21.
++        .and(not(nameStartsWith("lambdainternal")));
 +  }
 +
 +  @Override


### PR DESCRIPTION
- **V2 Issue:** [Non-top-level server span created by Lambda instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7808)  

- **V2 PR:** [#10736](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10736)  

The fix has been ported to v1 as a patch for non-stream handlers. This change extends the fix to the stream handler in the v1 repository.  

### Testing
- All unit tests pass.  
- End-to-end tests pass.  (with Java11, 17, and 21 runtime on Lambda)

### Backward Compatibility
- No risk of breaking existing functionality.  
- The change only adds instrumentation for `RequestStreamHandler` without modifying existing behavior for `RequestHandler`.  
- Existing users who do not use `RequestStreamHandler` remain unaffected.  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
