### PR TITLE
Fix: Incorrect zip file name in Lambda Java release workflow (#1208)

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -206,10 +206,13 @@ jobs:
           done
           echo "}" >> ../layer_cdk
           cat ../layer_cdk
-      - name: download layer.zip
+      - name: download aws-opentelemetry-java-layer.zip
         uses: actions/download-artifact@v5
         with:
-          name: layer.zip
+          name: aws-opentelemetry-java-layer.zip
+      - name: rename to layer.zip
+        run: |
+          mv aws-opentelemetry-java-layer.zip layer.zip
       - name: Get commit hash
         id: commit
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Problem:
The Lambda Java layer release fails because the workflow uses the wrong artifact (layer zip file) name.
https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/17867947751

Solution:
Rename aws-opentelemetry-java-layer.zip to layer.zip.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
