### PR TITLE
Upgrade jackson-bom to 2.21.1 to fix GHSA-72hv-8253-57qq

### DIFF
--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -8,7 +8,4 @@
 #    statement: "<Why are we excluding?> <link to CVE where we can we status>"
 #    expired_at: <required - YYYY-MM-DD>
 
-vulnerabilities:
-  - id: GHSA-72hv-8253-57qq
-    statement: "Excluding to unblock PR build as the CVE fix is not yet released in upstream: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/16353"
-    expired_at: 2026-03-16
+vulnerabilities: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   ([#1298](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1298))
 - feat: Allow disabling of default anomaly condition
   ([#1329](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1329))
+- Upgrade jackson-bom to 2.21.1 to fix CVE GHSA-72hv-8253-57qq
+  ([#1334](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1334))
 
 ## v2.23.0 - 2026-01-24
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -35,7 +35,7 @@ val otelJavaAgentVersion = if (!testSnapshots) otelVersion else "$otelSnapshotVe
 
 val dependencyBoms = listOf(
   "com.amazonaws:aws-java-sdk-bom:1.12.599",
-  "com.fasterxml.jackson:jackson-bom:2.16.0",
+  "com.fasterxml.jackson:jackson-bom:2.21.1",
   "com.google.guava:guava-bom:33.0.0-jre",
   "com.google.protobuf:protobuf-bom:3.25.1",
   "com.linecorp.armeria:armeria-bom:1.26.4",


### PR DESCRIPTION


*Issue #, if available:*
https://github.com/advisories/GHSA-72hv-8253-57qq

*Description of changes:*
Fixes jackson-core Number Length Constraint Bypass in Async Parser DoS vulnerability (CVE in versions >= 2.0.0, <= 2.18.5).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
