### PR TITLE
Update Kotlin version in UDP Exporter Sample Test App

### DIFF
--- a/sample-apps/udp-exporter-test-app/build.gradle.kts
+++ b/sample-apps/udp-exporter-test-app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("java")
-  kotlin("jvm") version "1.9.0"
+  kotlin("jvm") version "2.1.0-RC2"
   id("io.spring.dependency-management") version "1.1.0"
   id("org.springframework.boot") version "2.7.17"
 }


### PR DESCRIPTION
*Issue #, if available:*
- Fix failing workflow `udp-exporter-e2e-test`, where the sample app is unable to be built
  - https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/17587060722/job/49957841960

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':compileKotlin'.
> Unknown Kotlin JVM target: 21
```

*Description of changes:*
- Update Kotlin version in UDP Exporter Sample Test App. It is also now aligned with the Kotlin version used in other `build.gradle.kts` files in this repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
