### PR TITLE
feat: Extract account/access key id and region for cross-account support

### DIFF
--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -54,7 +54,7 @@ index f357a19f88..fa90530579 100644
    testImplementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
  
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
-index 483a0c5230..460036c274 100644
+index 483a0c5230..5b1ee9ac4a 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
 @@ -37,6 +37,7 @@ class AwsSpanAssertions {
@@ -73,62 +73,79 @@ index 483a0c5230..460036c274 100644
              equalTo(HTTP_REQUEST_METHOD, requestMethod),
              equalTo(HTTP_RESPONSE_STATUS_CODE, responseStatusCode),
              satisfies(URL_FULL, val -> val.startsWith("http://")),
-@@ -85,11 +87,36 @@ class AwsSpanAssertions {
+@@ -85,28 +87,52 @@ class AwsSpanAssertions {
    }
  
    static SpanDataAssert sns(SpanDataAssert span, String topicArn, String rpcMethod) {
--
++    SpanDataAssert spanAssert =
++        span.hasName("SNS." + rpcMethod).hasKind(SpanKind.CLIENT).hasNoParent();
+ 
 -    return span.hasName("SNS." + rpcMethod)
-+    SpanDataAssert spanAssert = span.hasName("SNS." + rpcMethod)
-         .hasKind(SpanKind.CLIENT)
+-        .hasKind(SpanKind.CLIENT)
 -        .hasNoParent()
 -        .hasAttributesSatisfyingExactly(
-+        .hasNoParent();
-+
-+    // For CreateTopic, the topicArn parameter might be null but aws.sns.topic.arn 
+-            equalTo(stringKey("aws.agent"), "java-aws-sdk"),
+-            equalTo(MESSAGING_DESTINATION_NAME, topicArn),
+-            satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
+-            satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
+-            equalTo(RPC_METHOD, rpcMethod),
+-            equalTo(RPC_SYSTEM, "aws-api"),
+-            equalTo(RPC_SERVICE, "AmazonSNS"),
+-            equalTo(HTTP_REQUEST_METHOD, "POST"),
+-            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+-            satisfies(URL_FULL, val -> val.startsWith("http://")),
+-            satisfies(SERVER_ADDRESS, v -> v.isInstanceOf(String.class)),
+-            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+-            satisfies(
+-                SERVER_PORT,
+-                val ->
+-                    val.satisfiesAnyOf(
+-                        v -> assertThat(v).isNull(),
+-                        v -> assertThat(v).isInstanceOf(Number.class))));
++    // For CreateTopic, the topicArn parameter might be null but aws.sns.topic.arn
 +    // will be set from the response
 +    if ("CreateTopic".equals(rpcMethod)) {
 +      return spanAssert.hasAttributesSatisfyingExactly(
-+            equalTo(stringKey("aws.agent"), "java-aws-sdk"),
-+            satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
-+            satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
-+            equalTo(RPC_METHOD, rpcMethod),
-+            equalTo(RPC_SYSTEM, "aws-api"),
-+            equalTo(RPC_SERVICE, "AmazonSNS"),
-+            equalTo(stringKey("aws.auth.account.access_key"), "test"),
-+            equalTo(HTTP_REQUEST_METHOD, "POST"),
-+            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-+            satisfies(URL_FULL, val -> val.startsWith("http://")),
-+            satisfies(SERVER_ADDRESS, v -> v.isInstanceOf(String.class)),
-+            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-+            satisfies(
-+                SERVER_PORT,
-+                val ->
-+                    val.satisfiesAnyOf(
-+                        v -> assertThat(v).isNull(),
-+                        v -> assertThat(v).isInstanceOf(Number.class))),
-+            satisfies(stringKey("aws.sns.topic.arn"), v -> v.isInstanceOf(String.class)));
++          equalTo(stringKey("aws.agent"), "java-aws-sdk"),
++          satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
++          satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
++          equalTo(RPC_METHOD, rpcMethod),
++          equalTo(RPC_SYSTEM, "aws-api"),
++          equalTo(RPC_SERVICE, "AmazonSNS"),
++          equalTo(stringKey("aws.auth.account.access_key"), "test"),
++          equalTo(HTTP_REQUEST_METHOD, "POST"),
++          equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
++          satisfies(URL_FULL, val -> val.startsWith("http://")),
++          satisfies(SERVER_ADDRESS, v -> v.isInstanceOf(String.class)),
++          equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++          satisfies(
++              SERVER_PORT,
++              val ->
++                  val.satisfiesAnyOf(
++                      v -> assertThat(v).isNull(), v -> assertThat(v).isInstanceOf(Number.class))),
++          satisfies(stringKey("aws.sns.topic.arn"), v -> v.isInstanceOf(String.class)));
 +    }
 +
 +    return spanAssert.hasAttributesSatisfyingExactly(
-             equalTo(stringKey("aws.agent"), "java-aws-sdk"),
-             equalTo(MESSAGING_DESTINATION_NAME, topicArn),
-             satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
-@@ -97,6 +124,7 @@ class AwsSpanAssertions {
-             equalTo(RPC_METHOD, rpcMethod),
-             equalTo(RPC_SYSTEM, "aws-api"),
-             equalTo(RPC_SERVICE, "AmazonSNS"),
-+            equalTo(stringKey("aws.auth.account.access_key"), "test"),
-             equalTo(HTTP_REQUEST_METHOD, "POST"),
-             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-             satisfies(URL_FULL, val -> val.startsWith("http://")),
-@@ -107,6 +135,7 @@ class AwsSpanAssertions {
-                 val ->
-                     val.satisfiesAnyOf(
-                         v -> assertThat(v).isNull(),
--                        v -> assertThat(v).isInstanceOf(Number.class))));
-+                        v -> assertThat(v).isInstanceOf(Number.class))),
-+            equalTo(stringKey("aws.sns.topic.arn"), topicArn));
++        equalTo(stringKey("aws.agent"), "java-aws-sdk"),
++        equalTo(MESSAGING_DESTINATION_NAME, topicArn),
++        satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
++        satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
++        equalTo(RPC_METHOD, rpcMethod),
++        equalTo(RPC_SYSTEM, "aws-api"),
++        equalTo(RPC_SERVICE, "AmazonSNS"),
++        equalTo(stringKey("aws.auth.account.access_key"), "test"),
++        equalTo(HTTP_REQUEST_METHOD, "POST"),
++        equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
++        satisfies(URL_FULL, val -> val.startsWith("http://")),
++        satisfies(SERVER_ADDRESS, v -> v.isInstanceOf(String.class)),
++        equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++        satisfies(
++            SERVER_PORT,
++            val ->
++                val.satisfiesAnyOf(
++                    v -> assertThat(v).isNull(), v -> assertThat(v).isInstanceOf(Number.class))),
++        equalTo(stringKey("aws.sns.topic.arn"), topicArn));
    }
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3TracingTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3TracingTest.java
@@ -1896,15 +1913,15 @@ index 0000000000..98a5873614
 +  }
 +}
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
-index 441a4a3a0b..63156c88df 100644
+index 441a4a3a0b..529e317a65 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
-@@ -12,9 +12,12 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
+@@ -11,10 +11,12 @@ import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_DY
+ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
  import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DYNAMODB;
  import static java.util.Collections.singletonList;
- 
 +import static org.junit.Assert.assertEquals;
-+
+ 
  import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
  import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
  import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
@@ -1912,7 +1929,7 @@ index 441a4a3a0b..63156c88df 100644
  import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
  import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
  import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
-@@ -53,4 +56,39 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
+@@ -53,4 +55,39 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
      assertRequestWithMockedResponse(
          response, client, "DynamoDBv2", "CreateTable", "POST", additionalAttributes);
    }
@@ -1953,7 +1970,7 @@ index 441a4a3a0b..63156c88df 100644
 +  }
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java
-index ee6d1b7501..5fb8db3592 100644
+index ee6d1b7501..a21b1ebefa 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java
 @@ -12,13 +12,16 @@ import static java.util.Collections.singletonList;
@@ -1973,7 +1990,7 @@ index ee6d1b7501..5fb8db3592 100644
  import org.junit.jupiter.params.ParameterizedTest;
  import org.junit.jupiter.params.provider.Arguments;
  import org.junit.jupiter.params.provider.MethodSource;
-@@ -54,6 +57,39 @@ public abstract class AbstractKinesisClientTest extends AbstractBaseAwsClientTes
+@@ -54,6 +57,41 @@ public abstract class AbstractKinesisClientTest extends AbstractBaseAwsClientTes
          response, client, "Kinesis", operation, "POST", additionalAttributes);
    }
  
@@ -2001,7 +2018,9 @@ index ee6d1b7501..5fb8db3592 100644
 +    List<AttributeAssertion> additionalAttributes =
 +        Arrays.asList(
 +            equalTo(stringKey("aws.stream.name"), "somestream"),
-+            equalTo(stringKey("aws.stream.arn"), "arn:aws:kinesis:us-east-1:123456789012:stream/somestream"));
++            equalTo(
++                stringKey("aws.stream.arn"),
++                "arn:aws:kinesis:us-east-1:123456789012:stream/somestream"));
 +
 +    Object response =
 +        client.describeStream(new DescribeStreamRequest().withStreamName("somestream"));

--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -1,42 +1,38 @@
 diff --git a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
-index 93437ef1e0..4e9248fd01 100644
+index 93437ef1e0..3f564d25bc 100644
 --- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
 +++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
 @@ -1,2 +1,2 @@
--Comparing source compatibility of opentelemetry-instrumentation-annotations-2.11.0.jar against opentelemetry-instrumentation-annotations-2.10.0.jar
+ Comparing source compatibility of opentelemetry-instrumentation-annotations-2.11.0.jar against opentelemetry-instrumentation-annotations-2.10.0.jar
 -No changes.
 \ No newline at end of file
-+Comparing source compatibility of opentelemetry-instrumentation-annotations-2.11.0-adot1.jar against opentelemetry-instrumentation-annotations-2.11.0.jar
 +No changes.
 diff --git a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
-index d759eed30a..1c725a0a25 100644
+index d759eed30a..385bd90663 100644
 --- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
 +++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
 @@ -1,2 +1,2 @@
--Comparing source compatibility of opentelemetry-instrumentation-api-2.11.0.jar against opentelemetry-instrumentation-api-2.10.0.jar
+ Comparing source compatibility of opentelemetry-instrumentation-api-2.11.0.jar against opentelemetry-instrumentation-api-2.10.0.jar
 -No changes.
 \ No newline at end of file
-+Comparing source compatibility of opentelemetry-instrumentation-api-2.11.0-adot1.jar against opentelemetry-instrumentation-api-2.11.0.jar
 +No changes.
 diff --git a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
-index f657f219ae..a6ec574fe5 100644
+index f657f219ae..2b4a59db8f 100644
 --- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
 +++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-autoconfigure.txt
 @@ -1,2 +1,2 @@
--Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.11.0.jar against opentelemetry-spring-boot-autoconfigure-2.10.0.jar
+ Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.11.0.jar against opentelemetry-spring-boot-autoconfigure-2.10.0.jar
 -No changes.
 \ No newline at end of file
-+Comparing source compatibility of opentelemetry-spring-boot-autoconfigure-2.11.0-adot1.jar against opentelemetry-spring-boot-autoconfigure-2.11.0.jar
 +No changes.
 diff --git a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-starter.txt b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-starter.txt
-index 02f520fd45..2109c5a927 100644
+index 02f520fd45..99505334b7 100644
 --- a/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-starter.txt
 +++ b/docs/apidiffs/current_vs_latest/opentelemetry-spring-boot-starter.txt
 @@ -1,2 +1,2 @@
--Comparing source compatibility of opentelemetry-spring-boot-starter-2.11.0.jar against opentelemetry-spring-boot-starter-2.10.0.jar
+ Comparing source compatibility of opentelemetry-spring-boot-starter-2.11.0.jar against opentelemetry-spring-boot-starter-2.10.0.jar
 -No changes.
 \ No newline at end of file
-+Comparing source compatibility of opentelemetry-spring-boot-starter-2.11.0-adot1.jar against opentelemetry-spring-boot-starter-2.11.0.jar
 +No changes.
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
 index f357a19f88..fa90530579 100644
