### PR TITLE
Add main build validation for release workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -256,6 +256,7 @@ jobs:
           aws s3 cp ./build/distributions/aws-opentelemetry-java-layer.zip s3://adot-main-build-staging-jar/adot-java-lambda-layer-${{ github.run_id }}.zip
 
   application-signals-e2e-test:
+    name: "Application Signals E2E Test"
     needs: [build]
     uses: ./.github/workflows/application-signals-e2e-test.yml
     secrets: inherit

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,7 +20,20 @@ permissions:
   contents: write
 
 jobs:
+  wait-for-main-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for E2E test to succeed
+        uses: ezhang6811/wait-on-check-action@6275ea93847ce5952ab8ceeac8fb1111820cf44d
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Application Signals E2E Test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          allowed-conclusions: success
+
   build:
+    needs: wait-for-main-build
     environment: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR modifies the release build workflow to wait for the E2E test called in the main build workflow to succeed before proceeding. This ensures that the release process is blocked by any unsuccessful tests.

See the https://github.com/aws-observability/aws-otel-js-instrumentation/pull/237 for more context and local testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
