### PR TITLE
Add SigV4 release test to main build 

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -93,6 +93,14 @@ jobs:
       java-version: '22'
       cpu-architecture: 'x86_64'
 
+  java-ec2-adot-sigv4-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-adot-sigv4-test.yml@main
+    secrets: inherit
+    with:
+      caller-workflow-name: 'main-build'
+      staging_distro_name: ${{ inputs.ec2-windows-image-name }}
+
   #
   # DOCKER DISTRIBUTION LANGUAGE VERSION COVERAGE
   # DEFAULT SETTING: {Java Version}, EKS, AMD64, AL2

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -99,8 +99,6 @@ jobs:
     secrets: inherit
     with:
       caller-workflow-name: 'main-build'
-      staging_distro_name: ${{ inputs.ec2-windows-image-name }}
-
   #
   # DOCKER DISTRIBUTION LANGUAGE VERSION COVERAGE
   # DEFAULT SETTING: {Java Version}, EKS, AMD64, AL2


### PR DESCRIPTION
Follow up to: https://github.com/aws-observability/aws-application-signals-test-framework/pull/381

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