@@ -58,10 +54,26 @@ index f357a19f88..fa90530579 100644
    testImplementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
  
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
-index 483a0c5230..2415577e37 100644
+index 483a0c5230..460036c274 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSpanAssertions.java
-@@ -85,11 +85,35 @@ class AwsSpanAssertions {
+@@ -37,6 +37,7 @@ class AwsSpanAssertions {
+             satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
+             equalTo(stringKey("aws.queue.name"), queueName),
+             equalTo(stringKey("aws.queue.url"), queueUrl),
++            equalTo(stringKey("aws.auth.account.access_key"), "test"),
+             satisfies(AWS_REQUEST_ID, v -> v.isInstanceOf(String.class)),
+             equalTo(RPC_METHOD, rpcMethod),
+             equalTo(RPC_SYSTEM, "aws-api"),
+@@ -71,6 +72,7 @@ class AwsSpanAssertions {
+             equalTo(RPC_METHOD, rpcMethod),
+             equalTo(RPC_SYSTEM, "aws-api"),
+             equalTo(RPC_SERVICE, "Amazon S3"),
++            equalTo(stringKey("aws.auth.account.access_key"), "test"),
+             equalTo(HTTP_REQUEST_METHOD, requestMethod),
+             equalTo(HTTP_RESPONSE_STATUS_CODE, responseStatusCode),
+             satisfies(URL_FULL, val -> val.startsWith("http://")),
+@@ -85,11 +87,36 @@ class AwsSpanAssertions {
    }
  
    static SpanDataAssert sns(SpanDataAssert span, String topicArn, String rpcMethod) {
@@ -83,6 +95,7 @@ index 483a0c5230..2415577e37 100644
 +            equalTo(RPC_METHOD, rpcMethod),
 +            equalTo(RPC_SYSTEM, "aws-api"),
 +            equalTo(RPC_SERVICE, "AmazonSNS"),
++            equalTo(stringKey("aws.auth.account.access_key"), "test"),
 +            equalTo(HTTP_REQUEST_METHOD, "POST"),
 +            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
 +            satisfies(URL_FULL, val -> val.startsWith("http://")),
@@ -101,7 +114,15 @@ index 483a0c5230..2415577e37 100644
              equalTo(stringKey("aws.agent"), "java-aws-sdk"),
              equalTo(MESSAGING_DESTINATION_NAME, topicArn),
              satisfies(stringKey("aws.endpoint"), v -> v.isInstanceOf(String.class)),
-@@ -107,6 +131,7 @@ class AwsSpanAssertions {
+@@ -97,6 +124,7 @@ class AwsSpanAssertions {
+             equalTo(RPC_METHOD, rpcMethod),
+             equalTo(RPC_SYSTEM, "aws-api"),
+             equalTo(RPC_SERVICE, "AmazonSNS"),
++            equalTo(stringKey("aws.auth.account.access_key"), "test"),
+             equalTo(HTTP_REQUEST_METHOD, "POST"),
+             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+             satisfies(URL_FULL, val -> val.startsWith("http://")),
+@@ -107,6 +135,7 @@ class AwsSpanAssertions {
                  val ->
                      val.satisfiesAnyOf(
                          v -> assertThat(v).isNull(),
@@ -110,6 +131,38 @@ index 483a0c5230..2415577e37 100644
 +            equalTo(stringKey("aws.sns.topic.arn"), topicArn));
    }
  }
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3TracingTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3TracingTest.java
+index 56eca09f8c..82c3379840 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3TracingTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/S3TracingTest.java
+@@ -105,6 +105,7 @@ class S3TracingTest {
+                             equalTo(RPC_METHOD, "ReceiveMessage"),
+                             equalTo(RPC_SYSTEM, "aws-api"),
+                             equalTo(RPC_SERVICE, "AmazonSQS"),
++                            equalTo(stringKey("aws.auth.account.access_key"), "test"),
+                             equalTo(HTTP_REQUEST_METHOD, "POST"),
+                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                             satisfies(URL_FULL, val -> val.startsWith("http://")),
+@@ -198,6 +199,7 @@ class S3TracingTest {
+                             equalTo(RPC_METHOD, "ReceiveMessage"),
+                             equalTo(RPC_SYSTEM, "aws-api"),
+                             equalTo(RPC_SERVICE, "AmazonSQS"),
++                            equalTo(stringKey("aws.auth.account.access_key"), "test"),
+                             equalTo(HTTP_REQUEST_METHOD, "POST"),
+                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                             satisfies(URL_FULL, val -> val.startsWith("http://")),
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/SnsTracingTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/SnsTracingTest.java
+index 429ca07938..d21918bc70 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/SnsTracingTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/SnsTracingTest.java
+@@ -89,6 +89,7 @@ class SnsTracingTest {
+                             equalTo(RPC_METHOD, "ReceiveMessage"),
+                             equalTo(RPC_SYSTEM, "aws-api"),
+                             equalTo(RPC_SERVICE, "AmazonSQS"),
++                            equalTo(stringKey("aws.auth.account.access_key"), "test"),
+                             equalTo(HTTP_REQUEST_METHOD, "POST"),
+                             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                             satisfies(URL_FULL, val -> val.startsWith("http://")),
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
 index 6cf49a21c4..3705634153 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
@@ -287,13 +340,16 @@ index 0000000000..e890cb3c0f
 +  }
 +}
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
-index 096c7826a1..a271b16da8 100644
+index 096c7826a1..27613c04f2 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsExperimentalAttributes.java
-@@ -17,6 +17,36 @@ final class AwsExperimentalAttributes {
+@@ -16,7 +16,41 @@ final class AwsExperimentalAttributes {
+   static final AttributeKey<String> AWS_QUEUE_URL = stringKey("aws.queue.url");
    static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
    static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
++  static final AttributeKey<String> AWS_STREAM_ARN = stringKey("aws.stream.arn");
    static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
++  static final AttributeKey<String> AWS_TABLE_ARN = stringKey("aws.table.arn");
 +  static final AttributeKey<String> AWS_AGENT_ID = stringKey("aws.bedrock.agent.id");
 +  static final AttributeKey<String> AWS_KNOWLEDGE_BASE_ID =
 +      stringKey("aws.bedrock.knowledge_base.id");
@@ -322,20 +378,23 @@ index 096c7826a1..a271b16da8 100644
 +  static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
 +  static final AttributeKey<String> AWS_SECRET_ARN = stringKey("aws.secretsmanager.secret.arn");
 +  static final AttributeKey<String> AWS_LAMBDA_NAME = stringKey("aws.lambda.function.name");
++  static final AttributeKey<String> AWS_LAMBDA_ARN = stringKey("aws.lambda.function.arn");
 +  static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
 +      stringKey("aws.lambda.resource_mapping.id");
++  static final AttributeKey<String> AWS_AUTH_ACCESS_KEY = stringKey("aws.auth.account.access_key");
  
    private AwsExperimentalAttributes() {}
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
-index 541e67d23b..1abf8e9c28 100644
+index 541e67d23b..d0e0ac71fa 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
-@@ -6,12 +6,30 @@
+@@ -6,25 +6,54 @@
  package io.opentelemetry.instrumentation.awssdk.v1_11;
  
  import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_AGENT;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_AGENT_ID;
++import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_AUTH_ACCESS_KEY;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BEDROCK_RUNTIME_MODEL_ID;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BEDROCK_SYSTEM;
  import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_BUCKET_NAME;
@@ -343,6 +402,7 @@ index 541e67d23b..1abf8e9c28 100644
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_GUARDRAIL_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_KNOWLEDGE_BASE_ID;
++import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_LAMBDA_RESOURCE_ID;
  import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_QUEUE_NAME;
@@ -351,7 +411,9 @@ index 541e67d23b..1abf8e9c28 100644
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
++import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STREAM_ARN;
  import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_STREAM_NAME;
++import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_TABLE_ARN;
  import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_TABLE_NAME;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
 +import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.GEN_AI_REQUEST_TEMPERATURE;
@@ -362,7 +424,9 @@ index 541e67d23b..1abf8e9c28 100644
  
  import com.amazonaws.Request;
  import com.amazonaws.Response;
-@@ -19,12 +37,17 @@ import io.opentelemetry.api.common.AttributeKey;
++import com.amazonaws.auth.AWSCredentials;
++import com.amazonaws.handlers.HandlerContextKey;
+ import io.opentelemetry.api.common.AttributeKey;
  import io.opentelemetry.api.common.AttributesBuilder;
  import io.opentelemetry.context.Context;
  import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -380,7 +444,7 @@ index 541e67d23b..1abf8e9c28 100644
  
    @Override
    public void onStart(AttributesBuilder attributes, Context parentContext, Request<?> request) {
-@@ -32,14 +55,155 @@ class AwsSdkExperimentalAttributesExtractor
+@@ -32,14 +61,166 @@ class AwsSdkExperimentalAttributesExtractor
      attributes.put(AWS_ENDPOINT, request.getEndpoint().toString());
  
      Object originalRequest = request.getOriginalRequest();
@@ -390,10 +454,19 @@ index 541e67d23b..1abf8e9c28 100644
 -    setRequestAttribute(attributes, AWS_STREAM_NAME, originalRequest, RequestAccess::getStreamName);
 -    setRequestAttribute(attributes, AWS_TABLE_NAME, originalRequest, RequestAccess::getTableName);
 +    String requestClassName = originalRequest.getClass().getSimpleName();
++
++    AWSCredentials credentials = request.getHandlerContext(HandlerContextKey.AWS_CREDENTIALS);
++    if (credentials != null) {
++      String accessKeyId = credentials.getAWSAccessKeyId();
++      if (accessKeyId != null) {
++        attributes.put(AWS_AUTH_ACCESS_KEY, accessKeyId);
++      }
++    }
 +    setAttribute(attributes, AWS_BUCKET_NAME, originalRequest, RequestAccess::getBucketName);
 +    setAttribute(attributes, AWS_QUEUE_URL, originalRequest, RequestAccess::getQueueUrl);
 +    setAttribute(attributes, AWS_QUEUE_NAME, originalRequest, RequestAccess::getQueueName);
 +    setAttribute(attributes, AWS_STREAM_NAME, originalRequest, RequestAccess::getStreamName);
++    setAttribute(attributes, AWS_STREAM_ARN, originalRequest, RequestAccess::getStreamArn);
 +    setAttribute(attributes, AWS_TABLE_NAME, originalRequest, RequestAccess::getTableName);
 +    setAttribute(
 +        attributes, AWS_STATE_MACHINE_ARN, originalRequest, RequestAccess::getStateMachineArn);
@@ -424,6 +497,8 @@ index 541e67d23b..1abf8e9c28 100644
 +      @Nullable Throwable error) {
 +    if (response != null) {
 +      Object awsResp = response.getAwsResponse();
++      setAttribute(attributes, AWS_TABLE_ARN, awsResp, RequestAccess::getTableArn);
++      setAttribute(attributes, AWS_LAMBDA_ARN, awsResp, RequestAccess::getLambdaArn);
 +      setAttribute(attributes, AWS_STATE_MACHINE_ARN, awsResp, RequestAccess::getStateMachineArn);
 +      setAttribute(
 +          attributes,
@@ -542,7 +617,7 @@ index 541e67d23b..1abf8e9c28 100644
        AttributesBuilder attributes,
        AttributeKey<String> key,
        Object request,
-@@ -49,12 +213,4 @@ class AwsSdkExperimentalAttributesExtractor
+@@ -49,12 +230,4 @@ class AwsSdkExperimentalAttributesExtractor
        attributes.put(key, value);
      }
    }
@@ -829,7 +904,7 @@ index 0000000000..d1acc5768a
 +  }
 +}
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
-index c212a69678..3101685194 100644
+index c212a69678..82a7185abe 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/RequestAccess.java
 @@ -8,6 +8,12 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
@@ -845,7 +920,7 @@ index c212a69678..3101685194 100644
  import javax.annotation.Nullable;
  
  final class RequestAccess {
-@@ -20,48 +26,392 @@ final class RequestAccess {
+@@ -20,48 +26,417 @@ final class RequestAccess {
          }
        };
  
@@ -1075,6 +1150,14 @@ index c212a69678..3101685194 100644
 +  }
 +
 +  @Nullable
++  static String getLambdaArn(Object request) {
++    if (request == null) {
++      return null;
++    }
++    return findNestedAccessorOrNull(request, "getConfiguration", "getFunctionArn");
++  }
++
++  @Nullable
 +  static String getLambdaResourceId(Object request) {
 +    if (request == null) {
 +      return null;
@@ -1164,6 +1247,23 @@ index c212a69678..3101685194 100644
      return invokeOrNull(access.getTableName, request);
    }
  
++  @Nullable
++  static String getTableArn(Object request) {
++    if (request == null) {
++      return null;
++    }
++    return findNestedAccessorOrNull(request, "getTable", "getTableArn");
++  }
++
++  @Nullable
++  static String getStreamArn(Object request) {
++    if (request == null) {
++      return null;
++    }
++    RequestAccess access = REQUEST_ACCESSORS.get(request.getClass());
++    return invokeOrNull(access.getStreamArn, request);
++  }
++
    @Nullable
    static String getTopicArn(Object request) {
 +    if (request == null) {
@@ -1238,7 +1338,7 @@ index c212a69678..3101685194 100644
    @Nullable
    private static String invokeOrNull(@Nullable MethodHandle method, Object obj) {
      if (method == null) {
-@@ -74,6 +424,19 @@ final class RequestAccess {
+@@ -74,31 +449,88 @@ final class RequestAccess {
      }
    }
  
@@ -1258,7 +1358,8 @@ index c212a69678..3101685194 100644
    @Nullable private final MethodHandle getBucketName;
    @Nullable private final MethodHandle getQueueUrl;
    @Nullable private final MethodHandle getQueueName;
-@@ -81,24 +444,66 @@ final class RequestAccess {
+   @Nullable private final MethodHandle getStreamName;
++  @Nullable private final MethodHandle getStreamArn;
    @Nullable private final MethodHandle getTableName;
    @Nullable private final MethodHandle getTopicArn;
    @Nullable private final MethodHandle getTargetArn;
@@ -1287,6 +1388,7 @@ index c212a69678..3101685194 100644
 +    getQueueUrl = findAccessorOrNull(clz, "getQueueUrl", String.class);
 +    getQueueName = findAccessorOrNull(clz, "getQueueName", String.class);
 +    getStreamName = findAccessorOrNull(clz, "getStreamName", String.class);
++    getStreamArn = findAccessorOrNull(clz, "getStreamARN", String.class);
 +    getTableName = findAccessorOrNull(clz, "getTableName", String.class);
 +    getTopicArn = findAccessorOrNull(clz, "getTopicArn", String.class);
 +    getTargetArn = findAccessorOrNull(clz, "getTargetArn", String.class);
@@ -1793,6 +1895,124 @@ index 0000000000..98a5873614
 +        });
 +  }
 +}
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+index 441a4a3a0b..63156c88df 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractDynamoDbClientTest.java
+@@ -12,9 +12,12 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYST
+ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DYNAMODB;
+ import static java.util.Collections.singletonList;
+ 
++import static org.junit.Assert.assertEquals;
++
+ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+ import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
++import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
+ import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+ import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
+ import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
+@@ -53,4 +56,39 @@ public abstract class AbstractDynamoDbClientTest extends AbstractBaseAwsClientTe
+     assertRequestWithMockedResponse(
+         response, client, "DynamoDBv2", "CreateTable", "POST", additionalAttributes);
+   }
++
++  @Test
++  public void testGetTableArnWithMockedResponse() {
++    AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard();
++    AmazonDynamoDB client =
++        configureClient(clientBuilder)
++            .withEndpointConfiguration(endpoint)
++            .withCredentials(credentialsProvider)
++            .build();
++
++    String tableName = "MockTable";
++    String expectedArn = "arn:aws:dynamodb:us-west-2:123456789012:table/" + tableName;
++
++    String body =
++        "{\n"
++            + "\"Table\": {\n"
++            + "\"TableName\": \""
++            + tableName
++            + "\",\n"
++            + "\"TableArn\": \""
++            + expectedArn
++            + "\"\n"
++            + "}\n"
++            + "}";
++
++    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, body));
++
++    String actualArn =
++        client
++            .describeTable(new DescribeTableRequest().withTableName(tableName))
++            .getTable()
++            .getTableArn();
++
++    assertEquals("Table ARN should match expected value", expectedArn, actualArn);
++  }
+ }
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java
+index ee6d1b7501..5fb8db3592 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractKinesisClientTest.java
+@@ -12,13 +12,16 @@ import static java.util.Collections.singletonList;
+ import com.amazonaws.services.kinesis.AmazonKinesis;
+ import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
+ import com.amazonaws.services.kinesis.model.DeleteStreamRequest;
++import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+ import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+ import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
+ import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
+ import io.opentelemetry.testing.internal.armeria.common.MediaType;
++import java.util.Arrays;
+ import java.util.List;
+ import java.util.function.Function;
+ import java.util.stream.Stream;
++import org.junit.Test;
+ import org.junit.jupiter.params.ParameterizedTest;
+ import org.junit.jupiter.params.provider.Arguments;
+ import org.junit.jupiter.params.provider.MethodSource;
+@@ -54,6 +57,39 @@ public abstract class AbstractKinesisClientTest extends AbstractBaseAwsClientTes
+         response, client, "Kinesis", operation, "POST", additionalAttributes);
+   }
+ 
++  @Test
++  public void sendRequestWithStreamArnMockedResponse() throws Exception {
++    AmazonKinesisClientBuilder clientBuilder = AmazonKinesisClientBuilder.standard();
++    AmazonKinesis client =
++        configureClient(clientBuilder)
++            .withEndpointConfiguration(endpoint)
++            .withCredentials(credentialsProvider)
++            .build();
++
++    String body =
++        "{\n"
++            + "\"StreamDescription\": {\n"
++            + "\"StreamARN\": \"arn:aws:kinesis:us-east-1:123456789012:stream/somestream\",\n"
++            + "\"StreamName\": \"somestream\",\n"
++            + "\"StreamStatus\": \"ACTIVE\",\n"
++            + "\"Shards\": []\n"
++            + "}\n"
++            + "}";
++
++    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, body));
++
++    List<AttributeAssertion> additionalAttributes =
++        Arrays.asList(
++            equalTo(stringKey("aws.stream.name"), "somestream"),
++            equalTo(stringKey("aws.stream.arn"), "arn:aws:kinesis:us-east-1:123456789012:stream/somestream"));
++
++    Object response =
++        client.describeStream(new DescribeStreamRequest().withStreamName("somestream"));
++
++    assertRequestWithMockedResponse(
++        response, client, "Kinesis", "DescribeStream", "POST", additionalAttributes);
++  }
++
+   private static Stream<Arguments> provideArguments() {
+     return Stream.of(
+         Arguments.of(
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractLambdaClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractLambdaClientTest.java
 new file mode 100644
 index 0000000000..9f5a245ee7
@@ -1871,6 +2091,18 @@ index 0000000000..9f5a245ee7
 +                c -> c.getFunction(new GetFunctionRequest().withFunctionName("functionName"))));
 +  }
 +}
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractS3ClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractS3ClientTest.java
+index 574165992f..5248d050b6 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractS3ClientTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractS3ClientTest.java
+@@ -175,6 +175,7 @@ public abstract class AbstractS3ClientTest extends AbstractBaseAwsClientTest {
+                                 equalTo(RPC_SYSTEM, "aws-api"),
+                                 equalTo(RPC_SERVICE, "Amazon S3"),
+                                 equalTo(RPC_METHOD, "GetObject"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
+                                 equalTo(stringKey("aws.endpoint"), server.httpUri().toString()),
+                                 equalTo(stringKey("aws.agent"), "java-aws-sdk"),
+                                 equalTo(stringKey("aws.bucket.name"), "someBucket"),
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSecretsManagerClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSecretsManagerClientTest.java
 new file mode 100644
 index 0000000000..03de6fce3f
@@ -2166,10 +2398,10 @@ index 3b7381a8ba..6f77951710 100644
  testing {
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java
 new file mode 100644
-index 0000000000..4aed4a58c0
+index 0000000000..fd951ffe37
 --- /dev/null
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsExperimentalAttributes.java
-@@ -0,0 +1,73 @@
+@@ -0,0 +1,80 @@
 +/*
 + * Copyright The OpenTelemetry Authors
 + * SPDX-License-Identifier: Apache-2.0
@@ -2186,6 +2418,7 @@ index 0000000000..4aed4a58c0
 +  static final AttributeKey<String> AWS_QUEUE_URL = stringKey("aws.queue.url");
 +  static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
 +  static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
++  static final AttributeKey<String> AWS_STREAM_ARN = stringKey("aws.stream.arn");
 +  static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
 +  static final AttributeKey<String> AWS_GUARDRAIL_ID = stringKey("aws.bedrock.guardrail.id");
 +  static final AttributeKey<String> AWS_GUARDRAIL_ARN = stringKey("aws.bedrock.guardrail.arn");
@@ -2231,6 +2464,12 @@ index 0000000000..4aed4a58c0
 +
 +  static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
 +      stringKey("aws.lambda.resource_mapping.id");
++
++  static final AttributeKey<String> AWS_TABLE_ARN = stringKey("aws.table.arn");
++
++  static final AttributeKey<String> AWS_AUTH_ACCESS_KEY = stringKey("aws.auth.account.access_key");
++
++  static final AttributeKey<String> AWS_AUTH_REGION = stringKey("aws.auth.region");
 +
 +  static boolean isGenAiAttribute(String attributeKey) {
 +    return attributeKey.equals(GEN_AI_REQUEST_MAX_TOKENS.getKey())
@@ -2322,10 +2561,10 @@ index 02d92ca070..aa98cd62c7 100644
    BatchGetItem(
        DYNAMODB,
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
-index 274ec27194..83d9353c3b 100644
+index 274ec27194..d8dba6cf5c 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java
-@@ -5,7 +5,32 @@
+@@ -5,7 +5,34 @@
  
  package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
  
@@ -2344,7 +2583,9 @@ index 274ec27194..83d9353c3b 100644
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
++import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_STREAM_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_STREAM_NAME;
++import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_TABLE_ARN;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_TABLE_NAME;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.GEN_AI_MODEL;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
@@ -2358,7 +2599,7 @@ index 274ec27194..83d9353c3b 100644
  
  import io.opentelemetry.api.common.AttributeKey;
  import java.util.Collections;
-@@ -13,16 +38,60 @@ import java.util.List;
+@@ -13,16 +40,64 @@ import java.util.List;
  import java.util.Map;
  
  enum AwsSdkRequestType {
@@ -2370,9 +2611,13 @@ index 274ec27194..83d9353c3b 100644
 +
 +  SQS(request(AWS_QUEUE_URL.getKey(), "QueueUrl"), request(AWS_QUEUE_NAME.getKey(), "QueueName")),
 +
-+  KINESIS(request(AWS_STREAM_NAME.getKey(), "StreamName")),
++  KINESIS(
++      request(AWS_STREAM_NAME.getKey(), "StreamName"),
++      request(AWS_STREAM_ARN.getKey(), "StreamARN")),
 +
-+  DYNAMODB(request(AWS_TABLE_NAME.getKey(), "TableName")),
++  DYNAMODB(
++      request(AWS_TABLE_NAME.getKey(), "TableName"),
++      response(AWS_TABLE_ARN.getKey(), "Table.TableArn")),
 +
    SNS(
        /*
@@ -2962,19 +3207,37 @@ index 7ae1590152..5b7a188914 100644
 +  }
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
-index 94243d0b11..7b15a1c84b 100644
+index 94243d0b11..06d8a9141b 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingExecutionInterceptor.java
-@@ -5,6 +5,8 @@
+@@ -5,6 +5,10 @@
  
  package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
  
++import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_AUTH_ACCESS_KEY;
++import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.AWS_AUTH_REGION;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsExperimentalAttributes.GEN_AI_SYSTEM;
 +import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.BEDROCKRUNTIME;
  import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkRequestType.DYNAMODB;
  
  import io.opentelemetry.api.common.AttributeKey;
-@@ -48,6 +50,7 @@ import software.amazon.awssdk.http.SdkHttpResponse;
+@@ -28,6 +32,7 @@ import java.time.Instant;
+ import java.util.Optional;
+ import java.util.stream.Collectors;
+ import javax.annotation.Nullable;
++import software.amazon.awssdk.auth.credentials.AwsCredentials;
+ import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+ import software.amazon.awssdk.awscore.AwsResponse;
+ import software.amazon.awssdk.core.ClientType;
+@@ -40,6 +45,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+ import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+ import software.amazon.awssdk.http.SdkHttpRequest;
+ import software.amazon.awssdk.http.SdkHttpResponse;
++import software.amazon.awssdk.regions.Region;
+ 
+ /**
+  * AWS request execution interceptor.
+@@ -48,6 +54,7 @@ import software.amazon.awssdk.http.SdkHttpResponse;
   * at any time.
   */
  public final class TracingExecutionInterceptor implements ExecutionInterceptor {
@@ -2982,7 +3245,34 @@ index 94243d0b11..7b15a1c84b 100644
  
    // copied from DbIncubatingAttributes
    private static final AttributeKey<String> DB_OPERATION = AttributeKey.stringKey("db.operation");
-@@ -342,6 +345,10 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
+@@ -261,6 +268,26 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
+     SdkHttpRequest httpRequest = context.httpRequest();
+     executionAttributes.putAttribute(SDK_HTTP_REQUEST_ATTRIBUTE, httpRequest);
+ 
++    if (captureExperimentalSpanAttributes) {
++      AwsCredentials credentials =
++          executionAttributes.getAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS);
++      Region signingRegion =
++          executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION);
++      Span span = Span.fromContext(otelContext);
++
++      if (credentials != null) {
++        String accessKeyId = credentials.accessKeyId();
++        if (accessKeyId != null) {
++          span.setAttribute(AWS_AUTH_ACCESS_KEY, accessKeyId);
++        }
++      }
++
++      if (signingRegion != null) {
++        String region = signingRegion.toString();
++        span.setAttribute(AWS_AUTH_REGION, region);
++      }
++    }
++
+     // We ought to pass the parent of otelContext here, but we didn't store it, and it shouldn't
+     // make a difference (unless we start supporting the http.resend_count attribute in this
+     // instrumentation, which, logically, we can't on this level of abstraction)
+@@ -342,6 +369,10 @@ public final class TracingExecutionInterceptor implements ExecutionInterceptor {
          }
        }
      }
