### PR TITLE
Update rust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 # Stage 1: Build the cp-utility binary
-FROM public.ecr.aws/docker/library/rust:1.82 as builder
+FROM public.ecr.aws/docker/library/rust:1.86 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
*Description of changes:*

Release build failed with:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/3df092be-b9f3-4e62-9652-32cf4823d0ef" />

Updating rust version required for `edition2024` 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
