### PR TITLE
Use PAT in nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -125,7 +125,7 @@ jobs:
     
     - name: Create or update PR
       env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN_GITHUB_RW_PATOKEN }}
+        GITHUB_TOKEN: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
       run: |
         BUILD_STATUS="${{ needs.build-and-test.result }}"
         BUILD_EMOJI="${{ needs.build-and-test.result == 'success' && '✅' || '❌' }}"


### PR DESCRIPTION
See https://github.com/aws-observability/aws-otel-dotnet-instrumentation/pull/307

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