@@ -3120,11 +3410,50 @@ index 08b000a05c..de0fe82638 100644
  
    // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
    implementation("org.elasticmq:elasticmq-rest-sqs_2.13")
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.groovy b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.groovy
+index 9aaacb3abe..198990a509 100644
+--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.groovy
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientCoreTest.groovy
+@@ -146,6 +146,8 @@ abstract class AbstractAws2ClientCoreTest extends InstrumentationSpecification {
+             "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
+             "$RpcIncubatingAttributes.RPC_SERVICE" "DynamoDb"
+             "$RpcIncubatingAttributes.RPC_METHOD" "CreateTable"
++            "aws.auth.account.access_key" "my-access-key"
++            "aws.auth.region" "ap-northeast-1"
+             "aws.agent" "java-aws-sdk"
+             "$AwsIncubatingAttributes.AWS_REQUEST_ID" "$requestId"
+             "aws.table.name" "sometable"
+@@ -179,6 +181,8 @@ abstract class AbstractAws2ClientCoreTest extends InstrumentationSpecification {
+             "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
+             "$RpcIncubatingAttributes.RPC_SERVICE" "DynamoDb"
+             "$RpcIncubatingAttributes.RPC_METHOD" "Query"
++            "aws.auth.account.access_key" "my-access-key"
++            "aws.auth.region" "ap-northeast-1"
+             "aws.agent" "java-aws-sdk"
+             "$AwsIncubatingAttributes.AWS_REQUEST_ID" "$requestId"
+             "aws.table.name" "sometable"
+@@ -211,6 +215,8 @@ abstract class AbstractAws2ClientCoreTest extends InstrumentationSpecification {
+             "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
+             "$RpcIncubatingAttributes.RPC_SERVICE" "$service"
+             "$RpcIncubatingAttributes.RPC_METHOD" "${operation}"
++            "aws.auth.account.access_key" "my-access-key"
++            "aws.auth.region" "ap-northeast-1"
+             "aws.agent" "java-aws-sdk"
+             "$AwsIncubatingAttributes.AWS_REQUEST_ID" "$requestId"
+             "aws.table.name" "sometable"
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
-index c571c0aa9c..1a4a00d95e 100644
+index c571c0aa9c..6836115c32 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
-@@ -37,10 +37,19 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
+@@ -26,6 +26,7 @@ import software.amazon.awssdk.regions.Region
+ import software.amazon.awssdk.services.ec2.Ec2AsyncClient
+ import software.amazon.awssdk.services.ec2.Ec2Client
+ import software.amazon.awssdk.services.kinesis.KinesisClient
++import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest
+ import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest
+ import software.amazon.awssdk.services.rds.RdsAsyncClient
+ import software.amazon.awssdk.services.rds.RdsClient
+@@ -37,10 +38,19 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
  import software.amazon.awssdk.services.sns.SnsAsyncClient
  import software.amazon.awssdk.services.sns.SnsClient
  import software.amazon.awssdk.services.sns.model.PublishRequest
@@ -3144,7 +3473,16 @@ index c571c0aa9c..1a4a00d95e 100644
  import spock.lang.Unroll
  
  import java.nio.charset.StandardCharsets
-@@ -148,8 +157,32 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -134,6 +144,8 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+             "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
+             "$RpcIncubatingAttributes.RPC_SERVICE" "$service"
+             "$RpcIncubatingAttributes.RPC_METHOD" "${operation}"
++            "aws.auth.account.access_key" "my-access-key"
++            "aws.auth.region" "ap-northeast-1"
+             "aws.agent" "java-aws-sdk"
+             "$AwsIncubatingAttributes.AWS_REQUEST_ID" "$requestId"
+             if (service == "S3") {
+@@ -148,8 +160,32 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
                "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS
              } else if (service == "Kinesis") {
                "aws.stream.name" "somestream"
@@ -3179,7 +3517,7 @@ index c571c0aa9c..1a4a00d95e 100644
              }
            }
          }
-@@ -164,7 +197,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -164,7 +200,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
      "S3"      | "CreateBucket"      | "PUT"  | "UNKNOWN"                              | s3ClientBuilder()       | { c -> c.createBucket(CreateBucketRequest.builder().bucket("somebucket").build()) }              | ""
      "S3"      | "GetObject"         | "GET"  | "UNKNOWN"                              | s3ClientBuilder()       | { c -> c.getObject(GetObjectRequest.builder().bucket("somebucket").key("somekey").build()) }     | ""
      "Kinesis" | "DeleteStream"      | "POST" | "UNKNOWN"                              | KinesisClient.builder() | { c -> c.deleteStream(DeleteStreamRequest.builder().streamName("somestream").build()) }          | ""
@@ -3188,7 +3526,7 @@ index c571c0aa9c..1a4a00d95e 100644
            <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
                <PublishResult>
                    <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>
-@@ -174,15 +207,15 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -174,15 +210,15 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
                </ResponseMetadata>
            </PublishResponse>
        """
@@ -3211,7 +3549,7 @@ index c571c0aa9c..1a4a00d95e 100644
        """
      "Sqs"     | "CreateQueue"       | "POST" | "7a62c49f-347e-4fc4-9331-6e8e7a96aa73" | SqsClient.builder()     | { c -> c.createQueue(CreateQueueRequest.builder().queueName("somequeue").build()) }              | {
        if (!Boolean.getBoolean("testLatestDeps")) {
-@@ -244,170 +277,193 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -244,170 +280,193 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
            <ResponseMetadata><RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId></ResponseMetadata>
          </DeleteOptionGroupResponse>
          """
@@ -3566,6 +3904,83 @@ index c571c0aa9c..1a4a00d95e 100644
    // TODO: Without AOP instrumentation of the HTTP client, we cannot model retries as
    // spans because of https://github.com/aws/aws-sdk-java-v2/issues/1741. We should at least tweak
    // the instrumentation to add Events for retries instead.
+@@ -457,6 +516,8 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+             "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
+             "$RpcIncubatingAttributes.RPC_SERVICE" "S3"
+             "$RpcIncubatingAttributes.RPC_METHOD" "GetObject"
++            "aws.auth.account.access_key" "my-access-key"
++            "aws.auth.region" "ap-northeast-1"
+             "aws.agent" "java-aws-sdk"
+             "aws.bucket.name" "somebucket"
+           }
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientRecordHttpErrorTest.java b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientRecordHttpErrorTest.java
+index 73d2a0ba82..f46361a078 100644
+--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientRecordHttpErrorTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientRecordHttpErrorTest.java
+@@ -172,6 +172,8 @@ public abstract class AbstractAws2ClientRecordHttpErrorTest {
+                       span.hasKind(SpanKind.CLIENT);
+                       span.hasNoParent();
+                       span.hasAttributesSatisfyingExactly(
++                          equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
++                          equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+                           equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                           equalTo(SERVER_PORT, server.httpPort()),
+                           equalTo(HTTP_REQUEST_METHOD, method),
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
+index 902bfdc0d4..4db85ba568 100644
+--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
+@@ -214,6 +214,8 @@ public abstract class AbstractAws2SqsBaseTest {
+             equalTo(RPC_SYSTEM, "aws-api"),
+             equalTo(RPC_SERVICE, "Sqs"),
+             equalTo(RPC_METHOD, "CreateQueue"),
++            equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
++            equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+             equalTo(HTTP_REQUEST_METHOD, "POST"),
+             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+             satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+@@ -232,6 +234,8 @@ public abstract class AbstractAws2SqsBaseTest {
+             equalTo(RPC_SYSTEM, "aws-api"),
+             equalTo(RPC_SERVICE, "Sqs"),
+             equalTo(RPC_METHOD, "ReceiveMessage"),
++            equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
++            equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+             equalTo(HTTP_REQUEST_METHOD, "POST"),
+             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+             satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+@@ -257,6 +261,8 @@ public abstract class AbstractAws2SqsBaseTest {
+             equalTo(RPC_SYSTEM, "aws-api"),
+             equalTo(RPC_SERVICE, "Sqs"),
+             equalTo(RPC_METHOD, rcpMethod),
++            equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
++            equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+             equalTo(HTTP_REQUEST_METHOD, "POST"),
+             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+             satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+index 6fa897d462..f7ac28762c 100644
+--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+@@ -80,6 +80,9 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
+                                   equalTo(RPC_METHOD, "SendMessage"),
+                                   equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                   equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
++                                  equalTo(
++                                      stringKey("aws.auth.account.access_key"), "my-access-key"),
++                                  equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+                                   satisfies(
+                                       URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                   equalTo(SERVER_ADDRESS, "localhost"),
+@@ -133,6 +136,9 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
+                                     equalTo(RPC_METHOD, "ReceiveMessage"),
+                                     equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                     equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
++                                    equalTo(
++                                        stringKey("aws.auth.account.access_key"), "my-access-key"),
++                                    equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+                                     satisfies(
+                                         URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                                     equalTo(SERVER_ADDRESS, "localhost"),
 diff --git a/version.gradle.kts b/version.gradle.kts
 index a1cae43b4b..c1520e9947 100644
 --- a/version.gradle.kts

--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -2270,6 +2270,174 @@ index 3f272ba477..bea20f3d86 100644
 +        response, client, "SNS", "Publish", "POST", additionalAttributes);
    }
  }
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
+index c0b4b13a17..4cfaf469d9 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
+@@ -116,7 +116,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                 equalTo(SERVER_ADDRESS, "localhost"),
+                                 equalTo(SERVER_PORT, sqsPort),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x"))),
+             trace ->
+                 trace.hasSpansSatisfyingExactly(
+                     span ->
+@@ -146,7 +147,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(MESSAGING_OPERATION, "publish"),
+                                 satisfies(
+                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                     span ->
+                         span.hasName("testSdkSqs process")
+                             .hasKind(SpanKind.CONSUMER)
+@@ -174,7 +176,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(MESSAGING_OPERATION, "process"),
+                                 satisfies(
+                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                     span ->
+                         span.hasName("process child")
+                             .hasParent(trace.getSpan(1))
+@@ -222,7 +225,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                 equalTo(SERVER_ADDRESS, "localhost"),
+                                 equalTo(SERVER_PORT, sqsPort),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x"))),
+             trace ->
+                 trace.hasSpansSatisfyingExactly(
+                     span ->
+@@ -252,7 +256,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(MESSAGING_OPERATION, "publish"),
+                                 satisfies(
+                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                     span ->
+                         span.hasName("testSdkSqs process")
+                             .hasKind(SpanKind.CONSUMER)
+@@ -280,7 +285,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(MESSAGING_OPERATION, "process"),
+                                 satisfies(
+                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                     span ->
+                         span.hasName("process child")
+                             .hasParent(trace.getSpan(1))
+@@ -311,7 +317,8 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
+                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                 equalTo(SERVER_ADDRESS, "localhost"),
+                                 equalTo(SERVER_PORT, sqsPort),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))));
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x"))));
+   }
+ 
+   @Test
+diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+index f1bfa126ca..dfb5b96550 100644
+--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+@@ -150,7 +150,8 @@ public abstract class AbstractSqsTracingTest {
+                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                 equalTo(SERVER_ADDRESS, "localhost"),
+                                 equalTo(SERVER_PORT, sqsPort),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x"))),
+             trace ->
+                 trace.hasSpansSatisfyingExactly(
+                     span -> {
+@@ -179,7 +180,8 @@ public abstract class AbstractSqsTracingTest {
+                                   equalTo(MESSAGING_OPERATION, "publish"),
+                                   satisfies(
+                                       MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1")));
++                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                  equalTo(stringKey("aws.auth.account.access_key"), "x")));
+ 
+                       if (testCaptureHeaders) {
+                         attributes.add(
+@@ -220,7 +222,8 @@ public abstract class AbstractSqsTracingTest {
+                                   equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                   equalTo(MESSAGING_OPERATION, "receive"),
+                                   equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
+-                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1")));
++                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                  equalTo(stringKey("aws.auth.account.access_key"), "x")));
+ 
+                       if (testCaptureHeaders) {
+                         attributes.add(
+@@ -260,7 +263,8 @@ public abstract class AbstractSqsTracingTest {
+                                   equalTo(MESSAGING_OPERATION, "process"),
+                                   satisfies(
+                                       MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1")));
++                                  equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                  equalTo(stringKey("aws.auth.account.access_key"), "x")));
+ 
+                       if (testCaptureHeaders) {
+                         attributes.add(
+@@ -320,7 +324,8 @@ public abstract class AbstractSqsTracingTest {
+                                 equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                 equalTo(SERVER_ADDRESS, "localhost"),
+                                 equalTo(SERVER_PORT, sqsPort),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x"))),
+             trace ->
+                 trace.hasSpansSatisfyingExactly(
+                     span ->
+@@ -350,7 +355,8 @@ public abstract class AbstractSqsTracingTest {
+                                 equalTo(MESSAGING_OPERATION, "publish"),
+                                 satisfies(
+                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+-                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))),
++                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                equalTo(stringKey("aws.auth.account.access_key"), "x"))),
+             trace -> {
+               AtomicReference<SpanData> receiveSpan = new AtomicReference<>();
+               AtomicReference<SpanData> processSpan = new AtomicReference<>();
+@@ -385,7 +391,8 @@ public abstract class AbstractSqsTracingTest {
+                                       equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                       equalTo(SERVER_ADDRESS, "localhost"),
+                                       equalTo(SERVER_PORT, sqsPort),
+-                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                      equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                           span ->
+                               span.hasName("testSdkSqs receive")
+                                   .hasKind(SpanKind.CONSUMER)
+@@ -419,7 +426,8 @@ public abstract class AbstractSqsTracingTest {
+                                           MessagingIncubatingAttributes
+                                               .MESSAGING_BATCH_MESSAGE_COUNT,
+                                           1),
+-                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                      equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                           span ->
+                               span.hasName("testSdkSqs process")
+                                   .hasKind(SpanKind.CONSUMER)
+@@ -452,7 +460,8 @@ public abstract class AbstractSqsTracingTest {
+                                       satisfies(
+                                           MESSAGING_MESSAGE_ID,
+                                           val -> val.isInstanceOf(String.class)),
+-                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1")),
++                                      equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
++                                      equalTo(stringKey("aws.auth.account.access_key"), "x")),
+                           span ->
+                               span.hasName("process child")
+                                   .hasParent(processSpan.get())
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractStepFunctionsClientTest.java b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractStepFunctionsClientTest.java
 new file mode 100644
 index 0000000000..fc58ec3c9b
@@ -3919,7 +4087,7 @@ index 73d2a0ba82..f46361a078 100644
                            equalTo(SERVER_PORT, server.httpPort()),
                            equalTo(HTTP_REQUEST_METHOD, method),
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
-index 902bfdc0d4..4db85ba568 100644
+index 902bfdc0d4..756968776e 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsBaseTest.java
 @@ -214,6 +214,8 @@ public abstract class AbstractAws2SqsBaseTest {
@@ -3931,16 +4099,7 @@ index 902bfdc0d4..4db85ba568 100644
              equalTo(HTTP_REQUEST_METHOD, "POST"),
              equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
              satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
-@@ -232,6 +234,8 @@ public abstract class AbstractAws2SqsBaseTest {
-             equalTo(RPC_SYSTEM, "aws-api"),
-             equalTo(RPC_SERVICE, "Sqs"),
-             equalTo(RPC_METHOD, "ReceiveMessage"),
-+            equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
-+            equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
-             equalTo(HTTP_REQUEST_METHOD, "POST"),
-             equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-             satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
-@@ -257,6 +261,8 @@ public abstract class AbstractAws2SqsBaseTest {
+@@ -257,6 +259,8 @@ public abstract class AbstractAws2SqsBaseTest {
              equalTo(RPC_SYSTEM, "aws-api"),
              equalTo(RPC_SERVICE, "Sqs"),
              equalTo(RPC_METHOD, rcpMethod),
@@ -3949,6 +4108,19 @@ index 902bfdc0d4..4db85ba568 100644
              equalTo(HTTP_REQUEST_METHOD, "POST"),
              equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
              satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.java b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.java
+index 4d0a9be89c..382c035bf5 100644
+--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.java
++++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.java
+@@ -84,6 +84,8 @@ public abstract class AbstractAws2SqsSuppressReceiveSpansTest extends AbstractAw
+                               equalTo(RPC_METHOD, "ReceiveMessage"),
+                               equalTo(HTTP_REQUEST_METHOD, "POST"),
+                               equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
++                              equalTo(stringKey("aws.auth.account.access_key"), "my-access-key"),
++                              equalTo(stringKey("aws.auth.region"), "ap-northeast-1"),
+                               satisfies(URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
+                               equalTo(SERVER_ADDRESS, "localhost"),
+                               equalTo(SERVER_PORT, sqsPort))));
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
 index 6fa897d462..f7ac28762c 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -3973,6 +4145,20 @@ index 6fa897d462..f7ac28762c 100644
                                      satisfies(
                                          URL_FULL, v -> v.startsWith("http://localhost:" + sqsPort)),
                                      equalTo(SERVER_ADDRESS, "localhost"),
+diff --git a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+index 8731717005..0d59b40f5e 100644
+--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
++++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+@@ -94,7 +94,8 @@ class AwsSpanAssertions {
+             equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+             equalTo(RPC_SYSTEM, "aws-api"),
+             satisfies(RPC_METHOD, stringAssert -> stringAssert.isEqualTo(rpcMethod)),
+-            equalTo(RPC_SERVICE, "AmazonSQS")));
++            equalTo(RPC_SERVICE, "AmazonSQS"),
++            equalTo(stringKey("aws.auth.account.access_key"), "x")));
+ 
+     if (spanName.endsWith("receive")
+         || spanName.endsWith("process")
 diff --git a/version.gradle.kts b/version.gradle.kts
 index a1cae43b4b..c1520e9947 100644
 --- a/version.gradle.kts

--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -3442,18 +3442,10 @@ index 9aaacb3abe..198990a509 100644
              "$AwsIncubatingAttributes.AWS_REQUEST_ID" "$requestId"
              "aws.table.name" "sometable"
 diff --git a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
-index c571c0aa9c..6836115c32 100644
+index c571c0aa9c..a6fbdab597 100644
 --- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
 +++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
-@@ -26,6 +26,7 @@ import software.amazon.awssdk.regions.Region
- import software.amazon.awssdk.services.ec2.Ec2AsyncClient
- import software.amazon.awssdk.services.ec2.Ec2Client
- import software.amazon.awssdk.services.kinesis.KinesisClient
-+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest
- import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest
- import software.amazon.awssdk.services.rds.RdsAsyncClient
- import software.amazon.awssdk.services.rds.RdsClient
-@@ -37,10 +38,19 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
+@@ -37,10 +37,19 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
  import software.amazon.awssdk.services.sns.SnsAsyncClient
  import software.amazon.awssdk.services.sns.SnsClient
  import software.amazon.awssdk.services.sns.model.PublishRequest
@@ -3473,7 +3465,7 @@ index c571c0aa9c..6836115c32 100644
  import spock.lang.Unroll
  
  import java.nio.charset.StandardCharsets
-@@ -134,6 +144,8 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -134,6 +143,8 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
              "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
              "$RpcIncubatingAttributes.RPC_SERVICE" "$service"
              "$RpcIncubatingAttributes.RPC_METHOD" "${operation}"
@@ -3482,7 +3474,7 @@ index c571c0aa9c..6836115c32 100644
              "aws.agent" "java-aws-sdk"
              "$AwsIncubatingAttributes.AWS_REQUEST_ID" "$requestId"
              if (service == "S3") {
-@@ -148,8 +160,32 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -148,8 +159,32 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
                "$MessagingIncubatingAttributes.MESSAGING_SYSTEM" MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS
              } else if (service == "Kinesis") {
                "aws.stream.name" "somestream"
@@ -3517,7 +3509,7 @@ index c571c0aa9c..6836115c32 100644
              }
            }
          }
-@@ -164,7 +200,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -164,7 +199,7 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
      "S3"      | "CreateBucket"      | "PUT"  | "UNKNOWN"                              | s3ClientBuilder()       | { c -> c.createBucket(CreateBucketRequest.builder().bucket("somebucket").build()) }              | ""
      "S3"      | "GetObject"         | "GET"  | "UNKNOWN"                              | s3ClientBuilder()       | { c -> c.getObject(GetObjectRequest.builder().bucket("somebucket").key("somekey").build()) }     | ""
      "Kinesis" | "DeleteStream"      | "POST" | "UNKNOWN"                              | KinesisClient.builder() | { c -> c.deleteStream(DeleteStreamRequest.builder().streamName("somestream").build()) }          | ""
@@ -3526,7 +3518,7 @@ index c571c0aa9c..6836115c32 100644
            <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
                <PublishResult>
                    <MessageId>567910cd-659e-55d4-8ccb-5aaf14679dc0</MessageId>
-@@ -174,15 +210,15 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -174,15 +209,15 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
                </ResponseMetadata>
            </PublishResponse>
        """
@@ -3549,7 +3541,7 @@ index c571c0aa9c..6836115c32 100644
        """
      "Sqs"     | "CreateQueue"       | "POST" | "7a62c49f-347e-4fc4-9331-6e8e7a96aa73" | SqsClient.builder()     | { c -> c.createQueue(CreateQueueRequest.builder().queueName("somequeue").build()) }              | {
        if (!Boolean.getBoolean("testLatestDeps")) {
-@@ -244,170 +280,193 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -244,170 +279,193 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
            <ResponseMetadata><RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId></ResponseMetadata>
          </DeleteOptionGroupResponse>
          """
@@ -3904,7 +3896,7 @@ index c571c0aa9c..6836115c32 100644
    // TODO: Without AOP instrumentation of the HTTP client, we cannot model retries as
    // spans because of https://github.com/aws/aws-sdk-java-v2/issues/1741. We should at least tweak
    // the instrumentation to add Events for retries instead.
-@@ -457,6 +516,8 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
+@@ -457,6 +515,8 @@ abstract class AbstractAws2ClientTest extends AbstractAws2ClientCoreTest {
              "$RpcIncubatingAttributes.RPC_SYSTEM" "aws-api"
              "$RpcIncubatingAttributes.RPC_SERVICE" "S3"
              "$RpcIncubatingAttributes.RPC_METHOD" "GetObject"

--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -403,10 +403,10 @@ index 096c7826a1..27613c04f2 100644
    private AwsExperimentalAttributes() {}
  }
 diff --git a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
-index 541e67d23b..d0e0ac71fa 100644
+index 541e67d23b..5a321f9cb1 100644
 --- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
 +++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkExperimentalAttributesExtractor.java
-@@ -6,25 +6,54 @@
+@@ -6,25 +6,56 @@
  package io.opentelemetry.instrumentation.awssdk.v1_11;
  
  import static io.opentelemetry.instrumentation.awssdk.v1_11.AwsExperimentalAttributes.AWS_AGENT;
@@ -458,10 +458,12 @@ index 541e67d23b..d0e0ac71fa 100644
 +  private static final String BEDROCK_AGENT_SERVICE = "AWSBedrockAgent";
 +  private static final String BEDROCK_AGENT_RUNTIME_SERVICE = "AWSBedrockAgentRuntime";
 +  private static final String BEDROCK_RUNTIME_SERVICE = "AmazonBedrockRuntime";
++  private static final HandlerContextKey<AWSCredentials> AWS_CREDENTIALS =
++      new HandlerContextKey<AWSCredentials>("AWSCredentials");
  
    @Override
    public void onStart(AttributesBuilder attributes, Context parentContext, Request<?> request) {
-@@ -32,14 +61,166 @@ class AwsSdkExperimentalAttributesExtractor
+@@ -32,14 +63,165 @@ class AwsSdkExperimentalAttributesExtractor
      attributes.put(AWS_ENDPOINT, request.getEndpoint().toString());
  
      Object originalRequest = request.getOriginalRequest();
@@ -471,8 +473,7 @@ index 541e67d23b..d0e0ac71fa 100644
 -    setRequestAttribute(attributes, AWS_STREAM_NAME, originalRequest, RequestAccess::getStreamName);
 -    setRequestAttribute(attributes, AWS_TABLE_NAME, originalRequest, RequestAccess::getTableName);
 +    String requestClassName = originalRequest.getClass().getSimpleName();
-+
-+    AWSCredentials credentials = request.getHandlerContext(HandlerContextKey.AWS_CREDENTIALS);
++    AWSCredentials credentials = request.getHandlerContext(AWS_CREDENTIALS);
 +    if (credentials != null) {
 +      String accessKeyId = credentials.getAWSAccessKeyId();
 +      if (accessKeyId != null) {
@@ -503,8 +504,9 @@ index 541e67d23b..d0e0ac71fa 100644
 +    if (isBedrockService(serviceName)) {
 +      bedrockOnStart(attributes, originalRequest, requestClassName, serviceName);
 +    }
-+  }
-+
+   }
+ 
+-  private static void setRequestAttribute(
 +  @Override
 +  public void onEnd(
 +      AttributesBuilder attributes,
@@ -627,14 +629,13 @@ index 541e67d23b..d0e0ac71fa 100644
 +        || serviceName.equals(BEDROCK_AGENT_SERVICE)
 +        || serviceName.equals(BEDROCK_AGENT_RUNTIME_SERVICE)
 +        || serviceName.equals(BEDROCK_RUNTIME_SERVICE);
-   }
- 
--  private static void setRequestAttribute(
++  }
++
 +  private static void setAttribute(
        AttributesBuilder attributes,
        AttributeKey<String> key,
        Object request,
-@@ -49,12 +230,4 @@ class AwsSdkExperimentalAttributesExtractor
+@@ -49,12 +231,4 @@ class AwsSdkExperimentalAttributesExtractor
        attributes.put(key, value);
      }
    }

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/base/AwsSdkBaseTest.java
@@ -54,6 +54,7 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
               "localstack",
               "s3.localstack",
               "create-bucket.s3.localstack",
+              "cross-account-bucket.s3.localstack",
               "put-object.s3.localstack",
               "get-object.s3.localstack");
 
@@ -258,6 +259,12 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
     };
   }
 
+  private ThrowingConsumer<KeyValue> assertKeyIsNotPresent(String key) {
+    return (attribute) -> {
+      assertThat(attribute.getKey()).isNotEqualTo(key);
+    };
+  }
+
   /** All the spans of the AWS SDK Should have a RPC properties. */
   private void assertSemanticConventionsAttributes(
       List<KeyValue> attributesList,
@@ -308,6 +315,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       String address,
       int port,
       String url,
@@ -327,6 +337,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        remoteAccountId,
+        remoteAccessKey,
+        remoteRegion,
         address,
         port,
         url,
@@ -345,6 +358,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       String address,
       int port,
       String url,
@@ -363,6 +379,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        remoteAccountId,
+        remoteAccessKey,
+        remoteRegion,
         address,
         port,
         url,
@@ -412,6 +431,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       String address,
       int port,
       String url,
@@ -436,6 +458,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
                   type,
                   identifier,
                   cloudformationIdentifier,
+                  remoteAccountId,
+                  remoteAccessKey,
+                  remoteRegion,
                   awsSpanKind);
               for (var assertion : extraAssertions) {
                 assertThat(spanAttributes).satisfiesOnlyOnce(assertion);
@@ -452,6 +477,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String clouformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       String spanKind) {
 
     var assertions =
@@ -470,6 +498,27 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       assertions.satisfiesOnlyOnce(
           assertAttribute(
               AppSignalsConstants.AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER, clouformationIdentifier));
+    }
+
+    if (remoteAccountId != null) {
+      assertions.satisfiesOnlyOnce(
+          assertKeyIsPresent(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER));
+      assertions.satisfiesOnlyOnce(
+          assertAttribute(AppSignalsConstants.AWS_REMOTE_RESOURCE_ACCOUNT_ID, remoteAccountId));
+      assertKeyIsNotPresent(AppSignalsConstants.AWS_REMOTE_RESOURCE_ACCESS_KEY);
+    }
+
+    if (remoteAccessKey != null) {
+      assertions.satisfiesOnlyOnce(
+          assertKeyIsPresent(AppSignalsConstants.AWS_REMOTE_RESOURCE_IDENTIFIER));
+      assertions.satisfiesOnlyOnce(
+          assertAttribute(AppSignalsConstants.AWS_REMOTE_RESOURCE_ACCESS_KEY, remoteAccessKey));
+      assertKeyIsNotPresent(AppSignalsConstants.AWS_REMOTE_RESOURCE_ACCOUNT_ID);
+    }
+
+    if (remoteRegion != null) {
+      assertions.satisfiesOnlyOnce(
+          assertAttribute(AppSignalsConstants.AWS_REMOTE_RESOURCE_REGION, remoteRegion));
     }
   }
 
