### PR TITLE
fix: prevent script injection in workflows

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -13,6 +13,8 @@ on:
 env:
   AWS_DEFAULT_REGION: us-east-1
   TEST_TAG: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:test-v2
+  VERSION: ${{ github.event.inputs.version }}
+  COMMITS: ${{ github.event.inputs.commits }}
 
 permissions:
   id-token: write
@@ -30,9 +32,9 @@ jobs:
         name: Parse release branch name
         run: |
           # Sets the release-branch-name output to the version number with the last non-period element replaced with an 'x' and preprended with v.
-          echo "release-branch-name=$(echo '${{ github.event.inputs.version }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.x/')" >> $GITHUB_OUTPUT
+          echo "release-branch-name=$(echo '${{ env.VERSION }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.x/')" >> $GITHUB_OUTPUT
           # Sets the release-tag-name output to the version number with the last non-period element replace with a '0' and prepended with v
-          echo "release-tag-name=$(echo '${{ github.event.inputs.version }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.0/')" >> $GITHUB_OUTPUT
+          echo "release-tag-name=$(echo '${{ env.VERSION }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.0/')" >> $GITHUB_OUTPUT
       - id: checkout-release-branch
         name: Check out release branch
         # Will fail if there is no release branch yet or succeed otherwise
@@ -81,17 +83,17 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Cherrypicks
-        if: ${{ github.event.inputs.commits != '' }}
+        if: ${{ env.COMMITS != '' }}
         run: |
           git fetch origin main
-          echo ${{ github.event.inputs.commits }} | sed -n 1'p' | tr ',' '\n' | while read word; do
+          echo ${{ env.COMMITS }} | sed -n 1'p' | tr ',' '\n' | while read word; do
               # Trim whitespaces and cherrypick
               echo $word | sed 's/ *$//g' | sed 's/^ *//g' | git cherry-pick --stdin
           done
       - name: Build release with Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ env.VERSION }} --stacktrace
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
@@ -116,7 +118,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: false
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
           context: .
           platforms: linux/amd64
           tags: ${{ env.TEST_TAG }}
@@ -124,22 +126,22 @@ jobs:
 
       - name: Test docker image
         shell: bash
-        run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "${{ github.event.inputs.version }}"
+        run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "${{ env.VERSION }}"
 
       - name: Build and push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: true
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ github.event.inputs.version }}
+            public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v${{ env.VERSION }}
 
       - name: Build and Publish release with Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ env.VERSION }} --stacktrace
         env:
           PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
           PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
@@ -151,9 +153,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-            cp "otelagent/build/libs/aws-opentelemetry-agent-${{ github.event.inputs.version }}.jar" aws-opentelemetry-agent.jar
+            cp "otelagent/build/libs/aws-opentelemetry-agent-${{ env.VERSION }}.jar" aws-opentelemetry-agent.jar
             gh release create --target "$GITHUB_REF_NAME" \
-               --title "Release v${{ github.event.inputs.version }}" \
+               --title "Release v${{ env.VERSION }}" \
                --draft \
-               "v${{ github.event.inputs.version }}" \
+               "v${{ env.VERSION }}" \
                aws-opentelemetry-agent.jar

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  VERSION: ${{ github.event.inputs.version }}
+  IS_PATCH: ${{ github.event.inputs.is_patch }}
 
 permissions:
   id-token: write
@@ -31,8 +33,8 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo ${{ env.VERSION }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Get current major.minor version from main branch
         id: get_version
@@ -89,8 +91,8 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo ${{ env.VERSION }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Determine release branch and checkout
         run: |
@@ -100,13 +102,13 @@ jobs:
 
       - name: Update version to next development version in main
         run: |
-          DEV_VERSION="${{ github.event.inputs.version }}-SNAPSHOT"
+          DEV_VERSION="${{ env.VERSION }}-SNAPSHOT"
           sed -i'' -e "s/val adotVersion = \".*\"/val adotVersion = \"${DEV_VERSION}\"/" version.gradle.kts
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ env.VERSION }}"
           sed -i'' -e 's/adot-autoinstrumentation-java:v2.*"/adot-autoinstrumentation-java:v'$VERSION'"/' .github/workflows/daily-scan.yml
 
           # for patch releases, avoid merge conflict by manually resolving CHANGELOG with main
-          if [[ "${{ github.event.inputs.is_patch }}" == "true" ]]; then
+          if [[ "${{ env.IS_PATCH }}" == "true" ]]; then
             # Copy the patch release entries
             sed -n "/^## v${VERSION}/,/^## v[0-9]/p" CHANGELOG.md | sed '$d' > /tmp/patch_release_section.txt
             git fetch origin main
