### PR TITLE
bump Netty to 4.1.126

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -41,7 +41,8 @@ val dependencyBoms = listOf(
   "com.linecorp.armeria:armeria-bom:1.26.4",
   "io.grpc:grpc-bom:1.59.1",
   // netty-bom is a fix for CVE-2025-58056 (https://github.com/advisories/GHSA-fghv-69vj-qj49).
-  // Remove once https://github.com/aws/aws-sdk-java-v2/pull/6398 is merged and released and we update com.amazonaws:aws-java-sdk-bom:1.12.599 dependency.
+  // Remove once https://github.com/aws/aws-sdk-java-v2/pull/6398 and https://github.com/aws/aws-sdk-java/pull/3192
+  // are both merged and released, and we update the corresponding dependencies.
   "io.netty:netty-bom:4.1.126.Final",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -42,7 +42,7 @@ val dependencyBoms = listOf(
   "io.grpc:grpc-bom:1.59.1",
   // netty-bom is a fix for CVE-2025-55163 (https://github.com/advisories/GHSA-prj3-ccx8-p6x4).
   // Remove once https://github.com/aws/aws-sdk-java-v2/pull/6344 is released.
-  "io.netty:netty-bom:4.1.124.Final",
+  "io.netty:netty-bom:4.1.126.Final",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",
   "org.junit:junit-bom:5.10.1",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -40,8 +40,8 @@ val dependencyBoms = listOf(
   "com.google.protobuf:protobuf-bom:3.25.1",
   "com.linecorp.armeria:armeria-bom:1.26.4",
   "io.grpc:grpc-bom:1.59.1",
-  // netty-bom is a fix for CVE-2025-55163 (https://github.com/advisories/GHSA-prj3-ccx8-p6x4).
-  // Remove once https://github.com/aws/aws-sdk-java-v2/pull/6344 is released.
+  // netty-bom is a fix for CVE-2025-58056 (https://github.com/advisories/GHSA-fghv-69vj-qj49).
+  // Remove once https://github.com/aws/aws-sdk-java-v2/pull/6398 is merged and released and we update com.amazonaws:aws-java-sdk-bom:1.12.599 dependency.
   "io.netty:netty-bom:4.1.126.Final",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes [CVE-2025-58056](https://github.com/advisories/GHSA-fghv-69vj-qj49). See upstream [PR](https://github.com/aws/aws-sdk-java-v2/pull/6398).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