@@ -495,6 +544,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       Double expectedSum) {
     assertMetricAttributes(
         resourceScopeMetrics,
@@ -507,6 +559,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        remoteAccountId,
+        remoteAccessKey,
+        remoteRegion,
         expectedSum);
   }
 
@@ -520,6 +575,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       Double expectedSum) {
     assertMetricAttributes(
         resourceScopeMetrics,
@@ -532,6 +590,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        remoteAccountId,
+        remoteAccessKey,
+        remoteRegion,
         expectedSum);
   }
 
@@ -545,6 +606,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       Double expectedSum) {
     assertMetricAttributes(
         resourceScopeMetrics,
@@ -557,6 +621,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        remoteAccountId,
+        remoteAccessKey,
+        remoteRegion,
         expectedSum);
   }
 
@@ -571,6 +638,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
       String type,
       String identifier,
       String cloudformationIdentifier,
+      String remoteAccountId,
+      String remoteAccessKey,
+      String remoteRegion,
       Double expectedSum) {
     assertThat(resourceScopeMetrics)
         .anySatisfy(
@@ -591,6 +661,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
                             type,
                             identifier,
                             cloudformationIdentifier,
+                            remoteAccountId,
+                            remoteAccessKey,
+                            remoteRegion,
                             spanKind);
                         if (expectedSum != null) {
                           double actualSum = dataPoint.getSum();
@@ -634,6 +707,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "create-bucket.s3.localstack",
         4566,
         "http://create-bucket.s3.localstack:4566",
@@ -649,6 +725,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -660,6 +739,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -671,6 +753,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -702,6 +787,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "put-object.s3.localstack",
         4566,
         "http://put-object.s3.localstack:4566",
@@ -717,6 +805,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -728,6 +819,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -739,6 +833,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -769,6 +866,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "get-object.s3.localstack",
         4566,
         "http://get-object.s3.localstack:4566",
@@ -784,6 +884,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -795,6 +898,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -806,6 +912,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -836,6 +945,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "error-bucket.s3.test",
         8080,
         "http://error-bucket.s3.test:8080",
@@ -851,6 +963,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -862,6 +977,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -873,6 +991,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
   }
 
@@ -903,6 +1024,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "fault-bucket.s3.test",
         8080,
         "http://fault-bucket.s3.test:8080",
@@ -918,6 +1042,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -929,6 +1056,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
     assertMetricClientAttributes(
         metrics,
@@ -940,6 +1070,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -978,6 +1111,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -993,6 +1129,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         20000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1004,6 +1143,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1015,6 +1157,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1045,6 +1190,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -1060,6 +1208,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1071,6 +1222,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1082,6 +1236,91 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
+        0.0);
+  }
+
+  protected void doTestDynamoDbDescribeTable() {
+    appClient.get("/ddb/describetable/test-table").aggregate().join();
+    var traces = mockCollectorClient.getTraces();
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC,
+                AppSignalsConstants.LATENCY_METRIC));
+
+    var localService = getApplicationOtelServiceName();
+    var localOperation = "GET /ddb/describetable/:tablename";
+    var type = "AWS::DynamoDB::Table";
+    var identifier = "test-table";
+    var cloudformationIdentifier = "test-table";
+    var remoteAccountId = "000000000000";
+    var remoteRegion = "us-west-2";
+
+    assertSpanClientAttributes(
+        traces,
+        dynamoDbSpanName("DescribeTable"),
+        getDynamoDbRpcServiceName(),
+        localService,
+        localOperation,
+        getDynamoDbServiceName(),
+        "DescribeTable",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
+        "localstack",
+        4566,
+        "http://localstack:4566",
+        200,
+        dynamoDbAttributes("DescribeTable", "test-table"));
+
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.LATENCY_METRIC,
+        localService,
+        localOperation,
+        getDynamoDbServiceName(),
+        "DescribeTable",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
+        5000.0);
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.FAULT_METRIC,
+        localService,
+        localOperation,
+        getDynamoDbServiceName(),
+        "DescribeTable",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
+        0.0);
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.ERROR_METRIC,
+        localService,
+        localOperation,
+        getDynamoDbServiceName(),
+        "DescribeTable",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
         0.0);
   }
 
