### PR TITLE
Add retry for the unstable steps in daily_scan workflow

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -59,14 +59,18 @@ jobs:
       - name: Install and run dependency scan
         id: dep_scan
         if: always()
-        run: |
-          gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 259A55407DD6C00299E6607EFFDE55BE73A2D1ED
-          VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt | head -n1 | cut -d' ' -f1)
-          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
-          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc
-          gpg --verify dependency-check.zip.asc
-          unzip dependency-check.zip
-          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} -s 'otelagent/build/libs/aws-opentelemetry-agent-*-SNAPSHOT.jar'
+        uses: ./.github/actions/execute_and_retry
+        with:
+          command: 'gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 259A55407DD6C00299E6607EFFDE55BE73A2D1ED && 
+          VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt | head -n1 | cut -d' ' -f1) && 
+          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip &&
+          curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc &&
+          gpg --verify dependency-check.zip.asc && 
+          unzip dependency-check.zip && 
+          ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} -s "otelagent/build/libs/aws-opentelemetry-agent-*-SNAPSHOT.jar"'
+          cleanup: 'rm -f ./dependency-check.zip && rm -f ./dependency-check.zip.asc && rm -rf ./dependency-check || true'
+          max_retry: 5
+          sleep_time: 60
 
       - name: Print dependency scan results on failure
         if: ${{ steps.dep_scan.outcome != 'success' }}


### PR DESCRIPTION
*Description of changes:*

add retry step for `Install and run dependency scan` which has higher transient failure rate.

https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/13637396412/job/38119414216

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
