### PR TITLE
[semconv]: Add functions to support migration of deprecated semconv keys

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -22,6 +22,12 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+// These DB keys have been deprecated:
+// https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.34.0/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java#L322-L327
+// They have been replaced with new keys:
+// https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.34.0/semconv/src/main/java/io/opentelemetry/semconv/DbAttributes.java#L77
+// TODO: Supporting new keys. Cannot do this now as new keys are not available in OTel Agent 2.11.
+// TODO: Delete deprecated keys once they no longer exist in binding version of the upstream code.
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -34,7 +40,10 @@ import static io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes.GR
 import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_URL;
+// https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.34.0/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessagingIncubatingAttributes.java#L236-L242
+// Deprecated, use {@code messaging.operation.type} instead.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.NetIncubatingAttributes.NET_PEER_NAME;
 import static io.opentelemetry.semconv.incubating.NetIncubatingAttributes.NET_PEER_PORT;
@@ -87,6 +96,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessin
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isAwsSDKSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isDBSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresent;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresentWithFallback;
 
 import com.amazonaws.arn.Arn;
 import io.opentelemetry.api.common.AttributeKey;
@@ -122,15 +132,6 @@ import javax.annotation.Nullable;
  * represent "outgoing" traffic, and {@link SpanKind#INTERNAL} spans are ignored.
  */
 final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
-  // ToDo: These two keys were deleted by upstream. Code need to be updated to capture the same
-  //  information by using new keys.
-  // https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.28.0/semconv/src/main/java/io/opentelemetry/semconv/SemanticAttributes.java#L3784-L3795
-  static final AttributeKey<String> SERVER_SOCKET_ADDRESS =
-      io.opentelemetry.api.common.AttributeKey.stringKey("server.socket.address");
-
-  static final AttributeKey<Long> SERVER_SOCKET_PORT =
-      io.opentelemetry.api.common.AttributeKey.longKey("server.socket.port");
-
   private static final Logger logger =
       Logger.getLogger(AwsMetricAttributeGenerator.class.getName());
 
@@ -293,9 +294,11 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     } else if (isKeyPresent(span, FAAS_INVOKED_NAME) || isKeyPresent(span, FAAS_TRIGGER)) {
       remoteService = getRemoteService(span, FAAS_INVOKED_NAME);
       remoteOperation = getRemoteOperation(span, FAAS_TRIGGER);
-    } else if (isKeyPresent(span, MESSAGING_SYSTEM) || isKeyPresent(span, MESSAGING_OPERATION)) {
+    } else if (isKeyPresent(span, MESSAGING_SYSTEM)
+        || isKeyPresentWithFallback(span, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION)) {
       remoteService = getRemoteService(span, MESSAGING_SYSTEM);
-      remoteOperation = getRemoteOperation(span, MESSAGING_OPERATION);
+      remoteOperation =
+          getRemoteOperationWithFallback(span, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION);
     } else if (isKeyPresent(span, GRAPHQL_OPERATION_TYPE)) {
       remoteService = GRAPHQL;
       remoteOperation = getRemoteOperation(span, GRAPHQL_OPERATION_TYPE);
@@ -772,7 +775,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * {address} attribute is retrieved in priority order:
    * - {@link SemanticAttributes#SERVER_ADDRESS},
    * - {@link SemanticAttributes#NET_PEER_NAME},
-   * - {@link SemanticAttributes#SERVER_SOCKET_ADDRESS}
+   * - {@link SemanticAttributes#NETWORK_PEER_ADDRESS}
    * - {@link SemanticAttributes#DB_CONNECTION_STRING}-Hostname
    * </pre>
    *
@@ -780,7 +783,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * {port} attribute is retrieved in priority order:
    * - {@link SemanticAttributes#SERVER_PORT},
    * - {@link SemanticAttributes#NET_PEER_PORT},
-   * - {@link SemanticAttributes#SERVER_SOCKET_PORT}
+   * - {@link SemanticAttributes#NETWORK_PEER_PORT}
    * - {@link SemanticAttributes#DB_CONNECTION_STRING}-Port
    * </pre>
    *
@@ -799,9 +802,9 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       String networkPeerAddress = span.getAttributes().get(NET_PEER_NAME);
       Long networkPeerPort = span.getAttributes().get(NET_PEER_PORT);
       dbConnection = buildDbConnection(networkPeerAddress, networkPeerPort);
-    } else if (isKeyPresent(span, SERVER_SOCKET_ADDRESS)) {
-      String serverSocketAddress = span.getAttributes().get(SERVER_SOCKET_ADDRESS);
-      Long serverSocketPort = span.getAttributes().get(SERVER_SOCKET_PORT);
+    } else if (isKeyPresent(span, NETWORK_PEER_ADDRESS)) {
+      String serverSocketAddress = span.getAttributes().get(NETWORK_PEER_ADDRESS);
+      Long serverSocketPort = span.getAttributes().get(NETWORK_PEER_PORT);
       dbConnection = buildDbConnection(serverSocketAddress, serverSocketPort);
     } else if (isKeyPresent(span, DB_CONNECTION_STRING)) {
       String connectionString = span.getAttributes().get(DB_CONNECTION_STRING);
@@ -952,6 +955,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       remoteOperation = UNKNOWN_REMOTE_OPERATION;
     }
     return remoteOperation;
+  }
+
+  static String getRemoteOperationWithFallback(
+      SpanData span, AttributeKey<String> remoteOpKey, AttributeKey<String> remoteOpFallbackKey) {
+    String remoteOp = span.getAttributes().get(remoteOpKey);
+    if (remoteOp == null) {
+      return getRemoteOperation(span, remoteOpFallbackKey);
+    }
+    return remoteOp;
   }
 
   /**

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -18,6 +18,7 @@ package software.amazon.opentelemetry.javaagent.providers;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.RECEIVE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
@@ -366,8 +367,24 @@ public class AwsSpanProcessingUtilTest {
   }
 
   @Test
+  public void testIsConsumerProcessSpanFalse_with_MESSAGING_OPERATION_TYPE() {
+    when(attributesMock.get(MESSAGING_OPERATION_TYPE)).thenReturn(RECEIVE);
+    when(attributesMock.get(MESSAGING_OPERATION)).thenReturn(PROCESS);
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
+    assertThat(AwsSpanProcessingUtil.isConsumerProcessSpan(spanDataMock)).isFalse();
+  }
+
+  @Test
   public void testIsConsumerProcessSpanTrue() {
     when(attributesMock.get(MESSAGING_OPERATION)).thenReturn(PROCESS);
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
+    assertThat(AwsSpanProcessingUtil.isConsumerProcessSpan(spanDataMock)).isTrue();
+  }
+
+  @Test
+  public void testIsConsumerProcessSpanTrue_with_MESSAGING_OPERATION_TYPE() {
+    when(attributesMock.get(MESSAGING_OPERATION_TYPE)).thenReturn(PROCESS);
+    when(attributesMock.get(MESSAGING_OPERATION)).thenReturn(RECEIVE);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
     assertThat(AwsSpanProcessingUtil.isConsumerProcessSpan(spanDataMock)).isTrue();
   }
@@ -437,6 +454,26 @@ public class AwsSpanProcessingUtilTest {
   }
 
   @Test
+  public void
+      testNoMetricAttributesForAwsSdkSqsConsumerProcessSpan_with_MESSAGING_OPERATION_TYPE() {
+    InstrumentationScopeInfo instrumentationScopeInfo = mock(InstrumentationScopeInfo.class);
+    when(instrumentationScopeInfo.getName()).thenReturn("io.opentelemetry.aws-sdk-2.2");
+    when(spanDataMock.getInstrumentationScopeInfo()).thenReturn(instrumentationScopeInfo);
+    when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
+    when(spanDataMock.getName()).thenReturn("Sqs.ReceiveMessage");
+    when(attributesMock.get(MESSAGING_OPERATION_TYPE)).thenReturn(PROCESS);
+
+    assertThat(AwsSpanProcessingUtil.shouldGenerateServiceMetricAttributes(spanDataMock)).isFalse();
+    assertThat(AwsSpanProcessingUtil.shouldGenerateDependencyMetricAttributes(spanDataMock))
+        .isFalse();
+
+    when(attributesMock.get(MESSAGING_OPERATION_TYPE)).thenReturn(RECEIVE);
+    assertThat(AwsSpanProcessingUtil.shouldGenerateServiceMetricAttributes(spanDataMock)).isTrue();
+    assertThat(AwsSpanProcessingUtil.shouldGenerateDependencyMetricAttributes(spanDataMock))
+        .isTrue();
+  }
+
+  @Test
   public void testSqlDialectKeywordsOrder() {
     List<String> keywords = getDialectKeywords();
     int prevKeywordLength = Integer.MAX_VALUE;
@@ -453,5 +490,58 @@ public class AwsSpanProcessingUtilTest {
     for (String keyword : keywords) {
       assertThat(MAX_KEYWORD_LENGTH >= keyword.length());
     }
+  }
+
+  @Test
+  public void testIsKeyPresentWithFallback_NewKeyPresent() {
+    when(attributesMock.get(MESSAGING_OPERATION_TYPE)).thenReturn("publish");
+    assertThat(
+            AwsSpanProcessingUtil.isKeyPresentWithFallback(
+                spanDataMock, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION))
+        .isTrue();
+  }
+
+  @Test
+  public void testIsKeyPresentWithFallback_DeprecatedKeyPresent() {
+    when(attributesMock.get(MESSAGING_OPERATION)).thenReturn("publish");
+    assertThat(
+            AwsSpanProcessingUtil.isKeyPresentWithFallback(
+                spanDataMock, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION))
+        .isTrue();
+  }
+
+  @Test
+  public void testIsKeyPresentWithFallback_BothKeysAbsent() {
+    assertThat(
+            AwsSpanProcessingUtil.isKeyPresentWithFallback(
+                spanDataMock, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION))
+        .isFalse();
+  }
+
+  @Test
+  public void testGetKeyValueWithFallback_NewKeyPresent() {
+    when(attributesMock.get(MESSAGING_OPERATION_TYPE)).thenReturn("send");
+    when(attributesMock.get(MESSAGING_OPERATION)).thenReturn("publish");
+    assertThat(
+            AwsSpanProcessingUtil.getKeyValueWithFallback(
+                spanDataMock, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION))
+        .isEqualTo("send");
+  }
+
+  @Test
+  public void testGetKeyValueWithFallback_DeprecatedKeyPresent() {
+    when(attributesMock.get(MESSAGING_OPERATION)).thenReturn("publish");
+    assertThat(
+            AwsSpanProcessingUtil.getKeyValueWithFallback(
+                spanDataMock, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION))
+        .isEqualTo("publish");
+  }
+
+  @Test
+  public void testGetKeyValueWithFallback_BothKeysAbsent() {
+    assertThat(
+            AwsSpanProcessingUtil.getKeyValueWithFallback(
+                spanDataMock, MESSAGING_OPERATION_TYPE, MESSAGING_OPERATION))
+        .isNull();
   }
 }


### PR DESCRIPTION
This PR adds a utility method to help migrate deprecated semconv keys. It first checks the new key; if the new key is not available, it falls back to the legacy deprecated key.

This PR also handles the following deprecated keys:

MESSAGING_OPERATION
SERVER_SOCKET_ADDRESS
SERVER_SOCKET_PORT

Tests:
./gradlew build test — Pass
./gradlew appsignals-tests:contract-tests:contractTests — Pass 
Manual E2E with Spring Boot sample app: Compared raw span data with and without this change — Pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
