### PR TITLE
Skip `checkstyleMain` in `Build opentelemetry java instrumentation` step

### DIFF
--- a/.github/actions/patch-dependencies/action.yml
+++ b/.github/actions/patch-dependencies/action.yml
@@ -106,14 +106,14 @@ runs:
       uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa #v2
       if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests != 'false' }}
       with:
-        arguments: check -x spotlessCheck publishToMavenLocal --scan --no-daemon
+        arguments: check -x spotlessCheck -x checkstyleMain publishToMavenLocal --scan --no-daemon
         build-root-directory: opentelemetry-java-instrumentation
 
     - name: Build opentelemetry java instrumentation
       uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa #v2
       if: ${{ env.patch_otel_java_instrumentation == 'true' && inputs.run_tests == 'false' }}
       with:
-        arguments: publishToMavenLocal --scan --no-daemon
+        arguments: publishToMavenLocal -x checkstyleMain --scan --no-daemon
         build-root-directory: opentelemetry-java-instrumentation
 
     - name: cleanup opentelmetry-java-instrumentation


### PR DESCRIPTION
*Description of changes:*
PR builds are failing:
https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18234501009/job/51925394400

```
    Reason: Task ':smoke-tests:images:quarkus:checkstyleMain' uses this output of task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' as an input of ':smoke-tests:images:quarkus:checkstyleMain'.
      2. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':smoke-tests:images:quarkus:compileQuarkusGeneratedSourcesJava' from ':smoke-tests:images:quarkus:checkstyleMain' using Task#mustRunAfter.
```
 
This is because the `checkstyle` task dependency issues where checkstyleMain uses outputs from `compileQuarkusGeneratedSourcesJava` without declaring explicit dependencies, causing "implicit dependency" errors. Since we're only testing patch behavior and need functional artifacts published to Maven local, code style validation is unnecessary overhead that can be safely skipped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
