### PR TITLE
Fix compatibility issue in e2e tests with java v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ Artifacts released will include a `.sha256` file for checksum verification start
 To verify, run the command `shasum -a 256 -c <artifact_name>.sha256` 
 It should return the output `<artifact_name>: OK` if the validation is successful
 
+

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -106,6 +106,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -648,7 +649,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     Optional<String> remoteResourceAccountId = Optional.empty();
     Optional<String> remoteResourceRegion = Optional.empty();
     List<AttributeKey<String>> ARN_ATTRIBUTES =
-        List.of(
+        Arrays.asList(
             AWS_TABLE_ARN,
             AWS_STREAM_ARN,
             AWS_SNS_TOPIC_ARN,


### PR DESCRIPTION
*Description of changes:*
`List.of()` doesn't exist in Java 8. Replaced it with `Arrays.asList()`.

*Test:*
1. Main build: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/16310551913

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
