### PR TITLE
[semconv]: Add support for new formal DB semantic convention keys

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -15,6 +15,10 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -26,7 +30,6 @@ import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 // https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.34.0/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java#L322-L327
 // They have been replaced with new keys:
 // https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.34.0/semconv/src/main/java/io/opentelemetry/semconv/DbAttributes.java#L77
-// TODO: Supporting new keys. Cannot do this now as new keys are not available in OTel Agent 2.11.
 // TODO: Delete deprecated keys once they no longer exist in binding version of the upstream code.
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -93,6 +96,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessin
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_SERVICE;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.getKeyValueWithFallback;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isAwsSDKSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isDBSpan;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresent;
@@ -285,11 +289,12 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
       remoteOperation = getRemoteOperation(span, RPC_METHOD);
 
     } else if (isDBSpan(span)) {
-      remoteService = getRemoteService(span, DB_SYSTEM);
-      if (isKeyPresent(span, DB_OPERATION)) {
-        remoteOperation = getRemoteOperation(span, DB_OPERATION);
+      remoteService = getRemoteServiceWithFallback(span, DB_SYSTEM_NAME, DB_SYSTEM);
+      if (isKeyPresentWithFallback(span, DB_OPERATION_NAME, DB_OPERATION)) {
+        remoteOperation = getRemoteOperationWithFallback(span, DB_OPERATION_NAME, DB_OPERATION);
       } else {
-        remoteOperation = getDBStatementRemoteOperation(span, DB_STATEMENT);
+        String dbStatement = getKeyValueWithFallback(span, DB_QUERY_TEXT, DB_STATEMENT);
+        remoteOperation = getDBStatementRemoteOperation(span, dbStatement);
       }
     } else if (isKeyPresent(span, FAAS_INVOKED_NAME) || isKeyPresent(span, FAAS_TRIGGER)) {
       remoteService = getRemoteService(span, FAAS_INVOKED_NAME);
@@ -349,10 +354,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static String generateRemoteOperation(SpanData span) {
     String remoteOperation = UNKNOWN_REMOTE_OPERATION;
     if (isKeyPresent(span, URL_FULL) || isKeyPresent(span, HTTP_URL)) {
-      String httpUrl =
-          isKeyPresent(span, URL_FULL)
-              ? span.getAttributes().get(URL_FULL)
-              : span.getAttributes().get(HTTP_URL);
+      String httpUrl = getKeyValueWithFallback(span, URL_FULL, HTTP_URL);
       try {
         URL url;
         if (httpUrl != null) {
@@ -363,11 +365,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         logger.log(Level.FINEST, "invalid http.url attribute: ", httpUrl);
       }
     }
-    if (isKeyPresent(span, HTTP_REQUEST_METHOD) || isKeyPresent(span, HTTP_METHOD)) {
-      String httpMethod =
-          isKeyPresent(span, HTTP_REQUEST_METHOD)
-              ? span.getAttributes().get(HTTP_REQUEST_METHOD)
-              : span.getAttributes().get(HTTP_METHOD);
+    if (isKeyPresentWithFallback(span, HTTP_REQUEST_METHOD, HTTP_METHOD)) {
+      String httpMethod = getKeyValueWithFallback(span, HTTP_REQUEST_METHOD, HTTP_METHOD);
       remoteOperation = httpMethod + " " + remoteOperation;
     }
     if (remoteOperation.equals(UNKNOWN_REMOTE_OPERATION)) {
@@ -791,7 +790,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * provided.
    */
   private static Optional<String> getDbConnection(SpanData span) {
-    String dbName = span.getAttributes().get(DB_NAME);
+    String dbName = getKeyValueWithFallback(span, DB_NAMESPACE, DB_NAME);
     Optional<String> dbConnection = Optional.empty();
 
     if (isKeyPresent(span, SERVER_ADDRESS)) {
@@ -949,6 +948,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     return remoteService;
   }
 
+  static String getRemoteServiceWithFallback(
+      SpanData span, AttributeKey<String> remoteSvcKey, AttributeKey<String> remoteSvcFallbackKey) {
+    String remoteService = span.getAttributes().get(remoteSvcKey);
+    if (remoteService == null) {
+      return getRemoteService(span, remoteSvcFallbackKey);
+    }
+    return remoteService;
+  }
+
   private static String getRemoteOperation(SpanData span, AttributeKey<String> remoteOperationKey) {
     String remoteOperation = span.getAttributes().get(remoteOperationKey);
     if (remoteOperation == null) {
@@ -972,9 +980,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * statement and compare to a regex list of known SQL keywords. The substring length is determined
    * by the longest known SQL keywords.
    */
-  private static String getDBStatementRemoteOperation(
-      SpanData span, AttributeKey<String> remoteOperationKey) {
-    String remoteOperation = span.getAttributes().get(remoteOperationKey);
+  private static String getDBStatementRemoteOperation(SpanData span, String dbStatement) {
+    String remoteOperation = dbStatement;
     if (remoteOperation == null) {
       remoteOperation = UNKNOWN_REMOTE_OPERATION;
     }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
@@ -18,7 +18,7 @@ package software.amazon.opentelemetry.javaagent.providers;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_STATUS_CODE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_SERVICE;
-import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresent;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.getKeyValueWithFallback;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
@@ -136,12 +136,8 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   // possible except for the throttle
   // https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsxrayexporter/internal/translator/cause.go#L121-L160
   private void recordErrorOrFault(SpanData spanData, Attributes attributes) {
-    Long httpStatusCode = null;
-    if (isKeyPresent(spanData, HTTP_RESPONSE_STATUS_CODE)) {
-      httpStatusCode = spanData.getAttributes().get(HTTP_RESPONSE_STATUS_CODE);
-    } else if (isKeyPresent(spanData, HTTP_STATUS_CODE)) {
-      httpStatusCode = spanData.getAttributes().get(HTTP_STATUS_CODE);
-    }
+    Long httpStatusCode =
+        getKeyValueWithFallback(spanData, HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE);
     StatusCode statusCode = spanData.getStatus().getStatusCode();
 
     if (httpStatusCode == null) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -15,6 +15,9 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
@@ -295,9 +298,9 @@ final class AwsSpanProcessingUtil {
 
   // Check if the current Span adheres to database semantic conventions
   static boolean isDBSpan(SpanData span) {
-    return isKeyPresent(span, DB_SYSTEM)
-        || isKeyPresent(span, DB_OPERATION)
-        || isKeyPresent(span, DB_STATEMENT);
+    return isKeyPresentWithFallback(span, DB_SYSTEM_NAME, DB_SYSTEM)
+        || isKeyPresentWithFallback(span, DB_OPERATION_NAME, DB_OPERATION)
+        || isKeyPresentWithFallback(span, DB_QUERY_TEXT, DB_STATEMENT);
   }
 
   static boolean isLambdaServerSpan(ReadableSpan span) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
+import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -1791,5 +1792,35 @@ class AwsMetricAttributeGeneratorTest {
 
     assertThat(attributeMap.get(SERVICE_METRIC)).isEqualTo(serviceAttributes);
     assertThat(attributeMap.get(DEPENDENCY_METRIC)).isEqualTo(dependencyAttributes);
+  }
+
+  @Test
+  public void testGetRemoteServiceWithFallback_PrimaryKeyPresent() {
+    mockAttribute(DB_SYSTEM_NAME, "mysql");
+    mockAttribute(DB_SYSTEM, "postgresql");
+    String result =
+        AwsMetricAttributeGenerator.getRemoteServiceWithFallback(
+            spanDataMock, DB_SYSTEM_NAME, DB_SYSTEM);
+
+    assertThat(result).isEqualTo("mysql");
+  }
+
+  @Test
+  public void testGetRemoteServiceWithFallback_FallbackKeyPresent() {
+    mockAttribute(DB_SYSTEM, "postgresql");
+    String result =
+        AwsMetricAttributeGenerator.getRemoteServiceWithFallback(
+            spanDataMock, DB_SYSTEM_NAME, DB_SYSTEM);
+
+    assertThat(result).isEqualTo("postgresql");
+  }
+
+  @Test
+  public void testGetRemoteServiceWithFallback_BothKeysAbsent() {
+    String result =
+        AwsMetricAttributeGenerator.getRemoteServiceWithFallback(
+            spanDataMock, DB_SYSTEM_NAME, DB_SYSTEM);
+
+    assertThat(result).isEqualTo(UNKNOWN_REMOTE_SERVICE);
   }
 }


### PR DESCRIPTION
ADOT Java currently uses some deprecated incubating semconv keys. This PR adds support for the newly introduced formal semconv keys that replace them, while maintaining backward compatibility by falling back to the legacy keys when necessary.

**Deprecated keys:**
- DB_NAME
- DB_OPERATION
- DB_STATEMENT
- DB_SYSTEM

(Reference: https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.34.0/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java#L322-L327)

**New keys:**
- DB_NAMESPACE
- DB_OPERATION_NAME
- DB_QUERY_TEXT
- DB_SYSTEM_NAME

**Tests performed:**
- Unit tests: `./gradlew build test`
- Smoke/contract tests: `./gradlew appsignals-tests:contract-tests:contractTests`
- Manual E2E test with SpringBoot sample app.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