@@ -125,7 +127,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
         run: |
-          DEV_VERSION="${{ github.event.inputs.version }}-SNAPSHOT"
+          DEV_VERSION="${{ env.VERSION }}-SNAPSHOT"
           gh pr create --title "Post release $VERSION: Update version to $DEV_VERSION" \
                        --body "This PR prepares the main branch for the next development cycle by updating the version to $DEV_VERSION and updating the image version to be scanned to the latest released.
           

--- a/.github/workflows/pre-release-prepare.yml
+++ b/.github/workflows/pre-release-prepare.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  VERSION: ${{ github.event.inputs.version }}
+  IS_PATCH: ${{ github.event.inputs.is_patch }}
 
 permissions:
   contents: write
@@ -51,12 +53,12 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo ${{ env.VERSION }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Create branches
         run: |
-          IS_PATCH=${{ github.event.inputs.is_patch }}
+          IS_PATCH=${{ env.IS_PATCH }}
           if [[ "$IS_PATCH" != "true" && "$IS_PATCH" != "false" ]]; then
             echo "Invalid input for IS_PATCH. Must be 'true' or 'false'."
             exit 1
@@ -95,7 +97,7 @@ jobs:
           git push origin "v${VERSION}_release"
 
       - name: Update CHANGELOG for release
-        if: github.event.inputs.is_patch != 'true'
+        if: ${{ env.IS_PATCH != 'true' }}
         run: |
           sed -i "s/## Unreleased/## Unreleased\n\n## v${VERSION} - $(date +%Y-%m-%d)/" CHANGELOG.md
           git add CHANGELOG.md
@@ -110,5 +112,5 @@ jobs:
                        --body "This PR updates the version to ${VERSION}.
           
           By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice." \
-                       --head v${{ github.event.inputs.version }}_release \
+                       --head v${{ env.VERSION }}_release \
                        --base release/v${MAJOR_MINOR}.x

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,6 +22,8 @@ env:
   # Legacy list of commercial regions to deploy to. New regions should NOT be added here, and instead should be added to the `aws_region` default input to the workflow.
   LEGACY_COMMERCIAL_REGIONS: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
   LAYER_NAME: AWSOpenTelemetryDistroJava
+  VERSION: ${{ github.event.inputs.version }}
+  AWS_REGION: ${{ github.event.inputs.aws_region }}
 
 permissions:
   id-token: write
@@ -77,13 +79,13 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ env.VERSION }} --stacktrace
 
       - name: Upload SDK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: otelagent/build/libs/aws-opentelemetry-agent-${{ github.event.inputs.version }}.jar
+          path: otelagent/build/libs/aws-opentelemetry-agent-${{ env.VERSION }}.jar
 
   build-layer:
     needs: build-sdk
@@ -94,7 +96,7 @@ jobs:
       - name: Set up regions matrix
         id: set-matrix
         env:
-          AWS_REGIONS: ${{ github.event.inputs.aws_region }}
+          AWS_REGIONS: ${{ env.AWS_REGION }}
         run: |
           IFS=',' read -ra REGIONS <<< "$AWS_REGIONS"
           MATRIX="["
@@ -158,7 +160,7 @@ jobs:
       - name: Build release with Gradle
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa #v2
         with:
-          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ env.VERSION }} --stacktrace
 
       - name: Configure AWS Credentials for public ECR
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
@@ -194,7 +196,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: false
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
           context: .
           platforms: linux/amd64
           tags: ${{ env.TEST_TAG }}
@@ -202,7 +204,7 @@ jobs:
 
       - name: Test docker image
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ env.VERSION }}
         shell: bash
         run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "$VERSION"
 
@@ -210,17 +212,17 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: true
-          build-args: "ADOT_JAVA_VERSION=${{ github.event.inputs.version }}"
+          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
-            ${{ env.PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
+            ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
+            ${{ env.PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
 
       - name: Build and Publish release with Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ env.VERSION }} --stacktrace
         env:
           PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
           PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
@@ -440,10 +442,8 @@ jobs:
           name: layer.zip
 
       - name: Rename artifacts
-        env:
-          VERSION: ${{ github.event.inputs.version }}
         run: |
-          cp "aws-opentelemetry-agent-$VERSION.jar" ${{ env.ARTIFACT_NAME }}
+          cp "aws-opentelemetry-agent-${{ env.VERSION }}.jar" ${{ env.ARTIFACT_NAME }}
           cp ${{ env.LAYER_ARTIFACT_NAME }} layer.zip
 
       # Publish to GitHub releases
@@ -451,7 +451,7 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ env.VERSION }}
         run: |
           # Extract versions from dependency files
           OTEL_INSTRUMENTATION_VERSION=$(grep "val otelVersion" dependencyManagement/build.gradle.kts | sed 's/.*= "\([^"]*\)".*/\1/' | sed 's/-adot1//')

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -25,6 +25,9 @@ env:
   CPU_LOAD_THRESHOLD: 55
   TOTAL_MEMORY_THRESHOLD: 4294967296 # 4 GiB
   MAX_BENCHMARKS_TO_KEEP: 100
