### PR TITLE
fix e2e test to work in release branches (#1253)

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -25,6 +25,8 @@ jobs:
   upload-main-build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #5.0.0
         with:
@@ -36,7 +38,10 @@ jobs:
           name: aws-opentelemetry-agent.jar
 
       - name: Upload main-build adot.jar to s3
-        run: aws s3 cp ./aws-opentelemetry-agent-*-SNAPSHOT.jar s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar
+        run: |
+          # Extract artifact suffix using version.gradle.kts
+          VERSION=$(awk -F'"' '/val adotVersion = / {print $2}' version.gradle.kts)
+          aws s3 cp ./aws-opentelemetry-agent-$VERSION.jar s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar
 
   #
   # PACKAGED DISTRIBUTION LANGUAGE VERSION COVERAGE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The workflow `application-signals-e2e-test.yml` assumes the version contains -SNAPSHOT. In release branches, we update `version.gradle.kts` to drop the -SNAPSHOT suffix to prepare for the release, so `upload-main-build` fails. See
https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18921541300/job/54022142576

This PR modifies the job to match any artifact with the name `aws-opentelemetry-agent-*.jar`, with or without the SNAPSHOT suffix.

tested by manually triggering main build in this branch:
1. adotVersion = 2.20.0-SNAPSHOT: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18925772853/job/54034432606 `upload: ./aws-opentelemetry-agent-2.20.0-SNAPSHOT.jar to s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar`
2. adotVersion = 2.20.0: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/18927001060 `upload: ./aws-opentelemetry-agent-2.20.0.jar to
s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar`

Both runs are successful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