@@ -1112,6 +1351,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "error.test",
         8080,
         "http://error.test:8080",
@@ -1127,6 +1369,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1138,6 +1383,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1149,6 +1397,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
   }
 
@@ -1185,6 +1436,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "fault.test",
         8080,
         "http://fault.test:8080",
@@ -1200,6 +1454,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         20000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1211,6 +1468,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
     assertMetricClientAttributes(
         metrics,
@@ -1222,6 +1482,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1252,6 +1515,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -1267,6 +1533,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1278,6 +1547,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1289,6 +1561,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1320,6 +1595,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -1336,6 +1614,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricProducerAttributes(
         metrics,
@@ -1347,6 +1628,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricProducerAttributes(
         metrics,
@@ -1358,6 +1642,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1406,6 +1693,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricConsumerAttributes(
         metrics,
@@ -1417,6 +1707,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1448,6 +1741,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "error.test",
         8080,
         "http://error.test:8080",
@@ -1464,6 +1760,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricProducerAttributes(
         metrics,
@@ -1475,6 +1774,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricProducerAttributes(
         metrics,
@@ -1486,6 +1788,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
   }
 
@@ -1517,6 +1822,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "fault.test",
         8080,
         "http://fault.test:8080",
@@ -1533,6 +1841,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricProducerAttributes(
         metrics,
@@ -1544,6 +1855,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
     assertMetricProducerAttributes(
         metrics,
@@ -1555,6 +1869,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1585,6 +1902,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -1600,6 +1920,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1611,6 +1934,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1622,6 +1948,93 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
+        0.0);
+  }
+
+  protected void doTestKinesisDescribeStream() {
+    appClient.get("/kinesis/describestream/test-stream").aggregate().join();
+    var traces = mockCollectorClient.getTraces();
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC,
+                AppSignalsConstants.LATENCY_METRIC));
+
+    var localService = getApplicationOtelServiceName();
+    var localOperation = "GET /kinesis/describestream/:streamname";
+    var type = "AWS::Kinesis::Stream";
+    var identifier = "test-stream";
+    var cloudformationIdentifier = "test-stream";
+    var remoteAccountId = "000000000000";
+    var remoteRegion = "us-west-2";
+
+    assertSpanClientAttributes(
+        traces,
+        kinesisSpanName("DescribeStream"),
+        getKinesisRpcServiceName(),
+        localService,
+        localOperation,
+        getKinesisServiceName(),
+        "DescribeStream",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
+        "localstack",
+        4566,
+        "http://localstack:4566",
+        200,
+        List.of(
+            assertAttribute(
+                SemanticConventionsConstants.AWS_STREAM_ARN,
+                "arn:aws:kinesis:us-west-2:000000000000:stream/test-stream")));
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.LATENCY_METRIC,
+        localService,
+        localOperation,
+        getKinesisServiceName(),
+        "DescribeStream",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
+        5000.0);
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.FAULT_METRIC,
+        localService,
+        localOperation,
+        getKinesisServiceName(),
+        "DescribeStream",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
+        0.0);
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.ERROR_METRIC,
+        localService,
+        localOperation,
+        getKinesisServiceName(),
+        "DescribeStream",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        remoteAccountId,
+        null,
+        remoteRegion,
         0.0);
   }
 
@@ -1652,6 +2065,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "error.test",
         8080,
         "http://error.test:8080",
@@ -1668,6 +2084,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1679,6 +2098,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1690,6 +2112,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
   }
 
@@ -1720,6 +2145,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "fault.test",
         8080,
         "http://fault.test:8080",
@@ -1735,6 +2163,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1746,6 +2177,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
     assertMetricClientAttributes(
         metrics,
@@ -1757,6 +2191,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1787,6 +2224,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -1804,6 +2244,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1815,6 +2258,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1826,6 +2272,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1855,6 +2304,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -1870,6 +2322,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1881,6 +2336,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1892,6 +2350,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1921,6 +2382,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -1938,6 +2402,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -1949,6 +2416,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -1960,6 +2430,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -1989,6 +2462,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2012,6 +2488,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2023,6 +2502,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2034,6 +2516,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2063,6 +2548,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2089,6 +2577,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2100,6 +2591,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2111,6 +2605,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2142,6 +2639,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2168,6 +2668,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2179,6 +2682,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2190,6 +2696,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2221,6 +2730,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2246,6 +2758,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2257,6 +2772,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2268,6 +2786,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2299,6 +2820,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2323,6 +2847,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2334,6 +2861,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2345,6 +2875,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2376,6 +2909,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2401,6 +2937,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2412,6 +2951,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2423,6 +2965,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2453,6 +2998,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2473,6 +3021,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2484,6 +3035,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2495,6 +3049,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2524,6 +3081,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2539,6 +3099,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2550,6 +3113,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2561,6 +3127,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2591,6 +3160,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "bedrock.test",
         8080,
         "http://bedrock.test:8080",
@@ -2608,6 +3180,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2619,6 +3194,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2630,6 +3208,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2659,6 +3240,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -2677,6 +3261,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2688,6 +3275,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2699,6 +3289,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2724,6 +3317,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         "error.test",
         8080,
         "http://error.test:8080",
@@ -2739,6 +3335,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2750,6 +3349,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2758,6 +3360,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         localOperation,
         getSecretsManagerServiceName(),
         "DescribeSecret",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -2787,6 +3392,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         "fault.test",
         8080,
         "http://fault.test:8080",
@@ -2802,6 +3410,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2813,6 +3424,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         1.0);
     assertMetricClientAttributes(
         metrics,
@@ -2821,6 +3435,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         localOperation,
         getSecretsManagerServiceName(),
         "DescribeSecret",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -2854,6 +3471,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -2872,6 +3492,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2883,6 +3506,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2894,6 +3520,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2923,6 +3552,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -2941,6 +3573,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -2952,6 +3587,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -2963,6 +3601,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -2994,6 +3635,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "error.test",
         8080,
         "http://error.test:8080",
@@ -3012,6 +3656,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -3023,6 +3670,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
     assertMetricClientAttributes(
         metrics,
@@ -3034,6 +3684,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
   }
 
@@ -3064,6 +3717,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "fault.test",
         8080,
         "http://fault.test:8080",
@@ -3082,6 +3738,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         5000.0);
     assertMetricClientAttributes(
         metrics,
@@ -3093,6 +3752,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         1.0);
     assertMetricClientAttributes(
         metrics,
@@ -3104,6 +3766,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         0.0);
   }
 
@@ -3134,6 +3799,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         type,
         identifier,
         cloudformationIdentifier,
+        null,
+        null,
+        null,
         "localstack",
         4566,
         "http://localstack:4566",
@@ -3167,6 +3835,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         "error.test",
         8080,
         "http://error.test:8080",
@@ -3183,6 +3854,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         5000.0);
 
     assertMetricClientAttributes(
@@ -3195,6 +3869,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         0.0);
 
     assertMetricClientAttributes(
@@ -3204,6 +3881,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         localOperation,
         getSnsServiceName(),
         "GetTopicAttributes",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -3233,6 +3913,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         "fault.test",
         8080,
         "http://fault.test:8080",
@@ -3249,6 +3932,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
         5000.0);
 
     assertMetricClientAttributes(
@@ -3258,6 +3944,9 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         localOperation,
         getSnsServiceName(),
         "GetTopicAttributes",
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -3273,6 +3962,91 @@ public abstract class AwsSdkBaseTest extends ContractTestBase {
         null,
         null,
         null,
+        null,
+        null,
+        null,
+        0.0);
+  }
+
+  protected void doTestCrossAccount(String remoteRegion) throws Exception {
+    appClient.get("/crossaccount/createbucket/accountb").aggregate().join();
+
+    var traces = mockCollectorClient.getTraces();
+    var metrics =
+        mockCollectorClient.getMetrics(
+            Set.of(
+                AppSignalsConstants.ERROR_METRIC,
+                AppSignalsConstants.FAULT_METRIC,
+                AppSignalsConstants.LATENCY_METRIC));
+
+    var localService = getApplicationOtelServiceName();
+    var localOperation = "GET /crossaccount/createbucket/accountb";
+    var type = "AWS::S3::Bucket";
+    var identifier = "cross-account-bucket";
+    var cloudformationIdentifier = "cross-account-bucket";
+    var remoteAccessKey = "account_b_access_key_id";
+
+    assertSpanClientAttributes(
+        traces,
+        s3SpanName("CreateBucket"),
+        getS3RpcServiceName(),
+        localService,
+        localOperation,
+        getS3ServiceName(),
+        "CreateBucket",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        null,
+        remoteAccessKey,
+        remoteRegion,
+        "cross-account-bucket.s3.localstack",
+        4566,
+        "http://cross-account-bucket.s3.localstack:4566",
+        200,
+        List.of(
+            assertAttribute(SemanticConventionsConstants.AWS_BUCKET_NAME, "cross-account-bucket")));
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.LATENCY_METRIC,
+        localService,
+        localOperation,
+        getS3ServiceName(),
+        "CreateBucket",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        null,
+        remoteAccessKey,
+        remoteRegion,
+        5000.0);
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.FAULT_METRIC,
+        localService,
+        localOperation,
+        getS3ServiceName(),
+        "CreateBucket",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        null,
+        remoteAccessKey,
+        remoteRegion,
+        0.0);
+    assertMetricClientAttributes(
+        metrics,
+        AppSignalsConstants.ERROR_METRIC,
+        localService,
+        localOperation,
+        getS3ServiceName(),
+        "CreateBucket",
+        type,
+        identifier,
+        cloudformationIdentifier,
+        null,
+        remoteAccessKey,
+        remoteRegion,
         0.0);
   }
 }

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/v1/AwsSdkV1Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/v1/AwsSdkV1Test.java
@@ -182,6 +182,11 @@ public class AwsSdkV1Test extends AwsSdkBaseTest {
   }
 
   @Test
