### PR TITLE
Change scheduled daily scan to run 3 times per day

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -8,8 +8,10 @@
 name: Daily scan
 
 on:
-  schedule:
-    - cron: '0 18 * * *' # scheduled to run at 18:00 UTC every day
+  schedule: # scheduled to run at 14:00, 20:00, 02:00 UTC every day
+    - cron: '0 14 * * *' # 6:00/7:00   PST/PDT (14:00 UTC)
+    - cron: '0 20 * * *' # 12:00/13:00 PST/PDT (20:00 UTC)
+    - cron: '0 02 * * *' # 18:00/19:00 PST/PDT (02:00 UTC)
   workflow_dispatch: # be able to run the workflow on demand
 
 env:


### PR DESCRIPTION
*Description of changes:*

Daily Scan failure metrics often show up for one day and are back to normal 24 hours later. The workflow error for these failures is always some timeout/transient issue that goes away if the workflow is manually re-run. We want to try to avoid alarming on these failures while catching actual, repeated failures.

Moving the cadence of the daily scan to run 3 times per day with 6-hour intervals: 02:00, 14:00, 20:00 UTC times. 
This is in case the failure isn't transitive, we want to avoid alarming during unreasonable PST/PDT hours.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
