### PR TITLE
Bump Rust Version in Dockerfile to 1.87

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 # Stage 1: Build the cp-utility binary
-FROM public.ecr.aws/docker/library/rust:1.86 as builder
+FROM public.ecr.aws/docker/library/rust:1.87 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
## What does this pull request do?
Proactively bumping rust version in our Dockerfile to 1.87 to align with our ADOT Python SDK repo: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/386


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
