### PR TITLE
Enforce docker builds using `linux/amd64,linux/arm64` everywhere

### DIFF
--- a/.github/actions/cpUtility-testing/action.yml
+++ b/.github/actions/cpUtility-testing/action.yml
@@ -51,7 +51,7 @@ runs:
         push: false
         build-args: "ADOT_JAVA_VERSION=${{ inputs.adot-java-version }}"
         context: .
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         tags: ${{ inputs.image_uri_with_tag }}
         load: true
 

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -118,7 +118,7 @@ jobs:
           push: false
           build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.TEST_TAG }}
           load: true
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -198,7 +198,7 @@ jobs:
           push: false
           build-args: "ADOT_JAVA_VERSION=${{ env.ADOT_JAVA_VERSION }}"
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.TEST_TAG }}
           load: true
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -195,7 +195,7 @@ jobs:
           push: false
           build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.TEST_TAG }}
           load: true
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
