### PR TITLE
Remove conflicting attributes from aws-sdk instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   ([#1275](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1275))
 - Bump Netty version to 4.1.130 Final
   ([#1271](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1271))
+- Remove conflicting attributes from aws-sdk instrumentation
+  ([#1294](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1294))
 
 
 ### Enhancements

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsExperimentalAttributes.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsExperimentalAttributes.java
@@ -20,12 +20,8 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import io.opentelemetry.api.common.AttributeKey;
 
 final class AwsExperimentalAttributes {
-  static final AttributeKey<String> AWS_BUCKET_NAME = stringKey("aws.bucket.name");
-  static final AttributeKey<String> AWS_QUEUE_URL = stringKey("aws.queue.url");
   static final AttributeKey<String> AWS_QUEUE_NAME = stringKey("aws.queue.name");
-  static final AttributeKey<String> AWS_STREAM_NAME = stringKey("aws.stream.name");
   static final AttributeKey<String> AWS_STREAM_ARN = stringKey("aws.stream.arn");
-  static final AttributeKey<String> AWS_TABLE_NAME = stringKey("aws.table.name");
   static final AttributeKey<String> AWS_GUARDRAIL_ID = stringKey("aws.bedrock.guardrail.id");
   static final AttributeKey<String> AWS_GUARDRAIL_ARN = stringKey("aws.bedrock.guardrail.arn");
   static final AttributeKey<String> AWS_AGENT_ID = stringKey("aws.bedrock.agent.id");

--- a/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkRequestType.java
@@ -23,7 +23,6 @@ package software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2;
  */
 
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_AGENT_ID;
-import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_BUCKET_NAME;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_DATA_SOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ARN;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_GUARDRAIL_ID;
@@ -32,15 +31,12 @@ import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_LAMBDA_NAME;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_LAMBDA_RESOURCE_ID;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_QUEUE_NAME;
-import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_QUEUE_URL;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_SECRET_ARN;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_SNS_TOPIC_ARN;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STATE_MACHINE_ARN;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STEP_FUNCTIONS_ACTIVITY_ARN;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STREAM_ARN;
-import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_STREAM_NAME;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_TABLE_ARN;
-import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.AWS_TABLE_NAME;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_MODEL;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_MAX_TOKENS;
 import static software.amazon.opentelemetry.javaagent.instrumentation.awssdk_v2_2.AwsExperimentalAttributes.GEN_AI_REQUEST_TEMPERATURE;
@@ -58,17 +54,13 @@ import java.util.Map;
 
 enum AwsSdkRequestType {
   // 2025-07-22: Amazon addition
-  S3(request(AWS_BUCKET_NAME.getKey(), "Bucket")),
+  S3(),
 
-  SQS(request(AWS_QUEUE_URL.getKey(), "QueueUrl"), request(AWS_QUEUE_NAME.getKey(), "QueueName")),
+  SQS(request(AWS_QUEUE_NAME.getKey(), "QueueName")),
 
-  KINESIS(
-      request(AWS_STREAM_NAME.getKey(), "StreamName"),
-      request(AWS_STREAM_ARN.getKey(), "StreamARN")),
+  KINESIS(request(AWS_STREAM_ARN.getKey(), "StreamARN")),
 
-  DYNAMODB(
-      request(AWS_TABLE_NAME.getKey(), "TableName"),
-      response(AWS_TABLE_ARN.getKey(), "Table.TableArn")),
+  DYNAMODB(response(AWS_TABLE_ARN.getKey(), "Table.TableArn")),
 
   SNS(
       /*

--- a/instrumentation/aws-sdk/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkExperimentalAttributesInjectionTest.java
+++ b/instrumentation/aws-sdk/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/awssdk_v2_2/AwsSdkExperimentalAttributesInjectionTest.java
@@ -47,39 +47,6 @@ public class AwsSdkExperimentalAttributesInjectionTest {
   }
 
   @Test
-  void testS3ExperimentalAttributes() {
-    when(mockRequest.getValueForField("Bucket", Object.class))
-        .thenReturn(Optional.of("test-bucket"));
-
-    fieldMapper.mapToAttributes(mockRequest, AwsSdkRequest.S3Request, mockSpan);
-
-    verify(mockSpan)
-        .setAttribute(eq(AwsExperimentalAttributes.AWS_BUCKET_NAME.getKey()), eq("test-bucket"));
-  }
-
-  @Test
-  void testSqsExperimentalAttributes() {
-    String queueUrl = "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue";
-    when(mockRequest.getValueForField("QueueUrl", Object.class)).thenReturn(Optional.of(queueUrl));
-
-    fieldMapper.mapToAttributes(mockRequest, AwsSdkRequest.SqsRequest, mockSpan);
-
-    verify(mockSpan)
-        .setAttribute(eq(AwsExperimentalAttributes.AWS_QUEUE_URL.getKey()), eq(queueUrl));
-  }
-
-  @Test
-  void testDynamoDbExperimentalAttributes() {
-    when(mockRequest.getValueForField("TableName", Object.class))
-        .thenReturn(Optional.of("test-table"));
-
-    fieldMapper.mapToAttributes(mockRequest, AwsSdkRequest.DynamoDbRequest, mockSpan);
-
-    verify(mockSpan)
-        .setAttribute(eq(AwsExperimentalAttributes.AWS_TABLE_NAME.getKey()), eq("test-table"));
-  }
-
-  @Test
   void testSnsExperimentalAttributes() {
     String topicArn = "arn:aws:sns:us-east-1:123456789012:test-topic";
     when(mockRequest.getValueForField("TopicArn", Object.class)).thenReturn(Optional.of(topicArn));
@@ -92,15 +59,10 @@ public class AwsSdkExperimentalAttributesInjectionTest {
 
   @Test
   void testKinesisExperimentalAttributes() {
-    when(mockRequest.getValueForField("StreamName", Object.class))
-        .thenReturn(Optional.of("test-stream"));
     when(mockRequest.getValueForField("StreamARN", Object.class))
         .thenReturn(Optional.of("arn:aws:kinesis:region:account:stream/test-stream"));
 
     fieldMapper.mapToAttributes(mockRequest, AwsSdkRequest.KinesisRequest, mockSpan);
-
-    verify(mockSpan)
-        .setAttribute(eq(AwsExperimentalAttributes.AWS_STREAM_NAME.getKey()), eq("test-stream"));
     verify(mockSpan)
         .setAttribute(
             eq(AwsExperimentalAttributes.AWS_STREAM_ARN.getKey()),


### PR DESCRIPTION
## Summary:
We are trying to upgrade to upstream's 2.23.x, but they have changed [AWS SDK 1.x/2.x  attributes to align with semantic conventions](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.22.0), generally, the changes are acceptable, but observed that in our aws-sdk instrumentation package, we are duplicating attribute generation for some of these changed attributes, specifically:
* `aws.bucket.name` -> `aws.s3.bucket`
* `aws.table.name` -> `aws.dynamnodb.table_names`
* `aws.stream.name` -> `aws.kinesis.stream_name`
* `aws.queue.url` -> `aws.sqs.queue_url`

Since we would have to change these fields in the aws-sdk instrumentation, we are questioning whether we need this attribute generation logic at all - if we are just duplicating what the upstream is doing, why do it? Our aws-sdk instrumentation runs IN ADDITION TO, not IN PLACE OF the upstream, so removing this logic should be a no-op.

## Testing:
* We have [robust contract tests](https://github.com/aws-observability/aws-otel-java-instrumentation/tree/main/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/awssdk) that validate the `aws.*` attributes (see PR approval workflow).
* E2E tests also cover this logic, which are run in [main-build](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/21257574136).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
