### PR TITLE
Fix YAML syntax error in main-build workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -276,8 +276,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' \
-            && needs.application-signals-lambda-layer-build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
+          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-lambda-layer-build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0' }}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \


### PR DESCRIPTION
*Description of changes:*
Removing problematic backslash which was making the workflow invalid: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/16840663861

Fixed in my branch release/v2.11.2 - https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/16841343395

Reciprocating the same change in main

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
