### PR TITLE
Enable AWS Resource Detectors without AppSignals

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -277,7 +277,7 @@ public class AwsApplicationSignalsCustomizerProvider
   }
 
   private String disableResourceProvider(
-          ConfigProperties oldProps, List<String> resourceProviders) {
+      ConfigProperties oldProps, List<String> resourceProviders) {
     List<String> list = oldProps.getList(OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG);
     List<String> disabledResourceProviders = new ArrayList<>(list);
     disabledResourceProviders.addAll(resourceProviders);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -194,16 +194,18 @@ public class AwsApplicationSignalsCustomizerProvider
   }
 
   private Map<String, String> customizeProperties(ConfigProperties configProps) {
-    boolean isLambdaEnvironment = isLambdaEnvironment();
     Map<String, String> propsOverride = new HashMap<>();
+    boolean isLambdaEnvironment = isLambdaEnvironment();
 
     // Enable AWS Resource Providers
     propsOverride.put(OTEL_RESOURCE_PROVIDERS_AWS_ENABLED, "true");
+
     if (!isLambdaEnvironment) {
-      this.disableAwsResourceProvider(
-          propsOverride,
-          configProps,
-          List.of("io.opentelemetry.contrib.aws.resource.LambdaResourceProvider"));
+      propsOverride.put(
+          OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG,
+          this.disableResourceProvider(
+              configProps,
+              List.of("io.opentelemetry.contrib.aws.resource.LambdaResourceProvider")));
     }
 
     if (isApplicationSignalsEnabled(configProps)) {
@@ -261,7 +263,9 @@ public class AwsApplicationSignalsCustomizerProvider
               "io.opentelemetry.contrib.aws.resource.EcsResourceProvider",
               "io.opentelemetry.contrib.aws.resource.EksResourceProvider");
 
-      this.disableAwsResourceProvider(propsOverride, configProperties, disabledResourceProviders);
+      propsOverride.put(
+          OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG,
+          this.disableResourceProvider(configProperties, disabledResourceProviders));
 
       // Set the max export batch size for BatchSpanProcessors
       propsOverride.put(
@@ -272,14 +276,12 @@ public class AwsApplicationSignalsCustomizerProvider
     return Collections.emptyMap();
   }
 
-  private void disableAwsResourceProvider(
-      Map<String, String> newProps, ConfigProperties oldProps, List<String> resourceProviders) {
-
+  private String disableResourceProvider(
+          ConfigProperties oldProps, List<String> resourceProviders) {
     List<String> list = oldProps.getList(OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG);
     List<String> disabledResourceProviders = new ArrayList<>(list);
     disabledResourceProviders.addAll(resourceProviders);
-    newProps.put(
-        OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG, String.join(",", disabledResourceProviders));
+    return String.join(",", disabledResourceProviders);
   }
 
   private Resource customizeResource(Resource resource, ConfigProperties configProps) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -194,12 +194,20 @@ public class AwsApplicationSignalsCustomizerProvider
   }
 
   private Map<String, String> customizeProperties(ConfigProperties configProps) {
-    if (isApplicationSignalsEnabled(configProps)) {
-      Map<String, String> propsOverride = new HashMap<>();
-      // Enable AWS Resource Providers
-      propsOverride.put(OTEL_RESOURCE_PROVIDERS_AWS_ENABLED, "true");
+    boolean isLambdaEnvironment = isLambdaEnvironment();
+    Map<String, String> propsOverride = new HashMap<>();
 
-      if (!isLambdaEnvironment()) {
+    // Enable AWS Resource Providers
+    propsOverride.put(OTEL_RESOURCE_PROVIDERS_AWS_ENABLED, "true");
+    if (!isLambdaEnvironment) {
+      this.disableAwsResourceProvider(
+          propsOverride,
+          configProps,
+          List.of("io.opentelemetry.contrib.aws.resource.LambdaResourceProvider"));
+    }
+
+    if (isApplicationSignalsEnabled(configProps)) {
+      if (!isLambdaEnvironment) {
         // Check if properties exist in `configProps`, and only set if missing
         if (configProps.getString(OTEL_METRICS_EXPORTER) == null) {
           propsOverride.put(OTEL_METRICS_EXPORTER, "none");
@@ -236,9 +244,9 @@ public class AwsApplicationSignalsCustomizerProvider
           propsOverride.put(OTEL_JMX_TARGET_SYSTEM_CONFIG, String.join(",", jmxTargets));
         }
       }
-      return propsOverride;
     }
-    return Collections.emptyMap();
+
+    return propsOverride;
   }
 
   private Map<String, String> customizeLambdaEnvProperties(ConfigProperties configProperties) {
@@ -246,15 +254,14 @@ public class AwsApplicationSignalsCustomizerProvider
       Map<String, String> propsOverride = new HashMap<>(2);
 
       // Disable other AWS Resource Providers
-      List<String> list = configProperties.getList(OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG);
-      List<String> disabledResourceProviders = new ArrayList<>(list);
-      disabledResourceProviders.add(
-          "io.opentelemetry.contrib.aws.resource.BeanstalkResourceProvider");
-      disabledResourceProviders.add("io.opentelemetry.contrib.aws.resource.Ec2ResourceProvider");
-      disabledResourceProviders.add("io.opentelemetry.contrib.aws.resource.EcsResourceProvider");
-      disabledResourceProviders.add("io.opentelemetry.contrib.aws.resource.EksResourceProvider");
-      propsOverride.put(
-          OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG, String.join(",", disabledResourceProviders));
+      List<String> disabledResourceProviders =
+          List.of(
+              "io.opentelemetry.contrib.aws.resource.BeanstalkResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.Ec2ResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.EcsResourceProvider",
+              "io.opentelemetry.contrib.aws.resource.EksResourceProvider");
+
+      this.disableAwsResourceProvider(propsOverride, configProperties, disabledResourceProviders);
 
       // Set the max export batch size for BatchSpanProcessors
       propsOverride.put(
@@ -263,6 +270,16 @@ public class AwsApplicationSignalsCustomizerProvider
       return propsOverride;
     }
     return Collections.emptyMap();
+  }
+
+  private void disableAwsResourceProvider(
+      Map<String, String> newProps, ConfigProperties oldProps, List<String> resourceProviders) {
+
+    List<String> list = oldProps.getList(OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG);
+    List<String> disabledResourceProviders = new ArrayList<>(list);
+    disabledResourceProviders.addAll(resourceProviders);
+    newProps.put(
+        OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG, String.join(",", disabledResourceProviders));
   }
 
   private Resource customizeResource(Resource resource, ConfigProperties configProps) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -279,7 +279,7 @@ public class AwsApplicationSignalsCustomizerProvider
   private String disableResourceProvider(
       ConfigProperties oldProps, List<String> resourceProviders) {
     List<String> list = oldProps.getList(OTEL_DISABLED_RESOURCE_PROVIDERS_CONFIG);
-    List<String> disabledResourceProviders = new ArrayList<>(list);
+    Set<String> disabledResourceProviders = new HashSet<>(list);
     disabledResourceProviders.addAll(resourceProviders);
     return String.join(",", disabledResourceProviders);
   }


### PR DESCRIPTION
*Issue #, if available:*
AWS Resource Detectors are currently only enabled when Application Signals are enabled. This behavior is different than other languages which enables the detectors regardless of AppSignals.

*Description of changes:*
Modified the logic in auto instrumentation Java Agent to enable resource detection (except for Lambda) without AppSignals.

*Test*
Ran a sample app on EC2 instance with ADOT Java Agent with the following environment variables:
```
export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=false
export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://xray.us-east-1.amazonaws.com/v1/traces
export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
export OTEL_LOGS_EXPORTER=console
export OTEL_LOGS_EXPORTER_ENDPOINT=none
export OTEL_METRICS_EXPORTER=none
export OTEL_SERVICE_NAME=TEST_SERVICE
export OTEL_TRACES_EXPORTER=otlp
```

```
{
    "resource": {
        "attributes": {
            "telemetry.distro.version": "0.1.0-aws-SNAPSHOT",
            "host.image.id": "ami-0520f976ad2e6300c",
            "process.command_args": [
                "/usr/lib/jvm/java-17-amazon-corretto.x86_64/bin/java",
                "-javaagent:aws-opentelemetry-agent-0.1.0-SNAPSHOT.jar",
                "-jar",
                "springboot-0.1.0-SNAPSHOT.jar"
            ],
            "process.runtime.version": "17.0.14+7-LTS",
            "os.type": "linux",
            "process.pid": 55316,
            "host.type": "c5a.24xlarge",
            "cloud.availability_zone": "us-west-2c",
            "telemetry.sdk.name": "opentelemetry",
            "telemetry.sdk.language": "java",
            "process.runtime.name": "OpenJDK Runtime Environment",
            "service.instance.id": "72cec347-f7c4-45a8-af2f-a32499369180",
            "os.description": "Linux 5.10.234-225.910.amzn2.x86_64",
            "host.arch": "amd64",
            "host.name": "ip-172-31-3-59.us-west-2.compute.internal",
            "telemetry.sdk.version": "1.44.1",
            "cloud.platform": "aws_ec2",
            "host.id": "i-0e25b376bf0712221",
            "cloud.region": "us-west-2",
            "service.name": "TEST_SERVICE",
            "telemetry.distro.name": "opentelemetry-java-instrumentation",
            "cloud.provider": "aws",
            "cloud.account.id": "571600841604",
            "process.executable.path": "/usr/lib/jvm/java-17-amazon-corretto.x86_64/bin/java",
            "process.runtime.description": "Amazon.com Inc. OpenJDK 64-Bit Server VM 17.0.14+7-LTS"
        }
    },
    "scope": {
        "name": "io.opentelemetry.tomcat-7.0",
        "version": "2.10.0-adot2-alpha"
    },
    "traceId": "67e45a374dd6a83b8020378076267f10",
    "spanId": "20068445f37a26a1",
    "flags": 257,
    "name": "GET /aws-sdk-call",
    "kind": "SERVER",
    "startTimeUnixNano": 1743018551621291762,
    "endTimeUnixNano": 1743018551637426307,
    "durationNano": 16134545,
    "attributes": {
        "user_agent.original": "curl/8.3.0",
        "aws.local.service": "TEST_SERVICE",
        "telemetry.extended": "true",
        "network.protocol.version": "1.1",
        "network.peer.port": 41904,
        "url.scheme": "http",
        "thread.name": "http-nio-127.0.0.1-8080-exec-10",
        "aws.local.environment": "ec2:default",
        "server.address": "127.0.0.1",
        "client.address": "127.0.0.1",
        "network.peer.address": "127.0.0.1",
        "aws.local.operation": "GET /aws-sdk-call",
        "http.status_code": 200,
        "aws.span.kind": "LOCAL_ROOT",
        "url.path": "/aws-sdk-call",
        "http.request.method": "GET",
        "http.route": "/aws-sdk-call",
        "server.port": 8080,
        "PlatformType": "AWS::EC2",
        "http.response.status_code": 200,
        "thread.id": 52
    },
    "status": {
        "code": "UNSET"
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
