### PR TITLE
Revert commented out release step

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -205,16 +205,16 @@ jobs:
         shell: bash
         run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "$VERSION"
 
-      # - name: Build and push image
-      #   uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-      #   with:
-      #     push: true
-      #     build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
-      #     context: .
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: |
-      #       ${{ env.PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
-      #       ${{ env.PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
+      - name: Build and push image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          push: true
+          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
+            ${{ env.PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
       - name: Build and Publish release with Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In #1255, after making a fix to the version file, we re-ran the workflow with the already-successful "Build and push image" step commented out. This PR uncomments the step again for future patch releases on the v2.20.x branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
