### PR TITLE
Make the APIGW+Lambda sample app consistent with main branch

### DIFF
--- a/sample-apps/apigateway-lambda/build.gradle.kts
+++ b/sample-apps/apigateway-lambda/build.gradle.kts
@@ -15,7 +15,6 @@ java {
 
 dependencies {
   implementation("com.amazonaws:aws-lambda-java-core:1.2.2")
-  implementation("com.squareup.okhttp3:okhttp:4.11.0")
   implementation("software.amazon.awssdk:s3:2.29.23")
   implementation("org.json:json:20240303")
   implementation("org.slf4j:jcl-over-slf4j:2.0.16")

--- a/sample-apps/apigateway-lambda/settings.gradle.kts
+++ b/sample-apps/apigateway-lambda/settings.gradle.kts
@@ -1,0 +1,16 @@
+pluginManagement {
+  plugins {
+    id("com.diffplug.spotless") version "6.13.0"
+    id("com.github.ben-manes.versions") version "0.50.0"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+    mavenLocal()
+  }
+}
+
+rootProject.name = "sample-app-apigw-lambda"

--- a/sample-apps/apigateway-lambda/terraform/main.tf
+++ b/sample-apps/apigateway-lambda/terraform/main.tf
@@ -16,13 +16,13 @@ resource "aws_iam_role" "lambda_role" {
 }
 
 resource "aws_iam_policy" "s3_access" {
-  name        = "S3ListBucketPolicy"
-  description = "Allow Lambda to check a given S3 bucket exists"
+  name        = "S3ListBucketsPolicy"
+  description = "Allow Lambda to list buckets"
   policy      = jsonencode({
     Version = "2012-10-17",
     Statement = [{
       Effect   = "Allow",
-      Action   = ["s3:ListBucket"],
+      Action   = ["s3:ListAllMyBuckets"],
       Resource = "*"
     }]
   })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,7 +51,6 @@ include(":smoke-tests:spring-boot")
 include(":sample-apps:springboot")
 include(":sample-apps:spark")
 include(":sample-apps:spark-awssdkv1")
-include(":sample-apps:apigateway-lambda")
 
 // Used for contract tests
 include("appsignals-tests:images:mock-collector")


### PR DESCRIPTION
The APIGW+Lambda Sample App in the `release/v1.33.x` branch has fallen out-of-sync with the one in the `main` branch. This causes confusion since we currently develop and release the Application Signals Lambda Layer from the `release/v1.33.x` branch. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
