### PR TITLE
Add retry for the unstable steps in daily_scan workflow

### DIFF
--- a/.github/actions/execute_and_retry/action.yml
+++ b/.github/actions/execute_and_retry/action.yml
@@ -1,0 +1,74 @@
+# Reusable Action for executing commands and retrying them if it fails
+name: Command Retry Logic
+
+inputs:
+  # (Optional) Command to run before the retry command. To be used for environment setup, etc
+  pre-command:
+    required: false
+    type: string
+  # (Optional) Number of retries to perform. Default is 3
+  max_retry:
+    required: false
+    type: number
+    default: 3
+  # (Required) Command to execute with the retry mechanism
+  command:
+    required: true
+    type: string
+  # (Required) Command to clean up resources before retrying the main command
+  cleanup:
+    required: false
+    type: string
+  # (Optional) Time to wait between each attempt in seconds. Default is 10 seconds
+  sleep_time:
+    required: false
+    type: number
+    default: 10
+  # (Optional) Follow-up command after the main command is finished.
+  post-command:
+    required: false
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run command
+      shell: bash
+      env:
+        PRE_COMMAND: ${{ inputs.pre-command }}
+        MAX_RETRY: ${{ inputs.max_retry }}
+        COMMAND: ${{ inputs.command }}
+        CLEANUP: ${{ inputs.cleanup }}
+        POST_COMMAND: ${{ inputs.post-command }}
+        SLEEP_TIME: ${{ inputs.sleep_time }}
+      run: |
+        echo "Starting the execute_and_retry action for command $COMMAND"
+        echo "Executing pre-command for the execute_and_retry action"
+        eval "$PRE_COMMAND"
+        
+        retry_counter=0
+        while [ $retry_counter -lt $MAX_RETRY ]; do
+           echo "Attempt Number $retry_counter for execute_and_retry action"
+
+          attempt_failed=0
+          eval "$COMMAND" || attempt_failed=$?
+  
+          if [ $attempt_failed -ne 0 ]; then
+            echo "Command failed for execute_and_retry action, executing cleanup command for another attempt"
+
+            eval "$CLEANUP" || true
+            retry_counter=$(($retry_counter+1))
+            sleep "$SLEEP_TIME"
+          else
+            echo "Command executed successfully for execute_and_retry"
+            break
+          fi
+          if [[ $retry_counter -ge $MAX_RETRY ]]; then
+            echo "Max retry reached, command failed to execute properly. Exiting action"
+            exit 1
+          fi
+        done
+        
+        echo "Executing post-command for the execute_and_retry action"
+        eval "$POST_COMMAND"
+        echo "Exiting execute_and_retry action"

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -57,16 +57,20 @@ jobs:
 
       # See http://jeremylong.github.io/DependencyCheck/dependency-check-cli/ for installation explanation
       - name: Install and run dependency scan
-        id: dep_scan
         if: always()
-        run: |
-          gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 259A55407DD6C00299E6607EFFDE55BE73A2D1ED
-          VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt | head -n1 | cut -d' ' -f1)
-          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
-          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc
-          gpg --verify dependency-check.zip.asc
-          unzip dependency-check.zip
-          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} -s 'otelagent/build/libs/aws-opentelemetry-agent-*-SNAPSHOT.jar'
+        id: dep_scan
+        uses: ./.github/actions/execute_and_retry
+        with:
+          command: 'gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 259A55407DD6C00299E6607EFFDE55BE73A2D1ED && \
+          VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt | head -n1 | cut -d' ' -f1) && \
+          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip && \
+          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc && \
+          gpg --verify dependency-check.zip.asc && \
+          unzip dependency-check.zip && \
+          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} -s "otelagent/build/libs/aws-opentelemetry-agent-*-SNAPSHOT.jar"'
+          cleanup: 'rm -f ./dependency-check.zip && rm -f ./dependency-check.zip.asc && rm -rf ./dependency-check || true'
+          max_retry: 5
+          sleep_time: 60
 
       - name: Print dependency scan results on failure
         if: ${{ steps.dep_scan.outcome != 'success' }}


### PR DESCRIPTION
*Description of changes:*

add retry step for `Install and run dependency scan` which has higher transient failure rate.

https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/13637396412/job/38119414216

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
