### PR TITLE
Add version.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ nebulaRelease {
   addReleaseBranchPattern("""v\d+\.\d+\.x""")
 }
 
+apply(from = "version.gradle.kts")
+
 nexusPublishing {
   repositories {
     sonatype {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,0 +1,5 @@
+val adotVersion = "2.11.1-dev0"
+
+allprojects {
+  version = adotVersion
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current version for SDK and Lambda Layer releases is only provided manually in the release workflow and auto-generated by the nebula release plugin based on previous tags, but never specified in the code. Adding a version file will provide explicit version management and make it easier to track upcoming releases. adotVersion is currently set to 2.11.1-dev0, following the convention used by our other ADOT projects ([Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py), [.NET](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs), [NodeJS](https://github.com/aws-observability/aws-otel-js-instrumentation/blob/629faf5d1608e6fd803f9b2c2e15d8c26ff7b40a/package.json#L3)).

Soon we will add pre-release and post-release workflows like the other language ADOT repos to automatically bump the version number. This is part of our work to align the release process for all 4 languages and streamline releases for future engineers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
