### PR TITLE
fix: Remove spring-boot as agent dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ For any change that affects end users of this package, please add an entry under
 If your change does not need a CHANGELOG entry, add the "skip changelog" label to your PR.
 
 ## Unreleased
+
+- fix: Remove spring-boot as agent dependency
+  ([#1204](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1204))

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -47,7 +47,6 @@ val dependencyBoms = listOf(
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",
   "org.junit:junit-bom:5.10.1",
-  "org.springframework.boot:spring-boot-dependencies:2.7.17",
   "org.testcontainers:testcontainers-bom:1.19.3",
   "software.amazon.awssdk:bom:2.30.17",
 )

--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -7,8 +7,9 @@ plugins {
 }
 
 dependencies {
-  implementation("org.springframework.boot:spring-boot-starter-web")
-  implementation("org.springframework.boot:spring-boot-starter")
+  implementation("org.springframework.boot:spring-boot-dependencies:2.7.17")
+  implementation("org.springframework.boot:spring-boot-starter-web:2.7.17")
+  implementation("org.springframework.boot:spring-boot-starter:2.7.17")
   implementation("com.squareup.okhttp3:okhttp")
   implementation("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:sts")

--- a/smoke-tests/spring-boot/build.gradle.kts
+++ b/smoke-tests/spring-boot/build.gradle.kts
@@ -42,7 +42,8 @@ java {
 }
 
 dependencies {
-  implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-dependencies:2.7.17")
+  implementation("org.springframework.boot:spring-boot-starter-web:2.7.17")
 }
 
 jib {


### PR DESCRIPTION
Currently, spring-boot is included as a shared dependency across all ADOT Java projects, including the ADOT Java Agent. This unnecessarily increases the agent's size, even though only the testing and sample applications actually use it.

This PR removes spring-boot from the ADOT Java Agent's dependency list.

Tests performed:

Local build: ./gradlew build ✅
Unit tests: ./gradlew test ✅
Smoke/contract tests: ./gradlew appsignals-tests:contract-tests:contractTests ✅

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
