### PR TITLE
Fix failing upstream test in PR build

### DIFF
--- a/.github/patches/opentelemetry-java-instrumentation.patch
+++ b/.github/patches/opentelemetry-java-instrumentation.patch
@@ -15,9 +15,11 @@ diff --git a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/
 index 1234567890..abcdef1234 100644
 --- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TomcatIntegrationTest.java
 +++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TomcatIntegrationTest.java
-@@ -21,7 +21,6 @@ public class TomcatIntegrationTest extends TargetSystemTest {
+@@ -20,8 +20,8 @@ public class TomcatIntegrationTest extends TargetSystemTest {
+ 
    @ParameterizedTest
    @CsvSource({
++    // TODO: Remove this patch after we no longer depend on 2.18.1 of opentelemetry-java-instrumentation.
      "tomcat:10.0, https://tomcat.apache.org/tomcat-10.0-doc/appdev/sample/sample.war",
 -    "tomcat:9.0, https://tomcat.apache.org/tomcat-9.0-doc/appdev/sample/sample.war"
    })
@@ -37,4 +39,3 @@ index 023d04703c..ec9690086c 100644
    if (findProperty("otel.stable") != "true") {
 -- 
 2.45.1
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
PR builds have been failing for the last 2+ weeks on the `Test patches applied to dependencies` job: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18328141549/job/52275908381

This was due to a failing `jmx-metrics` test in the upstream opentelemetry-java-instrumentation repo that we clone and patch, where several metrics seem to be delayed and thus missing when being verified.

```
java.lang.AssertionError: Metrics expected but not received: [tomcat.session.active.count, tomcat.session.active.limit]
Received only: [tomcat.network.io, tomcat.thread.busy.count, tomcat.request.duration.sum, tomcat.thread.count, tomcat.request.count, tomcat.error.count, tomcat.thread.limit, tomcat.request.duration.max]
```

I tried to build the upstream repo standalone on the release/2.18.x branch and got the same issue, confirming that our patches don't affect this. This test seems to depend on a [floating tag version](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/083d8639c634d9fb5803efd984956d870a572654/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TomcatIntegrationTest.java#L27) of the Tomcat docker image which new changes can be pushed to.

Add a temporary patch fix to skip the old Tomcat 9.0 dependency where the test failure is happening. **We can remove this after bumping the opentelemetry-java-instrumentation dependency**, as the error is fixed in future versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
