### PR TITLE
add version.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ allprojects {
       ktlint("1.4.0").editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2"))
 
       // Doesn't support pluginManagement block
-      targetExclude("settings.gradle.kts")
+      targetExclude("settings.gradle.kts", "version.gradle.kts")
 
       if (!project.path.startsWith(":sample-apps:")) {
         licenseHeaderFile("${rootProject.projectDir}/config/license/header.java", "plugins|include|import")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ nebulaRelease {
   addReleaseBranchPattern("""v\d+\.\d+\.x""")
 }
 
+apply(from = "version.gradle.kts")
+
 nexusPublishing {
   repositories {
     sonatype {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,0 +1,5 @@
+val adotVersion = "2.11.1-dev0"
+
+allprojects {
+  version = adotVersion
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -16,5 +16,9 @@
 val adotVersion = "2.11.1-dev0"
 
 allprojects {
-  version = adotVersion
+  version = if (project.hasProperty("release.version")) {
+    project.property("release.version") as String
+  } else {
+    adotVersion
+  }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 val adotVersion = "2.11.1-dev0"
 
 allprojects {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
(copied from #1121)
The current version for SDK and Lambda Layer releases is only provided manually in the release workflow and auto-generated by the nebula release plugin based on previous tags, but never specified in the code. Adding a version file will provide explicit version management and make it easier to track upcoming releases. adotVersion is currently set to 2.11.1-dev0, following the convention used by our other ADOT projects ([Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py), [.NET](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/Version.cs), [NodeJS](https://github.com/aws-observability/aws-otel-js-instrumentation/blob/629faf5d1608e6fd803f9b2c2e15d8c26ff7b40a/package.json#L3)).

The version provided in version.gradle.kts can still be overridden by release.version for uses cases such as building the lambda layer with the specified ADOT Java version.

Soon we will add pre-release and post-release workflows like the other language ADOT repos to automatically bump the version number. This is part of our work to align the release process for all 4 languages and streamline releases for future engineers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