+  void testDynamoDbDescribeTable() {
+    doTestDynamoDbDescribeTable();
+  }
+
+  @Test
   void testDynamoDbError() throws Exception {
     doTestDynamoDbError();
   }
@@ -219,6 +224,11 @@ public class AwsSdkV1Test extends AwsSdkBaseTest {
   @Test
   void testKinesisPutRecord() throws Exception {
     doTestKinesisPutRecord();
+  }
+
+  @Test
+  void testKinesisDescribeStream() {
+    doTestKinesisDescribeStream();
   }
 
   @Test
@@ -339,5 +349,10 @@ public class AwsSdkV1Test extends AwsSdkBaseTest {
   @Test
   void testSnsFault() throws Exception {
     doTestStepFunctionsFault();
+  }
+
+  @Test
+  void testCrossAccount() throws Exception {
+    doTestCrossAccount(null);
   }
 }

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/v2/AwsSdkV2Test.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk/v2/AwsSdkV2Test.java
@@ -180,6 +180,11 @@ public class AwsSdkV2Test extends AwsSdkBaseTest {
   }
 
   @Test
+  void testDynamoDbDescribeTable() {
+    doTestDynamoDbDescribeTable();
+  }
+
+  @Test
   void testDynamoDbError() throws Exception {
     doTestDynamoDbError();
   }
@@ -222,6 +227,11 @@ public class AwsSdkV2Test extends AwsSdkBaseTest {
   @Test
   void testKinesisPutRecord() throws Exception {
     doTestKinesisPutRecord();
+  }
+
+  @Test
+  void testKinesisDescribeStream() {
+    doTestKinesisDescribeStream();
   }
 
   @Test
@@ -342,5 +352,10 @@ public class AwsSdkV2Test extends AwsSdkBaseTest {
   @Test
   void testSnsFault() throws Exception {
     doTestStepFunctionsFault();
+  }
+
+  @Test
+  void testCrossAccount() throws Exception {
+    doTestCrossAccount("eu-central-1");
   }
 }

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/utils/AppSignalsConstants.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/utils/AppSignalsConstants.java
@@ -35,7 +35,10 @@ public class AppSignalsConstants {
       "aws.remote.resource.cfn.primary.identifier";
   public static final String AWS_SPAN_KIND = "aws.span.kind";
   public static final String AWS_REMOTE_DB_USER = "aws.remote.db.user";
-
+  public static final String AWS_REMOTE_RESOURCE_ACCESS_KEY =
+      "aws.remote.resource.account.access_key";
+  public static final String AWS_REMOTE_RESOURCE_ACCOUNT_ID = "aws.remote.resource.account.id";
+  public static final String AWS_REMOTE_RESOURCE_REGION = "aws.remote.resource.region";
   // JVM Metrics
   public static final String JVM_GC_DURATION = "jvm.gc.collections.elapsed";
   public static final String JVM_GC_COUNT = "jvm.gc.collections.count";

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/utils/SemanticConventionsConstants.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/utils/SemanticConventionsConstants.java
@@ -56,6 +56,7 @@ public class SemanticConventionsConstants {
   public static final String AWS_TABLE_NAME = "aws.table.name";
   public static final String AWS_QUEUE_URL = "aws.queue.url";
   public static final String AWS_QUEUE_NAME = "aws.queue.name";
+  public static final String AWS_STREAM_ARN = "aws.stream.arn";
   public static final String AWS_STREAM_NAME = "aws.stream.name";
   public static final String AWS_KNOWLEDGE_BASE_ID = "aws.bedrock.knowledge_base.id";
   public static final String AWS_DATA_SOURCE_ID = "aws.bedrock.data_source.id";

--- a/appsignals-tests/images/aws-sdk/aws-sdk-v1/src/main/java/com/amazon/sampleapp/App.java
+++ b/appsignals-tests/images/aws-sdk/aws-sdk-v1/src/main/java/com/amazon/sampleapp/App.java
@@ -21,8 +21,11 @@ import static spark.Spark.ipAddress;
 import static spark.Spark.port;
 import static spark.Spark.post;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.bedrock.AmazonBedrockClient;
@@ -49,6 +52,7 @@ import com.amazonaws.services.identitymanagement.model.CreateRoleRequest;
 import com.amazonaws.services.identitymanagement.model.PutRolePolicyRequest;
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.kinesis.model.CreateStreamRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
 import com.amazonaws.services.kinesis.model.PutRecordRequest;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
@@ -152,6 +156,7 @@ public class App {
     setupStepFunctions();
     setupSns();
     setupBedrock();
+    setupCrossAccount();
 
     // Add this log line so that we only start testing after all routes are configured.
     awaitInitialization();
@@ -320,6 +325,33 @@ public class App {
           dynamoDbClient.putItem(putItemRequest);
           return "";
         });
+
+    get(
+        "/ddb/describetable/:tablename",
+        (req, res) -> {
+          var tableName = req.params(":tablename");
+
+          var createTableRequest =
+              new CreateTableRequest()
+                  .withTableName(tableName)
+                  .withAttributeDefinitions(
+                      new AttributeDefinition()
+                          .withAttributeName("partitionKey")
+                          .withAttributeType("S"))
+                  .withKeySchema(
+                      new KeySchemaElement()
+                          .withAttributeName("partitionKey")
+                          .withKeyType(KeyType.HASH))
+                  .withProvisionedThroughput(
+                      new ProvisionedThroughput()
+                          .withReadCapacityUnits(1L)
+                          .withWriteCapacityUnits(1L));
+          dynamoDbClient.createTable(createTableRequest);
+
+          dynamoDbClient.describeTable(tableName);
+          return "";
+        });
+
     get(
         "/ddb/error",
         (req, res) -> {
@@ -402,6 +434,30 @@ public class App {
           putRecordRequest.setData(ByteBuffer.wrap(data));
           putRecordRequest.setPartitionKey("key");
           kinesisClient.putRecord(putRecordRequest);
+          return "";
+        });
+
+    get(
+        "/kinesis/describestream/:streamname",
+        (req, res) -> {
+          var streamName = req.params(":streamname");
+
+          var kinesisClient =
+              AmazonKinesisClient.builder()
+                  .withEndpointConfiguration(endpointConfiguration)
+                  .withCredentials(CREDENTIALS_PROVIDER)
+                  .build();
+
+          var createStreamRequest = new CreateStreamRequest();
+          createStreamRequest.setStreamName(streamName);
+
+          kinesisClient.createStream(createStreamRequest);
+
+          // Describe stream using ARN
+          var streamArn = "arn:aws:kinesis:us-west-2:000000000000:stream/" + streamName;
+          DescribeStreamRequest describeStreamRequest =
+              new DescribeStreamRequest().withStreamARN(streamArn);
+          kinesisClient.describeStream(describeStreamRequest);
           return "";
         });
 
@@ -1188,6 +1244,32 @@ public class App {
           String knowledgeBaseId = req.params(":knowledgeBaseId");
           RetrieveRequest request = new RetrieveRequest().withKnowledgeBaseId(knowledgeBaseId);
           var repo = bedrockAgentRuntimeClient.retrieve(request);
+          return "";
+        });
+  }
+
+  private static void setupCrossAccount() {
+    // Create credentials provider with temporary credentials
+    AWSCredentials sessionCredentials =
+        new BasicSessionCredentials(
+            "account_b_access_key_id", "account_b_secret_access_key", "account_b_token");
+    AWSCredentialsProvider sessionCredentialsProvider =
+        new AWSStaticCredentialsProvider(sessionCredentials);
+
+    // Create S3 client with temporary credentials
+    var crossAccountS3Client =
+        AmazonS3Client.builder()
+            .withCredentials(sessionCredentialsProvider)
+            .withEndpointConfiguration(
+                new EndpointConfiguration(s3Endpoint, Regions.EU_CENTRAL_1.getName()))
+            .build();
+
+    get(
+        "/crossaccount/createbucket/accountb",
+        (req, res) -> {
+          CreateBucketRequest createBucketRequest =
+              new CreateBucketRequest("cross-account-bucket", Region.EU_Frankfurt);
+          crossAccountS3Client.createBucket(createBucketRequest);
           return "";
         });
   }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -60,6 +60,15 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_REMOTE_RESOURCE_TYPE =
       AttributeKey.stringKey("aws.remote.resource.type");
 
+  static final AttributeKey<String> AWS_REMOTE_RESOURCE_ACCOUNT_ID =
+      AttributeKey.stringKey("aws.remote.resource.account.id");
+
+  static final AttributeKey<String> AWS_REMOTE_RESOURCE_ACCESS_KEY =
+      AttributeKey.stringKey("aws.remote.resource.account.access_key");
+
+  static final AttributeKey<String> AWS_REMOTE_RESOURCE_REGION =
+      AttributeKey.stringKey("aws.remote.resource.region");
+
   static final AttributeKey<String> AWS_REMOTE_DB_USER =
       AttributeKey.stringKey("aws.remote.db.user");
 
@@ -100,7 +109,9 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_QUEUE_URL = AttributeKey.stringKey("aws.queue.url");
   static final AttributeKey<String> AWS_QUEUE_NAME = AttributeKey.stringKey("aws.queue.name");
   static final AttributeKey<String> AWS_STREAM_NAME = AttributeKey.stringKey("aws.stream.name");
+  static final AttributeKey<String> AWS_STREAM_ARN = AttributeKey.stringKey("aws.stream.arn");
   static final AttributeKey<String> AWS_TABLE_NAME = AttributeKey.stringKey("aws.table.name");
+  static final AttributeKey<String> AWS_TABLE_ARN = AttributeKey.stringKey("aws.table.arn");
   static final AttributeKey<String> AWS_AGENT_ID = AttributeKey.stringKey("aws.bedrock.agent.id");
   static final AttributeKey<String> AWS_KNOWLEDGE_BASE_ID =
       AttributeKey.stringKey("aws.bedrock.knowledge_base.id");

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -22,6 +22,11 @@ final class AwsAttributeKeys {
 
   private AwsAttributeKeys() {}
 
+  static final AttributeKey<String> AWS_AUTH_ACCESS_KEY =
+      AttributeKey.stringKey("aws.auth.account.access_key");
+
+  static final AttributeKey<String> AWS_AUTH_REGION = AttributeKey.stringKey("aws.auth.region");
+
   static final AttributeKey<String> AWS_SPAN_KIND = AttributeKey.stringKey("aws.span.kind");
 
   static final AttributeKey<String> AWS_LOCAL_SERVICE = AttributeKey.stringKey("aws.local.service");
@@ -51,6 +56,15 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_REMOTE_OPERATION =
       AttributeKey.stringKey("aws.remote.operation");
 
+  static final AttributeKey<String> AWS_REMOTE_RESOURCE_ACCESS_KEY =
+      AttributeKey.stringKey("aws.remote.resource.account.access_key");
+
+  static final AttributeKey<String> AWS_REMOTE_RESOURCE_ACCOUNT_ID =
+      AttributeKey.stringKey("aws.remote.resource.account.id");
+
+  static final AttributeKey<String> AWS_REMOTE_RESOURCE_REGION =
+      AttributeKey.stringKey("aws.remote.resource.region");
+
   static final AttributeKey<String> AWS_REMOTE_RESOURCE_IDENTIFIER =
       AttributeKey.stringKey("aws.remote.resource.identifier");
 
@@ -59,15 +73,6 @@ final class AwsAttributeKeys {
 
   static final AttributeKey<String> AWS_REMOTE_RESOURCE_TYPE =
       AttributeKey.stringKey("aws.remote.resource.type");
-
-  static final AttributeKey<String> AWS_REMOTE_RESOURCE_ACCOUNT_ID =
-      AttributeKey.stringKey("aws.remote.resource.account.id");
-
-  static final AttributeKey<String> AWS_REMOTE_RESOURCE_ACCESS_KEY =
-      AttributeKey.stringKey("aws.remote.resource.account.access_key");
-
-  static final AttributeKey<String> AWS_REMOTE_RESOURCE_REGION =
-      AttributeKey.stringKey("aws.remote.resource.region");
 
   static final AttributeKey<String> AWS_REMOTE_DB_USER =
       AttributeKey.stringKey("aws.remote.db.user");
@@ -92,7 +97,7 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_LAMBDA_NAME =
       AttributeKey.stringKey("aws.lambda.function.name");
 
-  static final AttributeKey<String> AWS_LAMBDA_ARN =
+  static final AttributeKey<String> AWS_LAMBDA_FUNCTION_ARN =
       AttributeKey.stringKey("aws.lambda.function.arn");
 
   static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -55,8 +55,8 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ARN;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGE_BASE_ID;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_FUNCTION_ARN;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_RESOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_SERVICE;
@@ -604,7 +604,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
               getLambdaFunctionNameFromArn(
                   Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_NAME))));
           cloudformationPrimaryIdentifier =
-              Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_FUNCTION_ARN)));
+              Optional.ofNullable(
+                  escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_FUNCTION_ARN)));
         }
       } else if (isKeyPresent(span, AWS_LAMBDA_RESOURCE_ID)) {
         remoteResourceType = Optional.of(NORMALIZED_LAMBDA_SERVICE_NAME + "::EventSourceMapping");
@@ -717,8 +718,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       }
     } catch (IllegalArgumentException e) {
       logger.log(
-              Level.FINE,
-            String.format("Could not parse Lambda resource name from ARN: %s", stringArn));
+          Level.FINE,
+          String.format("Could not parse Lambda resource name from ARN: %s", stringArn));
     }
     return stringArn;
   }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -604,7 +604,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
               getLambdaFunctionNameFromArn(
                   Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_NAME))));
           cloudformationPrimaryIdentifier =
-              Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_ARN)));
+              Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_FUNCTION_ARN)));
         }
       } else if (isKeyPresent(span, AWS_LAMBDA_RESOURCE_ID)) {
         remoteResourceType = Optional.of(NORMALIZED_LAMBDA_SERVICE_NAME + "::EventSourceMapping");
@@ -720,7 +720,6 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
               Level.FINE,
             String.format("Could not parse Lambda resource name from ARN: %s", stringArn));
     }
-
     return stringArn;
   }
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -141,18 +141,6 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static final String NORMALIZED_SECRETSMANAGER_SERVICE_NAME = "AWS::SecretsManager";
   private static final String NORMALIZED_LAMBDA_SERVICE_NAME = "AWS::Lambda";
 
