### PR TITLE
AWS SDK v2.2 SPI Patch Migration

### DIFF
--- a/instrumentation/aws-sdk/build.gradle.kts
+++ b/instrumentation/aws-sdk/build.gradle.kts
@@ -16,6 +16,7 @@
 plugins {
   java
   id("com.gradleup.shadow")
+  id("groovy")
 }
 
 base.archivesBaseName = "aws-instrumentation-aws-sdk"
@@ -23,5 +24,11 @@ base.archivesBaseName = "aws-instrumentation-aws-sdk"
 dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   compileOnly("software.amazon.awssdk:aws-core:2.2.0")
+  compileOnly("software.amazon.awssdk:secretsmanager:2.2.0")
+
   compileOnly("net.bytebuddy:byte-buddy")
+  compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+
+  testImplementation("com.google.guava:guava")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
 }

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AdotAwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AdotAwsSdkInstrumentationModule.java
@@ -43,7 +43,23 @@ public class AdotAwsSdkInstrumentationModule extends InstrumentationModule {
   @Override
   public List<String> getAdditionalHelperClassNames() {
     return Arrays.asList(
-        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AdotAwsSdkTracingExecutionInterceptor");
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AdotAwsSdkTracingExecutionInterceptor",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AdotTracingExecutionInterceptor$RequestSpanFinisher",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequest",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.FieldMapper",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.FieldMapping",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.FieldMapping$Type",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.BedrockJsonParser",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.BedrockJsonParser$JsonPathResolver",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.BedrockJsonParser$LlmJson",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.BedrockJsonParser$JsonParser",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.MethodHandleFactory",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.MethodHandleFactory$1",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.Serializer",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsJsonProtocolFactoryAccess",
+        "software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType$AttributeKeys");
   }
 
   /**

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AdotAwsSdkTracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AdotAwsSdkTracingExecutionInterceptor.java
@@ -15,16 +15,48 @@
 
 package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
 
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_SYSTEM;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCKRUNTIME;
+
+import io.opentelemetry.api.trace.Span;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.*;
 
 public class AdotAwsSdkTracingExecutionInterceptor implements ExecutionInterceptor {
 
+  private static final String GEN_AI_SYSTEM_BEDROCK = "aws.bedrock";
+  private static final ExecutionAttribute<AwsSdkRequest> AWS_SDK_REQUEST_ATTRIBUTE =
+      new ExecutionAttribute<>(
+          AdotAwsSdkTracingExecutionInterceptor.class.getName() + ".AwsSdkRequest");
+
+  private final FieldMapper fieldMapper = new FieldMapper();
+
   // This is the latest point we can obtain the Sdk Request after it is modified by the upstream
   // TracingInterceptor. It ensures upstream handles the request and applies its changes first.
   @Override
   public void beforeTransmission(
-      Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {}
+      Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+
+    SdkRequest request = context.request();
+    Span currentSpan = Span.current();
+
+    try {
+      // Skip injection if Otel span is invalid
+      if (currentSpan != null && currentSpan.getSpanContext().isValid()) {
+        AwsSdkRequest awsSdkRequest = AwsSdkRequest.ofSdkRequest(request);
+        if (awsSdkRequest != null) {
+          executionAttributes.putAttribute(AWS_SDK_REQUEST_ATTRIBUTE, awsSdkRequest);
+          fieldMapper.mapToAttributes(request, awsSdkRequest, currentSpan);
+          if (awsSdkRequest.type() == BEDROCKRUNTIME) {
+            currentSpan.setAttribute(GEN_AI_SYSTEM, GEN_AI_SYSTEM_BEDROCK);
+          }
+        }
+      }
+    } catch (Throwable throwable) {
+      // ignore
+    }
+  }
 
   // This is the latest point we can obtain the Sdk Response before span completion in upstream's
   // afterExecution. This ensures we capture attributes from the final, fully modified response
@@ -32,6 +64,14 @@ public class AdotAwsSdkTracingExecutionInterceptor implements ExecutionIntercept
   @Override
   public SdkResponse modifyResponse(
       Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
+
+    Span currentSpan = Span.current();
+    AwsSdkRequest sdkRequest = executionAttributes.getAttribute(AWS_SDK_REQUEST_ATTRIBUTE);
+
+    if (sdkRequest != null) {
+      fieldMapper.mapToAttributes(context.response(), sdkRequest, currentSpan);
+      executionAttributes.putAttribute(AWS_SDK_REQUEST_ATTRIBUTE, null);
+    }
 
     return context.response();
   }

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsExperimentalAttributes.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+final class AwsExperimentalAttributes {
+  static final AttributeKey<String> AWS_BUCKET_NAME = stringKey("aws.bucket.name");
+  static final AttributeKey<String> AWS_QUEUE_URL = stringKey("aws.queue.url");
+  static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
+  static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
+  static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
+  static final AttributeKey<String> AWS_GUARDRAIL_ID = stringKey("aws.bedrock.guardrail.id");
+  static final AttributeKey<String> AWS_GUARDRAIL_ARN = stringKey("aws.bedrock.guardrail.arn");
+  static final AttributeKey<String> AWS_AGENT_ID = stringKey("aws.bedrock.agent.id");
+  static final AttributeKey<String> AWS_DATA_SOURCE_ID = stringKey("aws.bedrock.data_source.id");
+  static final AttributeKey<String> AWS_KNOWLEDGE_BASE_ID =
+      stringKey("aws.bedrock.knowledge_base.id");
+
+  // TODO: Merge in gen_ai attributes in opentelemetry-semconv-incubating once upgrade to v1.26.0
+  static final AttributeKey<String> GEN_AI_MODEL = stringKey("gen_ai.request.model");
+  static final AttributeKey<String> GEN_AI_SYSTEM = stringKey("gen_ai.system");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_MAX_TOKENS =
+      stringKey("gen_ai.request.max_tokens");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_TEMPERATURE =
+      stringKey("gen_ai.request.temperature");
+
+  static final AttributeKey<String> GEN_AI_REQUEST_TOP_P = stringKey("gen_ai.request.top_p");
+
+  static final AttributeKey<String> GEN_AI_RESPONSE_FINISH_REASONS =
+      stringKey("gen_ai.response.finish_reasons");
+
+  static final AttributeKey<String> GEN_AI_USAGE_INPUT_TOKENS =
+      stringKey("gen_ai.usage.input_tokens");
+
+  static final AttributeKey<String> GEN_AI_USAGE_OUTPUT_TOKENS =
+      stringKey("gen_ai.usage.output_tokens");
+
+  static final AttributeKey<String> AWS_STATE_MACHINE_ARN =
+      stringKey("aws.stepfunctions.state_machine.arn");
+
+  static final AttributeKey<String> AWS_STEP_FUNCTIONS_ACTIVITY_ARN =
+      stringKey("aws.stepfunctions.activity.arn");
+
+  static final AttributeKey<String> AWS_SNS_TOPIC_ARN = stringKey("aws.sns.topic.arn");
+
+  static final AttributeKey<String> AWS_SECRET_ARN = stringKey("aws.secretsmanager.secret.arn");
+
+  static final AttributeKey<String> AWS_LAMBDA_NAME = stringKey("aws.lambda.function.name");
+
+  static final AttributeKey<String> AWS_LAMBDA_ARN = stringKey("aws.lambda.function.arn");
+
+  static final AttributeKey<String> AWS_LAMBDA_RESOURCE_ID =
+      stringKey("aws.lambda.resource_mapping.id");
+
+  static boolean isGenAiAttribute(String attributeKey) {
+    return attributeKey.equals(GEN_AI_REQUEST_MAX_TOKENS.getKey())
+        || attributeKey.equals(GEN_AI_REQUEST_TEMPERATURE.getKey())
+        || attributeKey.equals(GEN_AI_REQUEST_TOP_P.getKey())
+        || attributeKey.equals(GEN_AI_RESPONSE_FINISH_REASONS.getKey())
+        || attributeKey.equals(GEN_AI_USAGE_INPUT_TOKENS.getKey())
+        || attributeKey.equals(GEN_AI_USAGE_OUTPUT_TOKENS.getKey());
+  }
+
+  private AwsExperimentalAttributes() {}
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsJsonProtocolFactoryAccess.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsJsonProtocolFactoryAccess.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Source: https://github.com/open-telemetry/opentelemetry-java-instrumentation
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.net.URI;
+import javax.annotation.Nullable;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.protocols.core.OperationInfo;
+import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
+
+final class AwsJsonProtocolFactoryAccess {
+
+  private static final OperationInfo OPERATION_INFO =
+      OperationInfo.builder().hasPayloadMembers(true).httpMethod(SdkHttpMethod.POST).build();
+
+  @Nullable private static final MethodHandle INVOKE_CREATE_PROTOCOL_MARSHALLER;
+
+  static {
+    MethodHandle invokeCreateProtocolMarshaller = null;
+    try {
+      Class<?> awsJsonProtocolFactoryClass =
+          Class.forName("software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory");
+      Object awsJsonProtocolFactoryBuilder =
+          awsJsonProtocolFactoryClass.getMethod("builder").invoke(null);
+      awsJsonProtocolFactoryBuilder
+          .getClass()
+          .getMethod("clientConfiguration", SdkClientConfiguration.class)
+          .invoke(
+              awsJsonProtocolFactoryBuilder,
+              SdkClientConfiguration.builder()
+                  // AwsJsonProtocolFactory requires any URI to be present
+                  .option(SdkClientOption.ENDPOINT, URI.create("http://empty"))
+                  .build());
+      @SuppressWarnings("rawtypes")
+      Class awsJsonProtocolClass =
+          Class.forName("software.amazon.awssdk.protocols.json.AwsJsonProtocol");
+      @SuppressWarnings("unchecked")
+      Object awsJsonProtocol = Enum.valueOf(awsJsonProtocolClass, "AWS_JSON");
+      awsJsonProtocolFactoryBuilder
+          .getClass()
+          .getMethod("protocol", awsJsonProtocolClass)
+          .invoke(awsJsonProtocolFactoryBuilder, awsJsonProtocol);
+      Object awsJsonProtocolFactory =
+          awsJsonProtocolFactoryBuilder
+              .getClass()
+              .getMethod("build")
+              .invoke(awsJsonProtocolFactoryBuilder);
+
+      MethodHandle createProtocolMarshaller =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  awsJsonProtocolFactoryClass,
+                  "createProtocolMarshaller",
+                  MethodType.methodType(ProtocolMarshaller.class, OperationInfo.class));
+      invokeCreateProtocolMarshaller =
+          createProtocolMarshaller.bindTo(awsJsonProtocolFactory).bindTo(OPERATION_INFO);
+    } catch (Throwable t) {
+      // Ignore;
+    }
+    INVOKE_CREATE_PROTOCOL_MARSHALLER = invokeCreateProtocolMarshaller;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Nullable
+  static ProtocolMarshaller<SdkHttpFullRequest> createMarshaller() {
+    if (INVOKE_CREATE_PROTOCOL_MARSHALLER == null) {
+      return null;
+    }
+
+    try {
+      return (ProtocolMarshaller<SdkHttpFullRequest>) INVOKE_CREATE_PROTOCOL_MARSHALLER.invoke();
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private AwsJsonProtocolFactoryAccess() {}
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkRequest.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkRequest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCK;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCKAGENTOPERATION;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCKAGENTRUNTIMEOPERATION;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCKDATASOURCEOPERATION;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCKKNOWLEDGEBASEOPERATION;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.BEDROCKRUNTIME;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.DYNAMODB;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.KINESIS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.LAMBDA;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.S3;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.SECRETSMANAGER;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.SNS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.SQS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsSdkRequestType.STEPFUNCTION;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.FieldMapping.request;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import software.amazon.awssdk.core.SdkRequest;
+
+@SuppressWarnings("MemberName")
+enum AwsSdkRequest {
+  // generic requests
+  DynamoDbRequest(DYNAMODB, "DynamoDbRequest"),
+  S3Request(S3, "S3Request"),
+  SnsRequest(SNS, "SnsRequest"),
+  SqsRequest(SQS, "SqsRequest"),
+  KinesisRequest(KINESIS, "KinesisRequest"),
+
+  BedrockRequest(BEDROCK, "BedrockRequest"),
+  BedrockAgentRuntimeRequest(BEDROCKAGENTRUNTIMEOPERATION, "BedrockAgentRuntimeRequest"),
+  BedrockRuntimeRequest(BEDROCKRUNTIME, "BedrockRuntimeRequest"),
+  // BedrockAgent API based requests. We only support operations that are related to
+  // Agent/DataSources/KnowledgeBases
+  // resources and the request/response context contains the resource ID.
+  BedrockCreateAgentActionGroupRequest(BEDROCKAGENTOPERATION, "CreateAgentActionGroupRequest"),
+  BedrockCreateAgentAliasRequest(BEDROCKAGENTOPERATION, "CreateAgentAliasRequest"),
+  BedrockDeleteAgentActionGroupRequest(BEDROCKAGENTOPERATION, "DeleteAgentActionGroupRequest"),
+  BedrockDeleteAgentAliasRequest(BEDROCKAGENTOPERATION, "DeleteAgentAliasRequest"),
+  BedrockDeleteAgentVersionRequest(BEDROCKAGENTOPERATION, "DeleteAgentVersionRequest"),
+  BedrockGetAgentActionGroupRequest(BEDROCKAGENTOPERATION, "GetAgentActionGroupRequest"),
+  BedrockGetAgentAliasRequest(BEDROCKAGENTOPERATION, "GetAgentAliasRequest"),
+  BedrockGetAgentRequest(BEDROCKAGENTOPERATION, "GetAgentRequest"),
+  BedrockGetAgentVersionRequest(BEDROCKAGENTOPERATION, "GetAgentVersionRequest"),
+  BedrockListAgentActionGroupsRequest(BEDROCKAGENTOPERATION, "ListAgentActionGroupsRequest"),
+  BedrockListAgentAliasesRequest(BEDROCKAGENTOPERATION, "ListAgentAliasesRequest"),
+  BedrockListAgentKnowledgeBasesRequest(BEDROCKAGENTOPERATION, "ListAgentKnowledgeBasesRequest"),
+  BedrocListAgentVersionsRequest(BEDROCKAGENTOPERATION, "ListAgentVersionsRequest"),
+  BedrockPrepareAgentRequest(BEDROCKAGENTOPERATION, "PrepareAgentRequest"),
+  BedrockUpdateAgentActionGroupRequest(BEDROCKAGENTOPERATION, "UpdateAgentActionGroupRequest"),
+  BedrockUpdateAgentAliasRequest(BEDROCKAGENTOPERATION, "UpdateAgentAliasRequest"),
+  BedrockUpdateAgentRequest(BEDROCKAGENTOPERATION, "UpdateAgentRequest"),
+  BedrockBedrockAgentRequest(BEDROCKAGENTOPERATION, "BedrockAgentRequest"),
+  BedrockDeleteDataSourceRequest(BEDROCKDATASOURCEOPERATION, "DeleteDataSourceRequest"),
+  BedrockGetDataSourceRequest(BEDROCKDATASOURCEOPERATION, "GetDataSourceRequest"),
+  BedrockUpdateDataSourceRequest(BEDROCKDATASOURCEOPERATION, "UpdateDataSourceRequest"),
+  BedrocAssociateAgentKnowledgeBaseRequest(
+      BEDROCKKNOWLEDGEBASEOPERATION, "AssociateAgentKnowledgeBaseRequest"),
+  BedrockCreateDataSourceRequest(BEDROCKKNOWLEDGEBASEOPERATION, "CreateDataSourceRequest"),
+  BedrockDeleteKnowledgeBaseRequest(BEDROCKKNOWLEDGEBASEOPERATION, "DeleteKnowledgeBaseRequest"),
+  BedrockDisassociateAgentKnowledgeBaseRequest(
+      BEDROCKKNOWLEDGEBASEOPERATION, "DisassociateAgentKnowledgeBaseRequest"),
+  BedrockGetAgentKnowledgeBaseRequest(
+      BEDROCKKNOWLEDGEBASEOPERATION, "GetAgentKnowledgeBaseRequest"),
+  BedrockGetKnowledgeBaseRequest(BEDROCKKNOWLEDGEBASEOPERATION, "GetKnowledgeBaseRequest"),
+  BedrockListDataSourcesRequest(BEDROCKKNOWLEDGEBASEOPERATION, "ListDataSourcesRequest"),
+  BedrockUpdateAgentKnowledgeBaseRequest(
+      BEDROCKKNOWLEDGEBASEOPERATION, "UpdateAgentKnowledgeBaseRequest"),
+
+  SfnRequest(STEPFUNCTION, "SfnRequest"),
+
+  SecretsManagerRequest(SECRETSMANAGER, "SecretsManagerRequest"),
+
+  LambdaRequest(LAMBDA, "LambdaRequest");
+
+  private final AwsSdkRequestType type;
+  private final String requestClass;
+
+  // Wrap in unmodifiableMap
+  @SuppressWarnings("ImmutableEnumChecker")
+  private final Map<FieldMapping.Type, List<FieldMapping>> fields;
+
+  AwsSdkRequest(AwsSdkRequestType type, String requestClass, FieldMapping... fields) {
+    this.type = type;
+    this.requestClass = requestClass;
+    this.fields = Collections.unmodifiableMap(FieldMapping.groupByType(fields));
+  }
+
+  @Nullable
+  static AwsSdkRequest ofSdkRequest(SdkRequest request) {
+    // try request type
+    AwsSdkRequest result = ofType(request.getClass().getSimpleName());
+    // try parent - generic
+    if (result == null) {
+      result = ofType(request.getClass().getSuperclass().getSimpleName());
+    }
+    return result;
+  }
+
+  private static AwsSdkRequest ofType(String typeName) {
+    for (AwsSdkRequest type : values()) {
+      if (type.requestClass.equals(typeName)) {
+        return type;
+      }
+    }
+    return null;
+  }
+
+  List<FieldMapping> fields(FieldMapping.Type type) {
+    return fields.get(type);
+  }
+
+  AwsSdkRequestType type() {
+    return type;
+  }
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkRequestType.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_AGENT_ID;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_BUCKET_NAME;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_DATA_SOURCE_ID;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ARN;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_KNOWLEDGE_BASE_ID;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_LAMBDA_ARN;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_LAMBDA_RESOURCE_ID;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_QUEUE_NAME;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_QUEUE_URL;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_SECRET_ARN;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STREAM_NAME;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_TABLE_NAME;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_MODEL;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TEMPERATURE;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TOP_P;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_USAGE_INPUT_TOKENS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.FieldMapping.request;
+import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.FieldMapping.response;
+
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+enum AwsSdkRequestType {
+  S3(request(AWS_BUCKET_NAME.getKey(), "Bucket")),
+
+  SQS(request(AWS_QUEUE_URL.getKey(), "QueueUrl"), request(AWS_QUEUE_NAME.getKey(), "QueueName")),
+
+  KINESIS(request(AWS_STREAM_NAME.getKey(), "StreamName")),
+
+  DYNAMODB(request(AWS_TABLE_NAME.getKey(), "TableName")),
+
+  SNS(
+      /*
+       * Only one of TopicArn and TargetArn are permitted on an SNS request.
+       */
+      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TargetArn"),
+      request(AttributeKeys.MESSAGING_DESTINATION_NAME.getKey(), "TopicArn"),
+      request(AWS_SNS_TOPIC_ARN.getKey(), "TopicArn")),
+
+  BEDROCK(
+      request(AWS_GUARDRAIL_ID.getKey(), "guardrailIdentifier"),
+      response(AWS_GUARDRAIL_ARN.getKey(), "guardrailArn")),
+  BEDROCKAGENTOPERATION(
+      request(AWS_AGENT_ID.getKey(), "agentId"), response(AWS_AGENT_ID.getKey(), "agentId")),
+  BEDROCKAGENTRUNTIMEOPERATION(
+      request(AWS_AGENT_ID.getKey(), "agentId"),
+      response(AWS_AGENT_ID.getKey(), "agentId"),
+      request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),
+      response(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId")),
+  BEDROCKDATASOURCEOPERATION(
+      request(AWS_DATA_SOURCE_ID.getKey(), "dataSourceId"),
+      response(AWS_DATA_SOURCE_ID.getKey(), "dataSourceId")),
+  BEDROCKKNOWLEDGEBASEOPERATION(
+      request(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId"),
+      response(AWS_KNOWLEDGE_BASE_ID.getKey(), "knowledgeBaseId")),
+  BEDROCKRUNTIME(
+      request(GEN_AI_MODEL.getKey(), "modelId"),
+      request(GEN_AI_REQUEST_MAX_TOKENS.getKey(), "body"),
+      request(GEN_AI_REQUEST_TEMPERATURE.getKey(), "body"),
+      request(GEN_AI_REQUEST_TOP_P.getKey(), "body"),
+      request(GEN_AI_USAGE_INPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_RESPONSE_FINISH_REASONS.getKey(), "body"),
+      response(GEN_AI_USAGE_INPUT_TOKENS.getKey(), "body"),
+      response(GEN_AI_USAGE_OUTPUT_TOKENS.getKey(), "body")),
+
+  STEPFUNCTION(
+      request(AWS_STATE_MACHINE_ARN.getKey(), "stateMachineArn"),
+      request(AWS_STEP_FUNCTIONS_ACTIVITY_ARN.getKey(), "activityArn")),
+
+  SECRETSMANAGER(response(AWS_SECRET_ARN.getKey(), "ARN")),
+
+  LAMBDA(
+      request(AWS_LAMBDA_NAME.getKey(), "FunctionName"),
+      request(AWS_LAMBDA_RESOURCE_ID.getKey(), "UUID"),
+      response(AWS_LAMBDA_ARN.getKey(), "Configuration.FunctionArn"));
+
+  // Copied form OTel aws-sdk
+  @SuppressWarnings("ImmutableEnumChecker")
+  private final Map<FieldMapping.Type, List<FieldMapping>> fields;
+
+  AwsSdkRequestType(FieldMapping... fieldMappings) {
+    this.fields = Collections.unmodifiableMap(FieldMapping.groupByType(fieldMappings));
+  }
+
+  List<FieldMapping> fields(FieldMapping.Type type) {
+    return fields.get(type);
+  }
+
+  private static class AttributeKeys {
+    // copied from MessagingIncubatingAttributes
+    static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+        AttributeKey.stringKey("messaging.destination.name");
+  }
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/BedrockJsonParser.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/BedrockJsonParser.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class BedrockJsonParser {
+
+  // Prevent instantiation
+  private BedrockJsonParser() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static LlmJson parse(String jsonString) {
+    JsonParser parser = new JsonParser(jsonString);
+    Map<String, Object> jsonBody = parser.parse();
+    return new LlmJson(jsonBody);
+  }
+
+  static class JsonParser {
+    private final String json;
+    private int position;
+
+    public JsonParser(String json) {
+      this.json = json.trim();
+      this.position = 0;
+    }
+
+    private void skipWhitespace() {
+      while (position < json.length() && Character.isWhitespace(json.charAt(position))) {
+        position++;
+      }
+    }
+
+    private char currentChar() {
+      return json.charAt(position);
+    }
+
+    private static boolean isHexDigit(char c) {
+      return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+    }
+
+    private void expect(char c) {
+      skipWhitespace();
+      if (currentChar() != c) {
+        throw new IllegalArgumentException(
+            "Expected '" + c + "' but found '" + currentChar() + "'");
+      }
+      position++;
+    }
+
+    private String readString() {
+      skipWhitespace();
+      expect('"'); // Ensure the string starts with a quote
+      StringBuilder result = new StringBuilder();
+      while (currentChar() != '"') {
+        // Handle escape sequences
+        if (currentChar() == '\\') {
+          position++; // Move past the backslash
+          if (position >= json.length()) {
+            throw new IllegalArgumentException("Unexpected end of input in string escape sequence");
+          }
+          char escapeChar = currentChar();
+          switch (escapeChar) {
+            case '"':
+            case '\\':
+            case '/':
+              result.append(escapeChar);
+              break;
+            case 'b':
+              result.append('\b');
+              break;
+            case 'f':
+              result.append('\f');
+              break;
+            case 'n':
+              result.append('\n');
+              break;
+            case 'r':
+              result.append('\r');
+              break;
+            case 't':
+              result.append('\t');
+              break;
+            case 'u': // Unicode escape sequence
+              if (position + 4 >= json.length()) {
+                throw new IllegalArgumentException("Invalid unicode escape sequence in string");
+              }
+              char[] hexChars = new char[4];
+              for (int i = 0; i < 4; i++) {
+                position++; // Move to the next character
+                char hexChar = json.charAt(position);
+                if (!isHexDigit(hexChar)) {
+                  throw new IllegalArgumentException(
+                      "Invalid hexadecimal digit in unicode escape sequence");
+                }
+                hexChars[i] = hexChar;
+              }
+              int unicodeValue = Integer.parseInt(new String(hexChars), 16);
+              result.append((char) unicodeValue);
+              break;
+            default:
+              throw new IllegalArgumentException("Invalid escape character: \\" + escapeChar);
+          }
+          position++;
+        } else {
+          result.append(currentChar());
+          position++;
+        }
+      }
+      position++; // Skip closing quote
+      return result.toString();
+    }
+
+    private Object readValue() {
+      skipWhitespace();
+      char c = currentChar();
+
+      if (c == '"') {
+        return readString();
+      } else if (Character.isDigit(c)) {
+        return readScopedNumber();
+      } else if (c == '{') {
+        return readObject(); // JSON Objects
+      } else if (c == '[') {
+        return readArray(); // JSON Arrays
+      } else if (json.startsWith("true", position)) {
+        position += 4;
+        return true;
+      } else if (json.startsWith("false", position)) {
+        position += 5;
+        return false;
+      } else if (json.startsWith("null", position)) {
+        position += 4;
+        return null; // JSON null
+      } else {
+        throw new IllegalArgumentException("Unexpected character: " + c);
+      }
+    }
+
+    private Number readScopedNumber() {
+      int start = position;
+
+      // Consume digits and the optional decimal point
+      while (position < json.length()
+          && (Character.isDigit(json.charAt(position)) || json.charAt(position) == '.')) {
+        position++;
+      }
+
+      String number = json.substring(start, position);
+
+      if (number.contains(".")) {
+        double value = Double.parseDouble(number);
+        if (value < 0.0 || value > 1.0) {
+          throw new IllegalArgumentException(
+              "Value out of bounds for Bedrock Floating Point Attribute: " + number);
+        }
+        return value;
+      } else {
+        return Integer.parseInt(number);
+      }
+    }
+
+    private Map<String, Object> readObject() {
+      Map<String, Object> map = new HashMap<>();
+      expect('{');
+      skipWhitespace();
+      while (currentChar() != '}') {
+        String key = readString();
+        expect(':');
+        Object value = readValue();
+        map.put(key, value);
+        skipWhitespace();
+        if (currentChar() == ',') {
+          position++;
+        }
+      }
+      position++; // Skip closing brace
+      return map;
+    }
+
+    private List<Object> readArray() {
+      List<Object> list = new ArrayList<>();
+      expect('[');
+      skipWhitespace();
+      while (currentChar() != ']') {
+        list.add(readValue());
+        skipWhitespace();
+        if (currentChar() == ',') {
+          position++;
+        }
+      }
+      position++;
+      return list;
+    }
+
+    public Map<String, Object> parse() {
+      return readObject();
+    }
+  }
+
+  // Resolves paths in a JSON structure
+  static class JsonPathResolver {
+
+    // Private constructor to prevent instantiation
+    private JsonPathResolver() {
+      throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static Object resolvePath(LlmJson llmJson, String... paths) {
+      for (String path : paths) {
+        Object value = resolvePath(llmJson.getJsonBody(), path);
+        if (value != null) {
+          return value;
+        }
+      }
+      return null;
+    }
+
+    private static Object resolvePath(Map<String, Object> json, String path) {
+      String[] keys = path.split("/");
+      Object current = json;
+
+      for (String key : keys) {
+        if (key.isEmpty()) {
+          continue;
+        }
+
+        if (current instanceof Map) {
+          current = ((Map<?, ?>) current).get(key);
+        } else if (current instanceof List) {
+          try {
+            int index = Integer.parseInt(key);
+            current = ((List<?>) current).get(index);
+          } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            return null;
+          }
+        } else {
+          return null;
+        }
+
+        if (current == null) {
+          return null;
+        }
+      }
+      return current;
+    }
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static class LlmJson {
+    private final Map<String, Object> jsonBody;
+
+    public LlmJson(Map<String, Object> jsonBody) {
+      this.jsonBody = jsonBody;
+    }
+
+    public Map<String, Object> getJsonBody() {
+      return jsonBody;
+    }
+  }
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/FieldMapper.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/FieldMapper.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+import io.opentelemetry.api.trace.Span;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.utils.StringUtils;
+
+class FieldMapper {
+
+  private final Serializer serializer;
+  private final MethodHandleFactory methodHandleFactory;
+
+  FieldMapper() {
+    serializer = new Serializer();
+    methodHandleFactory = new MethodHandleFactory();
+  }
+
+  FieldMapper(Serializer serializer, MethodHandleFactory methodHandleFactory) {
+    this.methodHandleFactory = methodHandleFactory;
+    this.serializer = serializer;
+  }
+
+  void mapToAttributes(SdkRequest sdkRequest, AwsSdkRequest request, Span span) {
+    mapToAttributes(
+        field -> sdkRequest.getValueForField(field, Object.class).orElse(null),
+        FieldMapping.Type.REQUEST,
+        request,
+        span);
+  }
+
+  void mapToAttributes(SdkResponse sdkResponse, AwsSdkRequest request, Span span) {
+    mapToAttributes(
+        field -> sdkResponse.getValueForField(field, Object.class).orElse(null),
+        FieldMapping.Type.RESPONSE,
+        request,
+        span);
+  }
+
+  private void mapToAttributes(
+      Function<String, Object> fieldValueProvider,
+      FieldMapping.Type type,
+      AwsSdkRequest request,
+      Span span) {
+    for (FieldMapping fieldMapping : request.fields(type)) {
+      mapToAttributes(fieldValueProvider, fieldMapping, span);
+    }
+    for (FieldMapping fieldMapping : request.type().fields(type)) {
+      mapToAttributes(fieldValueProvider, fieldMapping, span);
+    }
+  }
+
+  // Contains patching logic
+  private void mapToAttributes(
+      Function<String, Object> fieldValueProvider, FieldMapping fieldMapping, Span span) {
+    // traverse path
+    List<String> path = fieldMapping.getFields();
+    Object target = fieldValueProvider.apply(path.get(0));
+    for (int i = 1; i < path.size() && target != null; i++) {
+      target = next(target, path.get(i));
+    }
+    String value;
+    if (target != null) {
+      if (AwsExperimentalAttributes.isGenAiAttribute(fieldMapping.getAttribute())) {
+        value = serializer.serialize(fieldMapping.getAttribute(), target);
+      } else {
+        value = serializer.serialize(target);
+      }
+      if (!StringUtils.isEmpty(value)) {
+        span.setAttribute(fieldMapping.getAttribute(), value);
+      }
+    }
+  }
+
+  @Nullable
+  private Object next(Object current, String fieldName) {
+    try {
+      return methodHandleFactory.forField(current.getClass(), fieldName).invoke(current);
+    } catch (Throwable t) {
+      // ignore
+    }
+    return null;
+  }
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/FieldMapping.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/FieldMapping.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Source: https://github.com/open-telemetry/opentelemetry-java-instrumentation
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+class FieldMapping {
+
+  enum Type {
+    REQUEST,
+    RESPONSE
+  }
+
+  private final Type type;
+  private final String attribute;
+  private final List<String> fields;
+
+  static FieldMapping request(String attribute, String fieldPath) {
+    return new FieldMapping(Type.REQUEST, attribute, fieldPath);
+  }
+
+  static FieldMapping response(String attribute, String fieldPath) {
+    return new FieldMapping(Type.RESPONSE, attribute, fieldPath);
+  }
+
+  FieldMapping(Type type, String attribute, String fieldPath) {
+    this.type = type;
+    this.attribute = attribute;
+    this.fields = Collections.unmodifiableList(Arrays.asList(fieldPath.split("\\.")));
+  }
+
+  String getAttribute() {
+    return attribute;
+  }
+
+  List<String> getFields() {
+    return fields;
+  }
+
+  Type getType() {
+    return type;
+  }
+
+  static Map<Type, List<FieldMapping>> groupByType(FieldMapping[] fieldMappings) {
+
+    EnumMap<Type, List<FieldMapping>> fields = new EnumMap<>(Type.class);
+    for (FieldMapping.Type type : FieldMapping.Type.values()) {
+      fields.put(type, new ArrayList<>());
+    }
+    for (FieldMapping fieldMapping : fieldMappings) {
+      fields.get(fieldMapping.getType()).add(fieldMapping);
+    }
+    return fields;
+  }
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/MethodHandleFactory.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/MethodHandleFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Source: https://github.com/open-telemetry/opentelemetry-java-instrumentation
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+
+class MethodHandleFactory {
+
+  private static String unCapitalize(String string) {
+    return string.substring(0, 1).toLowerCase(Locale.ROOT) + string.substring(1);
+  }
+
+  private final ClassValue<ConcurrentHashMap<String, MethodHandle>> getterCache =
+      new ClassValue<ConcurrentHashMap<String, MethodHandle>>() {
+        @Override
+        protected ConcurrentHashMap<String, MethodHandle> computeValue(Class<?> type) {
+          return new ConcurrentHashMap<>();
+        }
+      };
+
+  MethodHandle forField(Class<?> clazz, String fieldName)
+      throws NoSuchMethodException, IllegalAccessException {
+    MethodHandle methodHandle = getterCache.get(clazz).get(fieldName);
+    if (methodHandle == null) {
+      // getter in AWS SDK is lowercased field name
+      methodHandle =
+          MethodHandles.publicLookup().unreflect(clazz.getMethod(unCapitalize(fieldName)));
+      getterCache.get(clazz).put(fieldName, methodHandle);
+    }
+    return methodHandle;
+  }
+}

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/Serializer.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/Serializer.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.StringUtils;
+
+class Serializer {
+
+  @Nullable
+  String serialize(Object target) {
+
+    if (target == null) {
+      return null;
+    }
+
+    if (target instanceof SdkPojo) {
+      return serialize((SdkPojo) target);
+    }
+
+    if (target instanceof Collection) {
+      return serialize((Collection<?>) target);
+    }
+    if (target instanceof Map) {
+      return serialize(((Map<?, ?>) target).keySet());
+    }
+    // simple type
+    return target.toString();
+  }
+
+  @Nullable
+  String serialize(String attributeName, Object target) {
+    try {
+      // Extract JSON string from target if it is a Bedrock Runtime JSON blob
+      String jsonString;
+      if (target instanceof SdkBytes) {
+        jsonString = ((SdkBytes) target).asUtf8String();
+      } else {
+        if (target != null) {
+          return target.toString();
+        }
+        return null;
+      }
+
+      // Parse the LLM JSON string into a Map
+      BedrockJsonParser.LlmJson llmJson = BedrockJsonParser.parse(jsonString);
+
+      // Use attribute name to extract the corresponding value
+      switch (attributeName) {
+        case "gen_ai.request.max_tokens":
+          return getMaxTokens(llmJson);
+        case "gen_ai.request.temperature":
+          return getTemperature(llmJson);
+        case "gen_ai.request.top_p":
+          return getTopP(llmJson);
+        case "gen_ai.response.finish_reasons":
+          return getFinishReasons(llmJson);
+        case "gen_ai.usage.input_tokens":
+          return getInputTokens(llmJson);
+        case "gen_ai.usage.output_tokens":
+          return getOutputTokens(llmJson);
+        default:
+          return null;
+      }
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  private static String serialize(SdkPojo sdkPojo) {
+    ProtocolMarshaller<SdkHttpFullRequest> marshaller =
+        AwsJsonProtocolFactoryAccess.createMarshaller();
+    if (marshaller == null) {
+      return null;
+    }
+    Optional<ContentStreamProvider> optional = marshaller.marshall(sdkPojo).contentStreamProvider();
+    return optional
+        .map(
+            csp -> {
+              try (InputStream cspIs = csp.newStream()) {
+                return IoUtils.toUtf8String(cspIs);
+              } catch (IOException e) {
+                return null;
+              }
+            })
+        .orElse(null);
+  }
+
+  private String serialize(Collection<?> collection) {
+    String serialized = collection.stream().map(this::serialize).collect(Collectors.joining(","));
+    return (StringUtils.isEmpty(serialized) ? null : "[" + serialized + "]");
+  }
+
+  @Nullable
+  private static String approximateTokenCount(
+      BedrockJsonParser.LlmJson jsonBody, String... textPaths) {
+    return Arrays.stream(textPaths)
+        .map(
+            path -> {
+              Object value = BedrockJsonParser.JsonPathResolver.resolvePath(jsonBody, path);
+              if (value instanceof String) {
+                int tokenEstimate = (int) Math.ceil(((String) value).length() / 6.0);
+                return Integer.toString(tokenEstimate);
+              }
+              return null;
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  // Model -> Path Mapping:
+  // Amazon Nova -> "/inferenceConfig/max_new_tokens"
+  // Amazon Titan -> "/textGenerationConfig/maxTokenCount"
+  // Anthropic Claude -> "/max_tokens"
+  // Cohere Command -> "/max_tokens"
+  // Cohere Command R -> "/max_tokens"
+  // AI21 Jamba -> "/max_tokens"
+  // Meta Llama -> "/max_gen_len"
+  // Mistral AI -> "/max_tokens"
+  @Nullable
+  private static String getMaxTokens(BedrockJsonParser.LlmJson jsonBody) {
+    Object value =
+        BedrockJsonParser.JsonPathResolver.resolvePath(
+            jsonBody,
+            "/max_tokens",
+            "/max_gen_len",
+            "/textGenerationConfig/maxTokenCount",
+            "inferenceConfig/max_new_tokens");
+    return value != null ? String.valueOf(value) : null;
+  }
+
+  // Model -> Path Mapping:
+  // Amazon Nova -> "/inferenceConfig/temperature"
+  // Amazon Titan -> "/textGenerationConfig/temperature"
+  // Anthropic Claude -> "/temperature"
+  // Cohere Command -> "/temperature"
+  // Cohere Command R -> "/temperature"
+  // AI21 Jamba -> "/temperature"
+  // Meta Llama -> "/temperature"
+  // Mistral AI -> "/temperature"
+  @Nullable
+  private static String getTemperature(BedrockJsonParser.LlmJson jsonBody) {
+    Object value =
+        BedrockJsonParser.JsonPathResolver.resolvePath(
+            jsonBody,
+            "/temperature",
+            "/textGenerationConfig/temperature",
+            "/inferenceConfig/temperature");
+    return value != null ? String.valueOf(value) : null;
+  }
+
+  // Model -> Path Mapping:
+  // Amazon Nova -> "/inferenceConfig/top_p"
+  // Amazon Titan -> "/textGenerationConfig/topP"
+  // Anthropic Claude -> "/top_p"
+  // Cohere Command -> "/p"
+  // Cohere Command R -> "/p"
+  // AI21 Jamba -> "/top_p"
+  // Meta Llama -> "/top_p"
+  // Mistral AI -> "/top_p"
+  @Nullable
+  private static String getTopP(BedrockJsonParser.LlmJson jsonBody) {
+    Object value =
+        BedrockJsonParser.JsonPathResolver.resolvePath(
+            jsonBody, "/top_p", "/p", "/textGenerationConfig/topP", "/inferenceConfig/top_p");
+    return value != null ? String.valueOf(value) : null;
+  }
+
+  // Model -> Path Mapping:
+  // Amazon Nova -> "/stopReason"
+  // Amazon Titan -> "/results/0/completionReason"
+  // Anthropic Claude -> "/stop_reason"
+  // Cohere Command -> "/generations/0/finish_reason"
+  // Cohere Command R -> "/finish_reason"
+  // AI21 Jamba -> "/choices/0/finish_reason"
+  // Meta Llama -> "/stop_reason"
+  // Mistral AI -> "/outputs/0/stop_reason"
+  @Nullable
+  private static String getFinishReasons(BedrockJsonParser.LlmJson jsonBody) {
+    Object value =
+        BedrockJsonParser.JsonPathResolver.resolvePath(
+            jsonBody,
+            "/stopReason",
+            "/finish_reason",
+            "/stop_reason",
+            "/results/0/completionReason",
+            "/generations/0/finish_reason",
+            "/choices/0/finish_reason",
+            "/outputs/0/stop_reason");
+
+    return value != null ? "[" + value + "]" : null;
+  }
+
+  // Model -> Path Mapping:
+  // Amazon Nova -> "/usage/inputTokens"
+  // Amazon Titan -> "/inputTextTokenCount"
+  // Anthropic Claude -> "/usage/input_tokens"
+  // Cohere Command -> "/prompt"
+  // Cohere Command R -> "/message"
+  // AI21 Jamba -> "/usage/prompt_tokens"
+  // Meta Llama -> "/prompt_token_count"
+  // Mistral AI -> "/prompt"
+  @Nullable
+  private static String getInputTokens(BedrockJsonParser.LlmJson jsonBody) {
+    // Try direct tokens counts first
+    Object directCount =
+        BedrockJsonParser.JsonPathResolver.resolvePath(
+            jsonBody,
+            "/inputTextTokenCount",
+            "/prompt_token_count",
+            "/usage/input_tokens",
+            "/usage/prompt_tokens",
+            "/usage/inputTokens");
+
+    if (directCount != null) {
+      return String.valueOf(directCount);
+    }
+
+    // Fall back to token approximation
+    Object approxTokenCount = approximateTokenCount(jsonBody, "/prompt", "/message");
+
+    return approxTokenCount != null ? String.valueOf(approxTokenCount) : null;
+  }
+
+  // Model -> Path Mapping:
+  // Amazon Nova -> "/usage/outputTokens"
+  // Amazon Titan -> "/results/0/tokenCount"
+  // Anthropic Claude -> "/usage/output_tokens"
+  // Cohere Command -> "/generations/0/text"
+  // Cohere Command R -> "/text"
+  // AI21 Jamba -> "/usage/completion_tokens"
+  // Meta Llama -> "/generation_token_count"
+  // Mistral AI -> "/outputs/0/text"
+  @Nullable
+  private static String getOutputTokens(BedrockJsonParser.LlmJson jsonBody) {
+    // Try direct token counts first
+    Object directCount =
+        BedrockJsonParser.JsonPathResolver.resolvePath(
+            jsonBody,
+            "/generation_token_count",
+            "/results/0/tokenCount",
+            "/usage/output_tokens",
+            "/usage/completion_tokens",
+            "/usage/outputTokens");
+
+    if (directCount != null) {
+      return String.valueOf(directCount);
+    }
+
+    // Fall back to token approximation
+    Object approxTokenCount = approximateTokenCount(jsonBody, "/text", "/outputs/0/text");
+
+    return approxTokenCount != null ? String.valueOf(approxTokenCount) : null;
+  }
+}

--- a/instrumentation/aws-sdk/src/test/groovy/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/BedrockJsonParserTest.groovy
+++ b/instrumentation/aws-sdk/src/test/groovy/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/BedrockJsonParserTest.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2
+
+import spock.lang.Specification
+
+class BedrockJsonParserTest extends Specification {
+    def "should parse simple JSON object"() {
+        given:
+        String json = '{"key":"value"}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+
+        then:
+        parsedJson.getJsonBody() == [key: "value"]
+    }
+
+    def "should parse nested JSON object"() {
+        given:
+        String json = '{"parent":{"child":"value"}}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+
+        then:
+        def parent = parsedJson.getJsonBody().get("parent")
+        parent instanceof Map
+        parent["child"] == "value"
+    }
+
+    def "should parse JSON array"() {
+        given:
+        String json = '{"array":[1, "two", 1.0]}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+
+        then:
+        def array = parsedJson.getJsonBody().get("array")
+        array instanceof List
+        array == [1, "two", 1.0]
+    }
+
+    def "should parse escape sequences"() {
+        given:
+        String json = '{"escaped":"Line1\\nLine2\\tTabbed\\\"Quoted\\\"\\bBackspace\\fFormfeed\\rCarriageReturn\\\\Backslash\\/Slash\\u0041"}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+
+        then:
+        parsedJson.getJsonBody().get("escaped") ==
+                "Line1\nLine2\tTabbed\"Quoted\"\bBackspace\fFormfeed\rCarriageReturn\\Backslash/SlashA"
+    }
+
+    def "should throw exception for malformed JSON"() {
+        given:
+        String malformedJson = '{"key":value}'
+
+        when:
+        BedrockJsonParser.parse(malformedJson)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("Unexpected character")
+    }
+
+    def "should resolve path in JSON object"() {
+        given:
+        String json = '{"parent":{"child":{"key":"value"}}}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+        def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/parent/child/key")
+
+        then:
+        resolvedValue == "value"
+    }
+
+    def "should resolve path in JSON array"() {
+        given:
+        String json = '{"array":[{"key":"value1"}, {"key":"value2"}]}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+        def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/array/1/key")
+
+        then:
+        resolvedValue == "value2"
+    }
+
+    def "should return null for invalid path resolution"() {
+        given:
+        String json = '{"parent":{"child":{"key":"value"}}}'
+
+        when:
+        def parsedJson = BedrockJsonParser.parse(json)
+        def resolvedValue = BedrockJsonParser.JsonPathResolver.resolvePath(parsedJson, "/invalid/path")
+
+        then:
+        resolvedValue == null
+    }
+}


### PR DESCRIPTION
Note: This is a continuation of #1111

#### Description of Changes
This implementation builds on the foundation established in PR #1111, transforming the structural setup into a fully functional SPI-based solution that will replace our current patching approach. This PR does not change the current ADOT functionality because patches have not been removed.

The next/final PR for v2.2 will remove the patches for aws-sdk-2.2 and have unit tests to ensure correct SPI functionality and behaviour. The final PR will also pass all the contract-tests once patches are removed.

#### Changes include:
- Migration of patched files into proper package structure:
NOTE: We are not copying entire files from upstream. Instead, we only migrated the new components that were added by our patches and the methods that use these AWS-specific components. I deliberately removed any code that was untouched by our patches to avoid duplicating upstream instrumentation code. This selective migration ensures we maintain only our AWS-specific additions while letting OTel handle its base functionality.
   - `AwsExperimentalAttributes` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2167) creates new class
   - `AwsSdkRequest` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2246) on [this otel file](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequest.java)
   - `AwsSdkRequestType` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2324) on [this otel file](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkRequestType.java)
   - `BedrockJsonParser` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2427) creates new class
   - `FieldMapper` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2712) on [this otel file](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/FieldMapper.java)
   - `Serializer` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2731) on [this otel file](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Serializer.java)
   - `BedrockJsonParserTest` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L2996) creates new class
   - `AbstractAws2ClientTest` - [patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch#L3123) on [this otel file](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy)
- Setup of dependent files directly copied from upstream aws-sdk:
  - `MethodHandleFactory` - copy-pasted from [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/MethodHandleFactory.java)
  - `FieldMapping` - copy-pasted from [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/FieldMapping.java)
  - `AwsJsonProtocolFactoryAccess` - copy-pasted from [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/release/v2.11.x/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsJsonProtocolFactoryAccess.java)

The classes we copied from upstream are just helper utilities that make it easier to inject span attributes during instrumentation. They're not core functionality that needs to stay in sync with upstream changes, rather standalone utilities that support our simpler, independent instrumentation without creating version lock-in. They're independent of OTel's core functionality, so we don't face the same version dependency issues we had with patching. We're just following upstream's structure for consistency.

These added files:
- Access and modify span attributes
- Provide consistent formatting tools for span attributes
- Can be updated at our convenience if needed

#### Testing
- Existing functionality verified
- Contract tests passing
- Build successful

#### Related
- Skeleton PR for aws-sdk v2.2: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1111
- Replaces patch: [current patch](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/patches/opentelemetry-java-instrumentation.patch)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
