### PR TITLE
Propagate sampling decision as attribute

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AttributePropagatingSpanProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AttributePropagatingSpanProcessor.java
@@ -112,6 +112,7 @@ public final class AttributePropagatingSpanProcessor implements SpanProcessor {
     if (propagationData != null) {
       span.setAttribute(propagationDataKey, propagationData);
     }
+    span.setAttribute(AwsAttributeKeys.AWS_TRACE_FLAG_SAMPLED, span.getSpanContext().isSampled());
   }
 
   private boolean isConsumerKind(ReadableSpan span) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -106,9 +106,6 @@ final class AwsAttributeKeys {
   static final AttributeKey<Boolean> AWS_TRACE_FLAG_SAMPLED =
       AttributeKey.booleanKey("aws.trace.flag.sampled");
 
-  static final AttributeKey<String> AWS_XRAY_SAMPLING_RULE =
-      AttributeKey.stringKey("aws.xray.sampling_rule");
-
   // use the same AWS Resource attribute name defined by OTel java auto-instr for aws_sdk_v_1_1
   // TODO: all AWS specific attributes should be defined in semconv package and reused cross all
   // otel packages. Related sim -


### PR DESCRIPTION
### Changes
Propagate the sampling decision as an attribute to allow anomalies captured through adaptive-sampling local SDK configuration to be identified in the console more easily. See #1141 

Also removed unused AwsAttributeKey

### Testing
Deployed to test environment and all spans now have the flag appropriately set under both sampled and manually exported circumstances.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
