### PR TITLE
Update Java lang version support from 22 to 23

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -83,14 +83,14 @@ jobs:
       java-version: '21'
       cpu-architecture: 'x86_64'
 
-  default-v22-amd64:
+  default-v23-amd64:
     needs: [ upload-main-build ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-default-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
       caller-workflow-name: 'main-build'
-      java-version: '22'
+      java-version: '23'
       cpu-architecture: 'x86_64'
 
   java-ec2-adot-sigv4-test:
@@ -147,7 +147,7 @@ jobs:
       caller-workflow-name: 'main-build'
       java-version: '21'
 
-  eks-v22-amd64:
+  eks-v23-amd64:
     needs: eks-v21-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
     secrets: inherit
@@ -156,7 +156,7 @@ jobs:
       test-cluster-name: 'e2e-adot-test'
       adot-image-name: ${{ inputs.adot-image-name }}
       caller-workflow-name: 'main-build'
-      java-version: '22'
+      java-version: '23'
 
   #
   # PACKAGED DISTRIBUTION PLATFORM COVERAGE
@@ -229,7 +229,7 @@ jobs:
   #
 
   metric-limiter-v11-amd64:
-    needs: [ eks-v22-amd64 ]
+    needs: [ eks-v23-amd64 ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/metric-limiter-test.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
We depend on [OTEL Java 2.11.0](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/release/v2.11.x/dependencyManagement/build.gradle.kts#L30C20-L30C26), which was released [Dec 23, 2024](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.11.0), at which Java 23 was supported (released [2024-09-17 ](https://www.java.com/releases/)). We should have bumped this version then, but we didn't have a good process in place at the time. Bump version now.

Skipping changelog as we will support Java 24 soon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.