### PR TITLE
Add docker login for daily scan workflow image scanning

### DIFF
--- a/.github/actions/image_scan/action.yml
+++ b/.github/actions/image_scan/action.yml
@@ -11,6 +11,9 @@ inputs:
   severity:
     required: true
     description: "List of severities that will cause a failure"
+  logout:
+    required: true
+    description: "Whether to logout of public AWS ECR"
 
 runs:
   using: "composite"
@@ -22,6 +25,7 @@ runs:
     # ensure we can make unauthenticated call. This is important for making the pr_build workflow run on
     # PRs created from forked repos.
     - name: Logout of public AWS ECR
+      if: inputs.logout == 'true'
       shell: bash
       run: docker logout public.ecr.aws
 

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -76,6 +76,17 @@ jobs:
         if: ${{ steps.dep_scan.outcome != 'success' }}
         run: less dependency-check-report.html
 
+      - name: Configure AWS credentials for image scan
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Login to Public ECR
+        uses: docker/login-action@v3
+        with:
+          registry: public.ecr.aws
+
       - name: Perform high image scan on v1
         if: always()
         id: high_scan_v1
@@ -83,6 +94,7 @@ jobs:
         with:
           image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.33.0"
           severity: 'CRITICAL,HIGH'
+          logout: 'false'
 
       - name: Perform low image scan on v1
         if: always()
@@ -91,6 +103,7 @@ jobs:
         with:
           image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.33.0"
           severity: 'MEDIUM,LOW,UNKNOWN'
+          logout: 'false'
 
       - name: Perform high image scan on v2
         if: always()
@@ -99,6 +112,7 @@ jobs:
         with:
           image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.11.1"
           severity: 'CRITICAL,HIGH'
+          logout: 'false'
 
       - name: Perform low image scan on v2
         if: always()
@@ -107,6 +121,7 @@ jobs:
         with:
           image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.11.1"
           severity: 'MEDIUM,LOW,UNKNOWN'
+          logout: 'false'
 
       - name: Configure AWS Credentials for emitting metrics
         if: always()

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -147,6 +147,7 @@ jobs:
         with:
           image-ref: ${{ env.TEST_TAG }}
           severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+          logout: 'true'
 
       - name: Test docker image
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
*Description of changes:*
The current daily scan's image scan workflow would often fail with the following error:
```
2025-08-12T22:35:36Z	INFO	[vuln] Vulnerability scanning is enabled
2025-08-12T22:35:36Z	INFO	[secret] Secret scanning is enabled
2025-08-12T22:35:36Z	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-12T22:35:36Z	INFO	[secret] Please see also https://trivy.dev/v0.64/docs/scanner/secret#recommendation for faster secret detection

📣 Notices:
  - Version 0.65.0 of Trivy is now available, current version is 0.64.1

To suppress version checks, run Trivy scans with the --skip-version-check flag

2025-08-12T22:35:37Z	FATAL	Fatal error	run error: image scan error: scan error: unable to initialize a scan service: unable to initialize an image scan service: unable to find the specified image "public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.11.1" in ["docker" "containerd" "podman" "remote"]: 4 errors occurred:
	* docker error: unable to inspect the image (public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.11.1): Error response from daemon: No such image: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.11.1
	* containerd error: failed to list images from containerd client: connection error: desc = "transport: Error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
	* podman error: unable to initialize Podman client: no podman socket found: stat /run/user/1001/podman/podman.sock: no such file or directory
	* remote error: GET https://public.ecr.aws/v2/aws-observability/adot-autoinstrumentation-java/manifests/sha256:7ebd362ec33ad1fa0218535540cec4db3165364fe0715b892e90afdf2374b531: TOOMANYREQUESTS: Rate exceeded
```

Turns out the issue is related to making unauthenticated GET request calls to public ECR images. 
We make these calls both in the `pr_build` (explanation can be found in the code comment) and in `owasp.yml`. Likely, our GET requests to pull the ADOT image are being throttled as a result.

https://github.com/aws-observability/aws-otel-java-instrumentation/blob/7ffb3d4f9200b10f7701926ff240dd5c0b36d136/.github/actions/image_scan/action.yml#L24

- Adding an intermediary step to log-in to ECR before making the GET request calls for `owasp.yml` image scanning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
