### PR TITLE
Send main build metrics

### DIFF
--- a/.github/workflows/e2e-tests-app-with-java-agent.yml
+++ b/.github/workflows/e2e-tests-app-with-java-agent.yml
@@ -167,18 +167,18 @@ jobs:
           VALIDATOR_COMMAND: -c spark-otel-trace-metric-validation.yml --endpoint http://app:4567 --metric-namespace aws-otel-integ-test -t ${{ github.run_id }}-${{ github.run_number }}
 
   # publish status
-  publish-build-status:
-    needs: [ test_Spring_App_With_Java_Agent, test_Spark_App_With_Java_Agent, test_Spark_AWS_SDK_V1_App_With_Java_Agent ]
-    if: ${{ always() }}
-    uses: ./.github/workflows/publish-status.yml
-    with:
-      namespace: 'ADOT/GitHubActions'
-      repository: ${{ github.repository }}
-      branch: ${{ github.ref_name }}
-      workflow: ${{ inputs.caller-workflow-name }}
-      success: ${{  needs.test_Spring_App_With_Java_Agent.result == 'success'  &&
-                    needs.test_Spark_App_With_Java_Agent.result == 'success'  &&
-                    needs.test_Spark_AWS_SDK_V1_App_With_Java_Agent.result == 'success' }}
-      region: us-east-1
-    secrets:
-      roleArn: ${{ secrets.METRICS_ROLE_ARN }}
+  # publish-build-status:
+  #   needs: [ test_Spring_App_With_Java_Agent, test_Spark_App_With_Java_Agent, test_Spark_AWS_SDK_V1_App_With_Java_Agent ]
+  #   if: ${{ always() }}
+  #   uses: ./.github/workflows/publish-status.yml
+  #   with:
+  #     namespace: 'ADOT/GitHubActions'
+  #     repository: ${{ github.repository }}
+  #     branch: ${{ github.ref_name }}
+  #     workflow: ${{ inputs.caller-workflow-name }}
+  #     success: ${{  needs.test_Spring_App_With_Java_Agent.result == 'success'  &&
+  #                   needs.test_Spark_App_With_Java_Agent.result == 'success'  &&
+  #                   needs.test_Spark_AWS_SDK_V1_App_With_Java_Agent.result == 'success' }}
+  #     region: us-east-1
+  #   secrets:
+  #     roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -265,7 +265,7 @@ jobs:
 
   publish-build-status:
     name: "Publish Main Build Status"
-    needs: [ build, contract-tests, application-signals-e2e-test ]
+    needs: [ build, e2e-test, contract-tests, application-signals-lambda-layer-build, application-signals-e2e-test ]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -277,7 +277,8 @@ jobs:
 
       - name: Publish main build status
         run: |
-          value="${{ needs.build.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
+          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' \
+            && needs.application-signals-lambda-layer-build.result == 'success' && \needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -276,8 +276,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          success="${{ needs.build.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-e2e-test.result == 'success' }}"
-          value="${success}" == "true" && "0.0" || "1.0"
+          value="${{ needs.build.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - "zhaez/*"
 env:
   AWS_DEFAULT_REGION: us-east-1
   STAGING_ECR_REGISTRY: 611364707713.dkr.ecr.us-west-2.amazonaws.com

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - "release/v*"
+      - "zhaez/*"
 env:
   AWS_DEFAULT_REGION: us-east-1
   STAGING_ECR_REGISTRY: 611364707713.dkr.ecr.us-west-2.amazonaws.com

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -263,16 +263,22 @@ jobs:
       adot-image-name: ${{ needs.build.outputs.staging-image }}
 
   publish-build-status:
-    needs: [ build, contract-tests ]
-    if: ${{ always() }}
-    uses: ./.github/workflows/publish-status.yml
-    with:
-      namespace: 'ADOT/GitHubActions'
-      repository: ${{ github.repository }}
-      branch: ${{ github.ref_name }}
-      workflow: main-build
-      success: ${{  needs.build.result == 'success' &&
-                    needs.contract-tests.result == 'success'  }}
-      region: us-east-1
-    secrets:
-      roleArn: ${{ secrets.METRICS_ROLE_ARN }}
+    name: "Publish Main Build Status"
+    needs: [ build, contract-tests, application-signals-e2e-test ]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Configure AWS Credentials for emitting metrics
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.METRICS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Publish main build status
+        run: |
+          success="${{ needs.build.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-e2e-test.result == 'success' }}"
+          value="${success}" == "true" && "0.0" || "1.0"
+          aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Failure \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \
+            --value $value


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Emit a failure metric if main build fails. Since this workflow is triggered with pushes to main or a release branch, we want to be notified if there is a failure with the build process or e2e tests.

Tested by temporarily adding an on: push: trigger to my own branch in this repo and testing the updated workflow. Verified that failure metric was successfully published to cloudwatch.
https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/16783145872

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