-  // List of resource arns to extract cross-account information
-  private static final List<AttributeKey<String>> ARN_ATTRIBUTES =
-      List.of(
-          AWS_TABLE_ARN,
-          AWS_STREAM_ARN,
-          AWS_SNS_TOPIC_ARN,
-          AWS_SECRET_ARN,
-          AWS_STEP_FUNCTIONS_ACTIVITY_ARN,
-          AWS_STATE_MACHINE_ARN,
-          AWS_GUARDRAIL_ARN,
-          AWS_LAMBDA_FUNCTION_ARN);
-
   // Constants for Lambda operations
   private static final String LAMBDA_INVOKE_OPERATION = "Invoke";
 
@@ -658,6 +646,16 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       SpanData span, AttributesBuilder builder) {
     Optional<String> remoteResourceAccountId = Optional.empty();
     Optional<String> remoteResourceRegion = Optional.empty();
+    List<AttributeKey<String>> ARN_ATTRIBUTES =
+        List.of(
+            AWS_TABLE_ARN,
+            AWS_STREAM_ARN,
+            AWS_SNS_TOPIC_ARN,
+            AWS_SECRET_ARN,
+            AWS_STEP_FUNCTIONS_ACTIVITY_ARN,
+            AWS_STATE_MACHINE_ARN,
+            AWS_GUARDRAIL_ARN,
+            AWS_LAMBDA_FUNCTION_ARN);
 
     if (isKeyPresent(span, AWS_QUEUE_URL)) {
       String url = escapeDelimiters(span.getAttributes().get(AWS_QUEUE_URL));

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -53,8 +53,6 @@ final class AwsSpanProcessingUtil {
   static final String UNKNOWN_OPERATION = "UnknownOperation";
   static final String UNKNOWN_REMOTE_SERVICE = "UnknownRemoteService";
   static final String UNKNOWN_REMOTE_OPERATION = "UnknownRemoteOperation";
-  static final String UNKNOWN_REMOTE_ACCOUNT_ID = "UnknownRemoteAccountId";
-  static final String UNKNOWN_REMOTE_REGION = "UnknownRemoteRegion";
   static final String INTERNAL_OPERATION = "InternalOperation";
   static final String LOCAL_ROOT = "LOCAL_ROOT";
   static final String SQS_RECEIVE_MESSAGE_SPAN_NAME = "Sqs.ReceiveMessage";

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -53,6 +53,8 @@ final class AwsSpanProcessingUtil {
   static final String UNKNOWN_OPERATION = "UnknownOperation";
   static final String UNKNOWN_REMOTE_SERVICE = "UnknownRemoteService";
   static final String UNKNOWN_REMOTE_OPERATION = "UnknownRemoteOperation";
+  static final String UNKNOWN_REMOTE_ACCOUNT_ID = "UnknownRemoteAccountId";
+  static final String UNKNOWN_REMOTE_REGION = "UnknownRemoteRegion";
   static final String INTERNAL_OPERATION = "InternalOperation";
   static final String LOCAL_ROOT = "LOCAL_ROOT";
   static final String SQS_RECEIVE_MESSAGE_SPAN_NAME = "Sqs.ReceiveMessage";

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/SqsUrlParser.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/SqsUrlParser.java
@@ -40,6 +40,42 @@ public class SqsUrlParser {
     return Optional.empty();
   }
 
+  public static Optional<String> getAccountId(String url) {
+    if (url == null) {
+      return Optional.empty();
+    }
+    url = url.replace(HTTP_SCHEMA, "").replace(HTTPS_SCHEMA, "");
+    if (isValidSqsUrl(url)) {
+      String[] splitUrl = url.split("/");
+      return Optional.of(splitUrl[1]);
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<String> getRegion(String url) {
+    if (url == null) {
+      return Optional.empty();
+    }
+    url = url.replace(HTTP_SCHEMA, "").replace(HTTPS_SCHEMA, "");
+    if (isValidSqsUrl(url)) {
+      String[] splitUrl = url.split("/");
+      String domain = splitUrl[0];
+      String[] domainParts = domain.split("\\.");
+      if (domainParts.length == 4) {
+        return Optional.of(domainParts[1]);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean isValidSqsUrl(String url) {
+    String[] splitUrl = url.split("/");
+    return splitUrl.length == 3
+        && splitUrl[0].startsWith("sqs")
+        && isAccountId(splitUrl[1])
+        && isValidQueueName(splitUrl[2]);
+  }
+
   private static boolean isAccountId(String input) {
     if (input == null || input.length() != 12) {
       return false;

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -30,7 +30,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ARN;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_GUARDRAIL_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_KNOWLEDGE_BASE_ID;
-import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_ARN;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_FUNCTION_ARN;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_NAME;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LAMBDA_RESOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
@@ -890,8 +890,6 @@ class AwsMetricAttributeGeneratorTest {
 
     // Validate behaviour of AWS_GUARDRAIL_ID attribute, then remove it.
     mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     // Also test with ARN to verify cloudformationPrimaryIdentifier uses ARN
     mockAttribute(
         AWS_GUARDRAIL_ARN, "arn:aws:bedrock:us-east-1:123456789012:guardrail/test_guardrail_id");
@@ -906,7 +904,6 @@ class AwsMetricAttributeGeneratorTest {
 
     // Validate behaviour of AWS_GUARDRAIL_ID attribute with special chars(^), then remove it.
     mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_^id");
-    validateRemoteResourceAttributes("AWS::Bedrock::Guardrail", "test_guardrail_^^id");
     // Also test with ARN containing special chars to verify delimiter escaping in
     // cloudformationPrimaryIdentifier
     mockAttribute(
@@ -918,8 +915,6 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAccountIdAndRegion(
           Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_GUARDRAIL_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
     mockAttribute(AWS_GUARDRAIL_ARN, null);
 
     // Validate behaviour of GEN_AI_REQUEST_MODEL attribute, then remove it.
@@ -992,35 +987,38 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_SERVICE, "Lambda");
     mockAttribute(RPC_METHOD, "GetFunction");
     mockAttribute(AWS_LAMBDA_NAME, "testLambdaName");
-    mockAttribute(AWS_LAMBDA_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
+    mockAttribute(AWS_LAMBDA_FUNCTION_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
     validateRemoteResourceAttributes(
         "AWS::Lambda::Function",
         "testLambdaName",
         "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
+    validateRemoteResourceAccountIdAndRegion(Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
-    mockAttribute(AWS_LAMBDA_ARN, null);
+    mockAttribute(AWS_LAMBDA_FUNCTION_ARN, null);
 
     // Validate behaviour of AWS_LAMBDA_NAME containing ARN for non-Invoke operations
     mockAttribute(RPC_SERVICE, "Lambda");
     mockAttribute(RPC_METHOD, "ListFunctions");
     mockAttribute(AWS_LAMBDA_NAME, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
-    mockAttribute(AWS_LAMBDA_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
+    mockAttribute(AWS_LAMBDA_FUNCTION_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
     validateRemoteResourceAttributes(
         "AWS::Lambda::Function",
         "testLambdaName",
         "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
+    validateRemoteResourceAccountIdAndRegion(Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
-    mockAttribute(AWS_LAMBDA_ARN, null);
+    mockAttribute(AWS_LAMBDA_FUNCTION_ARN, null);
 
     // Validate that Lambda Invoke with function name treats Lambda as a service, not a resource
     mockAttribute(RPC_SERVICE, "Lambda");
     mockAttribute(RPC_METHOD, "Invoke");
     mockAttribute(AWS_LAMBDA_NAME, "testLambdaName");
     validateRemoteResourceAttributes(null, null);
+    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
@@ -1030,6 +1028,7 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_METHOD, "Invoke");
     mockAttribute(AWS_LAMBDA_NAME, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
     validateRemoteResourceAttributes(null, null);
+    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -768,187 +768,125 @@ class AwsMetricAttributeGeneratorTest {
   @Test
   public void testSdkClientSpanWithRemoteResourceAttributes() {
     mockAttribute(RPC_SYSTEM, "aws-api");
-    // Validate behaviour of aws bucket name attribute, then remove it.
-    mockAttribute(AWS_BUCKET_NAME, "aws_s3_bucket_name");
     mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
     mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
+    // Validate behaviour of aws bucket name attribute, then remove it.
+    mockAttribute(AWS_BUCKET_NAME, "aws_s3_bucket_name");
     validateRemoteResourceAttributes("AWS::S3::Bucket", "aws_s3_bucket_name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_BUCKET_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_QUEUE_NAME attribute, then remove it.
     mockAttribute(AWS_QUEUE_NAME, "aws_queue_name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::SQS::Queue", "aws_queue_name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_QUEUE_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of having both AWS_QUEUE_NAME and AWS_QUEUE_URL attribute, then remove
     // them. Queue name is more reliable than queue URL, so we prefer to use name over URL.
     mockAttribute(AWS_QUEUE_URL, "https://sqs.us-east-2.amazonaws.com/123456789012/Queue");
     mockAttribute(AWS_QUEUE_NAME, "aws_queue_name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::SQS::Queue", "aws_queue_name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-2"));
     mockAttribute(AWS_QUEUE_URL, null);
     mockAttribute(AWS_QUEUE_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Valid queue name with invalid queue URL, we should default to using the queue name.
     mockAttribute(AWS_QUEUE_URL, "invalidUrl");
     mockAttribute(AWS_QUEUE_NAME, "aws_queue_name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::SQS::Queue", "aws_queue_name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_QUEUE_URL, null);
     mockAttribute(AWS_QUEUE_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_STREAM_NAME attribute, then remove it.
     mockAttribute(AWS_STREAM_NAME, "aws_stream_name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Kinesis::Stream", "aws_stream_name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_STREAM_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_STREAM_ARN attribute, then remove it.
     mockAttribute(AWS_STREAM_ARN, "arn:aws:kinesis:us-east-1:123456789012:stream/test_stream");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Kinesis::Stream", "test_stream");
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_STREAM_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_TABLE_NAME attribute, then remove it.
     mockAttribute(AWS_TABLE_NAME, "aws_table_name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::DynamoDB::Table", "aws_table_name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_TABLE_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_TABLE_NAME attribute with special chars(|), then remove it.
     mockAttribute(AWS_TABLE_NAME, "aws_table|name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::DynamoDB::Table", "aws_table^|name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_TABLE_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_TABLE_NAME attribute with special chars(^), then remove it.
     mockAttribute(AWS_TABLE_NAME, "aws_table^name");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::DynamoDB::Table", "aws_table^^name");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_TABLE_NAME, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_TABLE_ARN attribute, then remove it.
     mockAttribute(AWS_TABLE_ARN, "arn:aws:dynamodb:us-east-1:123456789012:table/test_table");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::DynamoDB::Table", "test_table");
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_TABLE_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_BEDROCK_AGENT_ID attribute, then remove it.
     mockAttribute(AWS_AGENT_ID, "test_agent_id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::Agent", "test_agent_id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_AGENT_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_BEDROCK_AGENT_ID attribute with special chars(^), then remove it.
     mockAttribute(AWS_AGENT_ID, "test_agent_^id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::Agent", "test_agent_^^id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_AGENT_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_KNOWLEDGE_BASE_ID attribute, then remove it.
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, "test_knowledgeBase_id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_KNOWLEDGE_BASE_ID attribute with special chars(^), then remove it.
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, "test_knowledgeBase_^id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::KnowledgeBase", "test_knowledgeBase_^^id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_KNOWLEDGE_BASE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_DATA_SOURCE_ID attribute, then remove it.
     mockAttribute(AWS_DATA_SOURCE_ID, "test_datasource_id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_DATA_SOURCE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_DATA_SOURCE_ID attribute with special chars(^), then remove
     // it.
     mockAttribute(AWS_DATA_SOURCE_ID, "test_datasource_^id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::DataSource", "test_datasource_^^id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_DATA_SOURCE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_GUARDRAIL_ID attribute, then remove it.
     mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_id");
@@ -965,13 +903,9 @@ class AwsMetricAttributeGeneratorTest {
           Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_GUARDRAIL_ID, null);
     mockAttribute(AWS_GUARDRAIL_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_GUARDRAIL_ID attribute with special chars(^), then remove it.
     mockAttribute(AWS_GUARDRAIL_ID, "test_guardrail_^id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::Guardrail", "test_guardrail_^^id");
     // Also test with ARN containing special chars to verify delimiter escaping in
     // cloudformationPrimaryIdentifier
@@ -990,26 +924,18 @@ class AwsMetricAttributeGeneratorTest {
 
     // Validate behaviour of GEN_AI_REQUEST_MODEL attribute, then remove it.
     mockAttribute(GEN_AI_REQUEST_MODEL, "test.service_id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service_id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(GEN_AI_REQUEST_MODEL, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of GEN_AI_REQUEST_MODEL attribute with special chars(^), then
     // remove it.
     mockAttribute(GEN_AI_REQUEST_MODEL, "test.service_^id");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Bedrock::Model", "test.service_^^id");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(GEN_AI_REQUEST_MODEL, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_STATE_MACHINE_ARN attribute, then remove it.
     mockAttribute(
@@ -1024,8 +950,6 @@ class AwsMetricAttributeGeneratorTest {
         "test_state_machine",
         "arn:aws:states:us-east-1:123456789012:stateMachine:test_state_machine");
     mockAttribute(AWS_STATE_MACHINE_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_STEPFUNCTIONS_ACTIVITY_ARN, then remove it.
     mockAttribute(
@@ -1040,8 +964,6 @@ class AwsMetricAttributeGeneratorTest {
         "testActivity",
         "arn:aws:states:us-east-1:123456789012:activity:testActivity");
     mockAttribute(AWS_STEP_FUNCTIONS_ACTIVITY_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_SNS_TOPIC_ARN, then remove it.
     mockAttribute(AWS_SNS_TOPIC_ARN, "arn:aws:sns:us-west-2:012345678901:testTopic");
@@ -1052,8 +974,6 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAttributes(
         "AWS::SNS::Topic", "testTopic", "arn:aws:sns:us-west-2:012345678901:testTopic");
     mockAttribute(AWS_SNS_TOPIC_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_SECRET_ARN, then remove it.
     mockAttribute(
@@ -1067,8 +987,6 @@ class AwsMetricAttributeGeneratorTest {
         "secretName",
         "arn:aws:secretsmanager:us-east-1:123456789012:secret:secretName");
     mockAttribute(AWS_SECRET_ARN, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_LAMBDA_NAME for non-Invoke operations (treated as resource)
     mockAttribute(RPC_SERVICE, "Lambda");
@@ -1118,28 +1036,32 @@ class AwsMetricAttributeGeneratorTest {
 
     // Validate behaviour of AWS_LAMBDA_RESOURCE_ID
     mockAttribute(AWS_LAMBDA_RESOURCE_ID, "eventSourceId");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Lambda::EventSourceMapping", "eventSourceId");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_LAMBDA_RESOURCE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Validate behaviour of AWS_LAMBDA_FUNCTION_NAME
     mockAttribute(AWS_LAMBDA_RESOURCE_ID, "eventSourceId");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAttributes("AWS::Lambda::EventSourceMapping", "eventSourceId");
     validateRemoteResourceAccountIdAndRegion(
         Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(AWS_LAMBDA_RESOURCE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     // Cross account support
+    // Invalid arn but account access key is available
+    mockAttribute(AWS_SECRET_ARN, "invalid_arn");
+    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
+    mockAttribute(AWS_SECRET_ARN, null);
+
+    // Invalid arn and no account access key
+    mockAttribute(AWS_SECRET_ARN, "invalid_arn");
+    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
+    mockAttribute(AWS_SECRET_ARN, null);
+
     // Both account access key and account id are not available
+    mockAttribute(AWS_AUTH_REGION, null);
+    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
     mockAttribute(AWS_BUCKET_NAME, "aws_s3_bucket_name");
     validateRemoteResourceAttributes("AWS::S3::Bucket", "aws_s3_bucket_name");
     validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
@@ -1168,20 +1090,6 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("invalid_region"));
     mockAttribute(AWS_SECRET_ARN, null);
-
-    // Invalid arn and no account access key
-    mockAttribute(AWS_SECRET_ARN, "invalid_arn");
-    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
-    mockAttribute(AWS_SECRET_ARN, null);
-
-    // Invalid arn but account access key is available
-    mockAttribute(AWS_SECRET_ARN, "invalid_arn");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
-    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
-    mockAttribute(AWS_LAMBDA_RESOURCE_ID, null);
-    mockAttribute(AWS_AUTH_REGION, null);
-    mockAttribute(AWS_AUTH_ACCESS_KEY, null);
 
     mockAttribute(RPC_SYSTEM, "null");
   }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -898,7 +898,7 @@ class AwsMetricAttributeGeneratorTest {
         "test_guardrail_id",
         "arn:aws:bedrock:us-east-1:123456789012:guardrail/test_guardrail_id");
     validateRemoteResourceAccountIdAndRegion(
-          Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
+        Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_GUARDRAIL_ID, null);
     mockAttribute(AWS_GUARDRAIL_ARN, null);
 
@@ -913,7 +913,7 @@ class AwsMetricAttributeGeneratorTest {
         "test_guardrail_^^id",
         "arn:aws:bedrock:us-east-1:123456789012:guardrail/test_guardrail_^^id");
     validateRemoteResourceAccountIdAndRegion(
-          Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
+        Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_GUARDRAIL_ID, null);
     mockAttribute(AWS_GUARDRAIL_ARN, null);
 
@@ -936,8 +936,6 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(
         AWS_STATE_MACHINE_ARN,
         "arn:aws:states:us-east-1:123456789012:stateMachine:test_state_machine");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     validateRemoteResourceAttributes(
@@ -962,8 +960,6 @@ class AwsMetricAttributeGeneratorTest {
 
     // Validate behaviour of AWS_SNS_TOPIC_ARN, then remove it.
     mockAttribute(AWS_SNS_TOPIC_ARN, "arn:aws:sns:us-west-2:012345678901:testTopic");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("012345678901"), Optional.empty(), Optional.of("us-west-2"));
     validateRemoteResourceAttributes(
@@ -973,8 +969,6 @@ class AwsMetricAttributeGeneratorTest {
     // Validate behaviour of AWS_SECRET_ARN, then remove it.
     mockAttribute(
         AWS_SECRET_ARN, "arn:aws:secretsmanager:us-east-1:123456789012:secret:secretName");
-    mockAttribute(AWS_AUTH_ACCESS_KEY, MOCK_ACCESS_KEY);
-    mockAttribute(AWS_AUTH_REGION, MOCK_REGION);
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     validateRemoteResourceAttributes(
@@ -987,12 +981,14 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_SERVICE, "Lambda");
     mockAttribute(RPC_METHOD, "GetFunction");
     mockAttribute(AWS_LAMBDA_NAME, "testLambdaName");
-    mockAttribute(AWS_LAMBDA_FUNCTION_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
+    mockAttribute(
+        AWS_LAMBDA_FUNCTION_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
     validateRemoteResourceAttributes(
         "AWS::Lambda::Function",
         "testLambdaName",
         "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
-    validateRemoteResourceAccountIdAndRegion(Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
+    validateRemoteResourceAccountIdAndRegion(
+        Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
@@ -1002,12 +998,14 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_SERVICE, "Lambda");
     mockAttribute(RPC_METHOD, "ListFunctions");
     mockAttribute(AWS_LAMBDA_NAME, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
-    mockAttribute(AWS_LAMBDA_FUNCTION_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
+    mockAttribute(
+        AWS_LAMBDA_FUNCTION_ARN, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
     validateRemoteResourceAttributes(
         "AWS::Lambda::Function",
         "testLambdaName",
         "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
-    validateRemoteResourceAccountIdAndRegion(Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
+    validateRemoteResourceAccountIdAndRegion(
+        Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
@@ -1018,7 +1016,6 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_METHOD, "Invoke");
     mockAttribute(AWS_LAMBDA_NAME, "testLambdaName");
     validateRemoteResourceAttributes(null, null);
-    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
@@ -1028,7 +1025,6 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_METHOD, "Invoke");
     mockAttribute(AWS_LAMBDA_NAME, "arn:aws:lambda:us-east-1:123456789012:function:testLambdaName");
     validateRemoteResourceAttributes(null, null);
-    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.of(MOCK_ACCESS_KEY), Optional.of(MOCK_REGION));
     mockAttribute(RPC_SERVICE, null);
     mockAttribute(RPC_METHOD, null);
     mockAttribute(AWS_LAMBDA_NAME, null);
@@ -1053,11 +1049,6 @@ class AwsMetricAttributeGeneratorTest {
     validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
     mockAttribute(AWS_SECRET_ARN, null);
 
-    // Invalid arn and no account access key
-    mockAttribute(AWS_SECRET_ARN, "invalid_arn");
-    validateRemoteResourceAccountIdAndRegion(Optional.empty(), Optional.empty(), Optional.empty());
-    mockAttribute(AWS_SECRET_ARN, null);
-
     // Both account access key and account id are not available
     mockAttribute(AWS_AUTH_REGION, null);
     mockAttribute(AWS_AUTH_ACCESS_KEY, null);
@@ -1069,7 +1060,10 @@ class AwsMetricAttributeGeneratorTest {
     // Account access key is not available
     mockAttribute(
         AWS_SECRET_ARN, "arn:aws:secretsmanager:us-east-1:123456789012:secret:secretName");
-    validateRemoteResourceAttributes("AWS::SecretsManager::Secret", "secretName");
+    validateRemoteResourceAttributes(
+        "AWS::SecretsManager::Secret",
+        "secretName",
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:secretName");
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_SECRET_ARN, null);
@@ -1077,7 +1071,10 @@ class AwsMetricAttributeGeneratorTest {
     // Arn with invalid account id
     mockAttribute(
         AWS_SECRET_ARN, "arn:aws:secretsmanager:us-east-1:invalid_account_id:secret:secretName");
-    validateRemoteResourceAttributes("AWS::SecretsManager::Secret", "secretName");
+    validateRemoteResourceAttributes(
+        "AWS::SecretsManager::Secret",
+        "secretName",
+        "arn:aws:secretsmanager:us-east-1:invalid_account_id:secret:secretName");
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("invalid_account_id"), Optional.empty(), Optional.of("us-east-1"));
     mockAttribute(AWS_SECRET_ARN, null);
@@ -1085,7 +1082,10 @@ class AwsMetricAttributeGeneratorTest {
     // Arn with invalid region
     mockAttribute(
         AWS_SECRET_ARN, "arn:aws:secretsmanager:invalid_region:123456789012:secret:secretName");
-    validateRemoteResourceAttributes("AWS::SecretsManager::Secret", "secretName");
+    validateRemoteResourceAttributes(
+        "AWS::SecretsManager::Secret",
+        "secretName",
+        "arn:aws:secretsmanager:invalid_region:123456789012:secret:secretName");
     validateRemoteResourceAccountIdAndRegion(
         Optional.of("123456789012"), Optional.empty(), Optional.of("invalid_region"));
     mockAttribute(AWS_SECRET_ARN, null);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/SqsUrlParserTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/SqsUrlParserTest.java
@@ -24,59 +24,105 @@ public class SqsUrlParserTest {
 
   @Test
   public void testSqsClientSpanBasicUrls() {
-    validate("https://sqs.us-east-1.amazonaws.com/123412341234/Q_Name-5", "Q_Name-5");
-    validate("https://sqs.af-south-1.amazonaws.com/999999999999/-_ThisIsValid", "-_ThisIsValid");
-    validate("http://sqs.eu-west-3.amazonaws.com/000000000000/FirstQueue", "FirstQueue");
-    validate("sqs.sa-east-1.amazonaws.com/123456781234/SecondQueue", "SecondQueue");
+    validateGetQueueName("https://sqs.us-east-1.amazonaws.com/123412341234/Q_Name-5", "Q_Name-5");
+    validateGetQueueName(
+        "https://sqs.af-south-1.amazonaws.com/999999999999/-_ThisIsValid", "-_ThisIsValid");
+    validateGetQueueName(
+        "http://sqs.eu-west-3.amazonaws.com/000000000000/FirstQueue", "FirstQueue");
+    validateGetQueueName("sqs.sa-east-1.amazonaws.com/123456781234/SecondQueue", "SecondQueue");
   }
 
   @Test
   public void testSqsClientSpanLegacyFormatUrls() {
-    validate("https://ap-northeast-2.queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
-    validate("http://cn-northwest-1.queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
-    validate("http://cn-north-1.queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
-    validate(
+    validateGetQueueName(
+        "https://ap-northeast-2.queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
+    validateGetQueueName(
+        "http://cn-northwest-1.queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
+    validateGetQueueName("http://cn-north-1.queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
+    validateGetQueueName(
         "ap-south-1.queue.amazonaws.com/123412341234/MyLongerQueueNameHere",
         "MyLongerQueueNameHere");
-    validate("https://queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
+    validateGetQueueName("https://queue.amazonaws.com/123456789012/MyQueue", "MyQueue");
   }
 
   @Test
   public void testSqsClientSpanCustomUrls() {
-    validate("http://127.0.0.1:1212/123456789012/MyQueue", "MyQueue");
-    validate("https://127.0.0.1:1212/123412341234/RRR", "RRR");
-    validate("127.0.0.1:1212/123412341234/QQ", "QQ");
-    validate("https://amazon.com/123412341234/BB", "BB");
+    validateGetQueueName("http://127.0.0.1:1212/123456789012/MyQueue", "MyQueue");
+    validateGetQueueName("https://127.0.0.1:1212/123412341234/RRR", "RRR");
+    validateGetQueueName("127.0.0.1:1212/123412341234/QQ", "QQ");
+    validateGetQueueName("https://amazon.com/123412341234/BB", "BB");
   }
 
   @Test
   public void testSqsClientSpanLongUrls() {
     String queueName = "a".repeat(80);
-    validate("http://127.0.0.1:1212/123456789012/" + queueName, queueName);
+    validateGetQueueName("http://127.0.0.1:1212/123456789012/" + queueName, queueName);
 
     String queueNameTooLong = "a".repeat(81);
-    validate("http://127.0.0.1:1212/123456789012/" + queueNameTooLong, null);
+    validateGetQueueName("http://127.0.0.1:1212/123456789012/" + queueNameTooLong, null);
   }
 
   @Test
   public void testClientSpanSqsInvalidOrEmptyUrls() {
-    validate(null, null);
-    validate("", null);
-    validate(" ", null);
-    validate("/", null);
-    validate("//", null);
-    validate("///", null);
-    validate("//asdf", null);
-    validate("/123412341234/as&df", null);
-    validate("invalidUrl", null);
-    validate("https://www.amazon.com", null);
-    validate("https://sqs.us-east-1.amazonaws.com/123412341234/.", null);
-    validate("https://sqs.us-east-1.amazonaws.com/12/Queue", null);
-    validate("https://sqs.us-east-1.amazonaws.com/A/A", null);
-    validate("https://sqs.us-east-1.amazonaws.com/123412341234/A/ThisShouldNotBeHere", null);
+    validateGetQueueName(null, null);
+    validateGetQueueName("", null);
+    validateGetQueueName(" ", null);
+    validateGetQueueName("/", null);
+    validateGetQueueName("//", null);
+    validateGetQueueName("///", null);
+    validateGetQueueName("//asdf", null);
+    validateGetQueueName("/123412341234/as&df", null);
+    validateGetQueueName("invalidUrl", null);
+    validateGetQueueName("https://www.amazon.com", null);
+    validateGetQueueName("https://sqs.us-east-1.amazonaws.com/123412341234/.", null);
+    validateGetQueueName("https://sqs.us-east-1.amazonaws.com/12/Queue", null);
+    validateGetQueueName("https://sqs.us-east-1.amazonaws.com/A/A", null);
+    validateGetQueueName(
+        "https://sqs.us-east-1.amazonaws.com/123412341234/A/ThisShouldNotBeHere", null);
   }
 
-  private void validate(String url, String expectedName) {
+  @Test
+  public void testClientSpanSqsAccountId() {
+    validateGetAccountId(null, null);
+    validateGetAccountId("", null);
+    validateGetAccountId(" ", null);
+    validateGetAccountId("/", null);
+    validateGetAccountId("//", null);
+    validateGetAccountId("///", null);
+    validateGetAccountId("//asdf", null);
+    validateGetAccountId("/123412341234/as&df", null);
+    validateGetAccountId("invalidUrl", null);
+    validateGetAccountId("https://www.amazon.com", null);
+    validateGetAccountId("https://sqs.us-east-1.amazonaws.com/123412341234/Queue", "123412341234");
+    validateGetAccountId("https://sqs.us-east-1.amazonaws.com/12341234/Queue", null);
+    validateGetAccountId("https://sqs.us-east-1.amazonaws.com/1234123412xx/Queue", null);
+    validateGetAccountId("https://sqs.us-east-1.amazonaws.com/1234123412xx", null);
+  }
+
+  @Test
+  public void testClientSpanSqsRegion() {
+    validateGetRegion(null, null);
+    validateGetRegion("", null);
+    validateGetRegion(" ", null);
+    validateGetRegion("/", null);
+    validateGetRegion("//", null);
+    validateGetRegion("///", null);
+    validateGetRegion("//asdf", null);
+    validateGetRegion("/123412341234/as&df", null);
+    validateGetRegion("invalidUrl", null);
+    validateGetRegion("https://www.amazon.com", null);
+    validateGetRegion("https://sqs.us-east-1.amazonaws.com/123412341234/Queue", "us-east-1");
+  }
+
+  private void validateGetRegion(String url, String expectedRegion) {
+    assertThat(SqsUrlParser.getRegion(url)).isEqualTo(Optional.ofNullable(expectedRegion));
+  }
+
+  private void validateGetAccountId(String url, String expectedAccountId) {
+    assertThat(SqsUrlParser.getAccountId(url)).isEqualTo(Optional.ofNullable(expectedAccountId));
+  }
+
+  private void validateGetQueueName(String url, String expectedName) {
     assertThat(SqsUrlParser.getQueueName(url)).isEqualTo(Optional.ofNullable(expectedName));
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/SqsUrlParserTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/SqsUrlParserTest.java
@@ -75,7 +75,7 @@ public class SqsUrlParserTest {
     validateGetQueueName("invalidUrl", null);
     validateGetQueueName("https://www.amazon.com", null);
     validateGetQueueName("https://sqs.us-east-1.amazonaws.com/123412341234/.", null);
-    validateGetQueueName("https://sqs.us-east-1.amazonaws.com/12/Queue", null);
+    validateGetQueueName("https://sqs.us-east-1.amazonaws.com/12xxxxxxxxxx/Queue", null);
     validateGetQueueName("https://sqs.us-east-1.amazonaws.com/A/A", null);
     validateGetQueueName(
         "https://sqs.us-east-1.amazonaws.com/123412341234/A/ThisShouldNotBeHere", null);
@@ -94,7 +94,7 @@ public class SqsUrlParserTest {
     validateGetAccountId("invalidUrl", null);
     validateGetAccountId("https://www.amazon.com", null);
     validateGetAccountId("https://sqs.us-east-1.amazonaws.com/123412341234/Queue", "123412341234");
-    validateGetAccountId("https://sqs.us-east-1.amazonaws.com/12341234/Queue", null);
+    validateGetAccountId("https://sqs.us-east-1.amazonaws.com/12341234/Queue", "12341234");
     validateGetAccountId("https://sqs.us-east-1.amazonaws.com/1234123412xx/Queue", null);
     validateGetAccountId("https://sqs.us-east-1.amazonaws.com/1234123412xx", null);
   }


### PR DESCRIPTION
**Description of changes:**
Changes in ADOT package to support cross-account observability in Java V1 & V2 SDK.
1. We extract account id and region from remote resource arn. 
2. We pass account access key id and region from span to metric when resource arn is not available. 
3. Add instrumentation patch for AWS SDK

Related changes in upstream package: https://github.com/yiyuan-he/opentelemetry-java-instrumentation/pull/2

**Testing Plan:**
1. Unit tests for extracting account id and region from remote resource arn.
2. Unit tests for extracting access key and region from credential.
3. Unit test for the scenario when resource arn and credential information are both available.
5. Contract tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
