### PR TITLE
Fix disk-buffering build failure in contrib

### DIFF
--- a/.github/patches/opentelemetry-java-contrib.patch
+++ b/.github/patches/opentelemetry-java-contrib.patch
@@ -3174,6 +3174,21 @@ index 00000000..32752d5e
 +    "speed": "0"
 +  }
 +}
+diff --git a/disk-buffering/build.gradle.kts b/disk-buffering/build.gradle.kts
+index 041d2e91..e3d60f46 100644
+--- a/disk-buffering/build.gradle.kts
++++ b/disk-buffering/build.gradle.kts
+@@ -70,6 +70,10 @@ tasks.named<ShadowJar>("shadowJar") {
+   mustRunAfter("jar")
+ }
+
++tasks.withType<Test>().configureEach {
++  dependsOn("shadowJar")
++}
++
+ // The javadoc from wire's generated classes has errors that make the task that generates the "javadoc" artifact to fail. This
+ // makes the javadoc task to ignore those generated classes.
+ tasks.withType(Javadoc::class.java) {
 diff --git a/version.gradle.kts b/version.gradle.kts
 index acefcee9..329b524f 100644
 --- a/version.gradle.kts


### PR DESCRIPTION
Change was already previously present, but was removed mistakenly: https://github.com/aws-observability/aws-otel-java-instrumentation/blob/8c8b717bea21d4c0afc43c6c2803254e58c4512e/.github/patches/opentelemetry-java-contrib.patch

Reintroducing the fix in the patch


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
