### PR TITLE
fix e2e test to work in release branches

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-val adotVersion = "2.20.0"
+val adotVersion = "2.20.0-SNAPSHOT"
 
 allprojects {
   version = if (project.hasProperty("release.version")) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The workflow `application-signals-e2e-test.yml` assumes the version contains -SNAPSHOT. In release branches, we update `version.gradle.kts` to drop the -SNAPSHOT suffix to prepare for the release, so `upload-main-build` fails. See https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18921541300/job/54022142576

This PR modifies the job to match any artifact with the name `aws-opentelemetry-agent-*.jar`, with or without the SNAPSHOT suffix.

tested by manually triggering main build in this branch:
1. adotVersion = 2.20.0-SNAPSHOT: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18925772853/job/54034432606
`upload: ./aws-opentelemetry-agent-2.20.0-SNAPSHOT.jar to s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar`
2. adotVersion = 2.20.0: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18927001060
`upload: ./aws-opentelemetry-agent-2.20.0.jar to s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar`

Both runs are successful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
