### PR TITLE
back patch lambda layer signature fix

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,6 +18,7 @@ env:
   PRIVATE_REPOSITORY: 020628701572.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java
   PRIVATE_REGISTRY: 020628701572.dkr.ecr.us-west-2.amazonaws.com
   ARTIFACT_NAME: aws-opentelemetry-agent.jar
+  LAYER_ARTIFACT_NAME: aws-opentelemetry-java-layer.zip
   # Legacy list of commercial regions to deploy to. New regions should NOT be added here, and instead should be added to the `aws_region` default input to the workflow.
   LEGACY_COMMERCIAL_REGIONS: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
   LAYER_NAME: AWSOpenTelemetryDistroJava
@@ -122,7 +123,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: layer.zip
-          path: lambda-layer/build/distributions/aws-opentelemetry-java-layer.zip
+          path: lambda-layer/build/distributions/${{ env.LAYER_ARTIFACT_NAME }}
 
   publish-sdk:
     runs-on: ubuntu-latest
@@ -275,30 +276,42 @@ jobs:
         continue-on-error: true
         run: |
           aws s3 mb s3://${{ env.BUCKET_NAME }}
-          aws s3 cp aws-opentelemetry-java-layer.zip s3://${{ env.BUCKET_NAME }}
+          aws s3 cp ${{ env.LAYER_ARTIFACT_NAME }} s3://${{ env.BUCKET_NAME }}
           
           # Sign the layer
+          echo "Checking for signing profile..."
           PROFILE=$(aws signer list-signing-profiles --query "profiles[?profileName=='ADOTLambdaLayerSigningProfile'].arn" --output text 2>/dev/null)
-          [ -z "$PROFILE" ] && exit 0
+          [ -z "$PROFILE" ] && echo "No signing profile found, skipping" && exit 0
           
+          echo "Starting signing job..."
           JOB_ID=$(aws signer start-signing-job \
-            --source "s3={bucketName=${{ env.BUCKET_NAME }},key=aws-opentelemetry-java-layer.zip,version=null}" \
+            --source "s3={bucketName=${{ env.BUCKET_NAME }},key=${{ env.LAYER_ARTIFACT_NAME }},version=null}" \
             --destination "s3={bucketName=${{ env.BUCKET_NAME }},prefix=signed-}" \
             --profile-name ADOTLambdaLayerSigningProfile \
             --query 'jobId' --output text 2>/dev/null) || exit 0
-          [ -z "$JOB_ID" ] && exit 0
+          [ -z "$JOB_ID" ] && echo "No job ID returned" && exit 0
+          echo "Job ID: $JOB_ID"
           
+          echo "Waiting for signing job to complete..."
           aws signer wait successful-signing-job --job-id "$JOB_ID" || exit 0
+          echo "Signing completed"
           
+          echo "Moving signed layer..."
           SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text 2>/dev/null)
-          [ -n "$SIGNED" ] && aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/aws-opentelemetry-python-layer.zip"
+          echo "SIGNED value: '$SIGNED'"
+          if [ -n "$SIGNED" ]; then
+            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }} --clobber"
+            echo "Signed layer moved successfully"
+          else
+            echo "No SIGNED value returned, skipping move"
+          fi
       
       - name: Publish Layer Version
         run: |
           layerARN=$(
             aws lambda publish-layer-version \
               --layer-name ${{ env.LAYER_NAME }} \
-              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=aws-opentelemetry-java-layer.zip \
+              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=${{ env.LAYER_ARTIFACT_NAME }} \
               --compatible-runtimes java11 java17 java21 \
               --compatible-architectures "arm64" "x86_64" \
               --license-info "Apache-2.0" \
@@ -431,7 +444,7 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
         run: |
           cp "aws-opentelemetry-agent-$VERSION.jar" ${{ env.ARTIFACT_NAME }}
-          cp aws-opentelemetry-java-layer.zip layer.zip
+          cp ${{ env.LAYER_ARTIFACT_NAME }} layer.zip
 
       # Publish to GitHub releases
       - name: Create GH release


### PR DESCRIPTION
*Issue #, if available:*

The lambda layer signature in python release is failed.

*Description of changes:*
using `--clobber` override the existing lambda layer artifact on s3 with the signed one. And adding more logs for debugging.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
