### PR TITLE
fix version.gradle.kts logic

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -16,9 +16,7 @@
 val adotVersion = "2.20.0-SNAPSHOT"
 
 allprojects {
-  version = if (project.hasProperty("release.version")) {
-    project.property("release.version") as String
-  } else {
-    adotVersion
+  if (!project.hasProperty("release.version")) {
+    version = adotVersion
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
cherry-picks commit from #1255, see for more details.

Do not touch the version variable in environments where `-Prelease.version` is passed in. This prevents a versioning conflict in `closeAndReleaseSonatypeStagingRepository`, an error which was only thrown when releasing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
