### PR TITLE
feat: Support microservice span in Lambda Java environment.

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -195,6 +195,10 @@ public class AwsApplicationSignalsCustomizerProvider
 
   private SdkTracerProviderBuilder customizeTracerProviderBuilder(
       SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties configProps) {
+    if (isLambdaEnvironment()) {
+      tracerProviderBuilder.addSpanProcessor(new AwsLambdaSpanProcessor());
+    }
+
     if (isApplicationSignalsEnabled(configProps)) {
       logger.info("AWS Application Signals enabled");
       Duration exportInterval =

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -97,4 +97,7 @@ final class AwsAttributeKeys {
       AttributeKey.stringKey("aws.bedrock.guardrail.id");
   static final AttributeKey<String> AWS_GUARDRAIL_ARN =
       AttributeKey.stringKey("aws.bedrock.guardrail.arn");
+
+  static final AttributeKey<Boolean> AWS_TRACE_LAMBDA_MULTIPLE_SERVER =
+      AttributeKey.booleanKey("aws.trace.lambda.multiple-server");
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsLambdaSpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsLambdaSpanProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public final class AwsLambdaSpanProcessor implements SpanProcessor {
+  @Override
+  public void onStart(Context parentContext, ReadWriteSpan span) {
+    if (AwsSpanProcessingUtil.isServletServerSpan(span)) {
+      Span parentSpan = Span.fromContextOrNull(parentContext);
+      if (parentSpan == null || !(parentSpan instanceof ReadWriteSpan)) {
+        return;
+      }
+
+      ReadWriteSpan parentReadWriteSpan = (ReadWriteSpan) parentSpan;
+      if (!AwsSpanProcessingUtil.isLambdaServerSpan(parentReadWriteSpan)) {
+        return;
+      }
+      parentReadWriteSpan.setAttribute(AwsAttributeKeys.AWS_TRACE_LAMBDA_MULTIPLE_SERVER, true);
+    }
+  }
+
+  @Override
+  public boolean isStartRequired() {
+    return true;
+  }
+
+  @Override
+  public void onEnd(ReadableSpan span) {}
+
+  @Override
+  public boolean isEndRequired() {
+    return false;
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsLambdaSpanProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsLambdaSpanProcessorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AwsLambdaSpanProcessorTest {
+
+  private AwsLambdaSpanProcessor processor;
+  private ReadWriteSpan mockLambdaServerSpan;
+  private SpanData mockLambdaSpanData;
+  private InstrumentationScopeInfo mockLambdaScopeInfo;
+  private Map<AttributeKey<?>, Object> attributeMapForLambdaSpan;
+  private SpanContext mockSpanContext;
+
+  private ReadWriteSpan mockServletServerSpan;
+  private SpanData mockServletSpanData;
+  private InstrumentationScopeInfo mockServletScopeInfo;
+
+  private Tracer lambdaTracer;
+  private Tracer servletTracer;
+  private Tracer otherTracer;
+
+  @BeforeEach
+  public void setup() {
+    processor = new AwsLambdaSpanProcessor();
+    lambdaTracer =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(processor)
+            .build()
+            .get(AwsSpanProcessingUtil.LAMBDA_SCOPE_PREFIX + "core-1.0");
+
+    servletTracer =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(processor)
+            .build()
+            .get(AwsSpanProcessingUtil.SERVLET_SCOPE_PREFIX + "lib-3.0");
+
+    otherTracer =
+        SdkTracerProvider.builder().addSpanProcessor(processor).build().get("other-lib-2.0");
+  }
+
+  @Test
+  void testOnStart_servletServerSpan_withLambdaServerSpan() {
+    Span parentSpan =
+        lambdaTracer.spanBuilder("parent-lambda").setSpanKind(SpanKind.SERVER).startSpan();
+    servletTracer
+        .spanBuilder("child-servlet")
+        .setSpanKind(SpanKind.SERVER)
+        .setParent(Context.current().with(parentSpan))
+        .startSpan();
+
+    ReadableSpan parentReadableSpan = (ReadableSpan) parentSpan;
+    assertThat(parentReadableSpan.getAttribute(AwsAttributeKeys.AWS_TRACE_LAMBDA_MULTIPLE_SERVER))
+        .isEqualTo(true);
+  }
+
+  @Test
+  void testOnStart_servletInternalSpan_withLambdaServerSpan() {
+    Span parentSpan =
+        lambdaTracer.spanBuilder("parent-lambda").setSpanKind(SpanKind.SERVER).startSpan();
+
+    servletTracer
+        .spanBuilder("child-servlet")
+        .setSpanKind(SpanKind.INTERNAL)
+        .setParent(Context.current().with(parentSpan))
+        .startSpan();
+
+    ReadableSpan parentReadableSpan = (ReadableSpan) parentSpan;
+    assertNull(parentReadableSpan.getAttribute(AwsAttributeKeys.AWS_TRACE_LAMBDA_MULTIPLE_SERVER));
+  }
+
+  @Test
+  void testOnStart_servletServerSpan_withLambdaInternalSpan() {
+    Span parentSpan =
+        lambdaTracer.spanBuilder("parent-lambda").setSpanKind(SpanKind.INTERNAL).startSpan();
+
+    servletTracer
+        .spanBuilder("child-servlet")
+        .setSpanKind(SpanKind.SERVER)
+        .setParent(Context.current().with(parentSpan))
+        .startSpan();
+
+    ReadableSpan parentReadableSpan = (ReadableSpan) parentSpan;
+    assertNull(parentReadableSpan.getAttribute(AwsAttributeKeys.AWS_TRACE_LAMBDA_MULTIPLE_SERVER));
+  }
+
+  @Test
+  void testOnStart_servletServerSpan_withLambdaServerSpanAsGrandParent() {
+    Span grandParentSpan =
+        lambdaTracer.spanBuilder("grandparent-lambda").setSpanKind(SpanKind.SERVER).startSpan();
+
+    Span parentSpan =
+        otherTracer
+            .spanBuilder("parent-other")
+            .setSpanKind(SpanKind.SERVER)
+            .setParent(Context.current().with(grandParentSpan))
+            .startSpan();
+
+    servletTracer
+        .spanBuilder("child-servlet")
+        .setSpanKind(SpanKind.SERVER)
+        .setParent(Context.current().with(parentSpan))
+        .startSpan();
+
+    ReadableSpan grandParentReadableSpan = (ReadableSpan) grandParentSpan;
+    assertNull(
+        grandParentReadableSpan.getAttribute(AwsAttributeKeys.AWS_TRACE_LAMBDA_MULTIPLE_SERVER));
+  }
+}


### PR DESCRIPTION
When a microservice is hosted in a Lambda Java environment (e.g., a Spring Boot app), this PR ensures the following to provide a better observation experience:

The microservice will emit a server span that follows Lambda's server span. 
Lambda's server span will be tagged with aws.trace.lambda.multiple-server=true.
If Lambda detects the HTTP call context, the operation attribute will be set as the HTTP method and path, instead of FunctionHandler.

Test:
All unit tests pass.
Built the Java layer and Spring Boot app on Lambda, and completed end-to-end testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