+  TARGET_COMMIT_SHA: ${{ github.event.inputs.target_commit_sha }}
+  TEST_DURATION_MINUTES_INPUT: ${{ github.event.inputs.test_duration_minutes }}
+  EVENT_NAME: ${{ github.event_name }}
   # TODO: We might be able to adapt the "Soak Tests" to be "Overhead Tests".
   # This means monitoring the Sample App's performance using high levels of TPS
   # for the Load Generator over a shorter period of testing time. For example:
@@ -52,16 +55,16 @@ jobs:
     # MARK: - GitHub Workflow Event Type Specific Values
 
       - name: Use INPUT as commit SHA
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ env.EVENT_NAME == 'workflow_dispatch' }}
         run: |
-          echo "TARGET_SHA=${{ github.event.inputs.target_commit_sha }}" | tee --append $GITHUB_ENV;
+          echo "TARGET_SHA=${{ env.TARGET_COMMIT_SHA }}" | tee --append $GITHUB_ENV;
       - name: Use LATEST as commit SHA
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ env.EVENT_NAME != 'workflow_dispatch' }}
         run: |
           echo "TARGET_SHA=${{ github.sha }}" | tee --append $GITHUB_ENV;
       - name: Configure Performance Test Duration
         run: |
-          echo "TEST_DURATION_MINUTES=${{ github.event.inputs.test_duration_minutes || env.DEFAULT_TEST_DURATION_MINUTES }}" | tee --append $GITHUB_ENV;
+          echo "TEST_DURATION_MINUTES=${{ env.TEST_DURATION_MINUTES_INPUT || env.DEFAULT_TEST_DURATION_MINUTES }}" | tee --append $GITHUB_ENV;
       - name: Clone This Repo @ ${{ env.TARGET_SHA }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -224,14 +227,14 @@ jobs:
           # https://github.com/open-telemetry/opentelemetry-python/pull/1478
           # comment-always: true
           fail-on-alert: true
-          auto-push: ${{ github.event_name == 'schedule' &&
+          auto-push: ${{ env.EVENT_NAME == 'schedule' &&
             steps.check-already-have-performance-results.outcome == 'failure' &&
             github.ref == 'refs/heads/main' }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: soak-tests/per-commit-overall-results
       - name: Publish Issue if failed DURING Performance Tests
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
-        if: ${{ github.event_name == 'schedule' &&
+        if: ${{ env.EVENT_NAME == 'schedule' &&
           steps.check-failure-during-performance-tests.outcome == 'failure' }}
         env:
           APP_PLATFORM: ${{ matrix.app-platform }}
@@ -242,7 +245,7 @@ jobs:
           update_existing: true
       - name: Publish Issue if failed AFTER Performance Tests
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 #v2.9.2
-        if: ${{ github.event_name == 'schedule' &&
+        if: ${{ env.EVENT_NAME == 'schedule' &&
           steps.check-failure-after-performance-tests.outcome == 'failure' }}
         env:
           APP_PLATFORM: ${{ matrix.app-platform }}


### PR DESCRIPTION
## Description
This PR prevents script injection vulnerabilities in GitHub Actions workflows by moving `github.event` references to environment variables.

## Changes
- Added top-level `env` variables for all `github.event.inputs.*` usage
- Replaced `github.event.inputs.*` with `env.*` in all run steps
- Kept `github.event` usage in non-run contexts (if, with, etc.) as they are safe

## Affected Workflows
- patch-release-build.yml
- post-release-version-bump.yml
- pre-release-prepare.yml
- release-build.yml
- soak-testing.yml

## Pattern
This follows the same security pattern implemented in aws-otel-js-instrumentation:
https://github.com/aws-observability/aws-otel-js-instrumentation/commit/3d9ac9dc453b320c7a071fc1b8346559339e046e

## Testing
Verified that no `github.event.*` usage remains in run steps (except for the validation step itself in pr-build.yml).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.