### PR TITLE
feat: custom dimensions for service RED metrics

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.contrib.awsxray.AwsXrayAdaptiveSamplingConfig;
@@ -49,6 +50,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.semconv.ServiceAttributes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -102,6 +104,7 @@ public final class AwsApplicationSignalsCustomizerProvider
       "LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT";
 
   private static final Duration DEFAULT_METRIC_EXPORT_INTERVAL = Duration.ofMinutes(1);
+  static final AttributeKey<String> CUSTOM_METRIC_SERVICE_KEY = AttributeKey.stringKey("Service");
   private static final Logger logger =
       Logger.getLogger(AwsApplicationSignalsCustomizerProvider.class.getName());
 
@@ -153,6 +156,8 @@ public final class AwsApplicationSignalsCustomizerProvider
   static final String OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "otel.exporter.otlp.logs.protocol";
   private static final String OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT =
       "otel.aws.application.signals.exporter.endpoint";
+  private static final String APPLICATION_SIGNALS_CUSTOM_METRICS_EXPORTER_ENDPOINT_CONFIG =
+      "otel.aws.application.signals.custom.metrics.exporter.endpoint";
   private static final String OTEL_EXPORTER_OTLP_PROTOCOL = "otel.exporter.otlp.protocol";
   static final String OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "otel.exporter.otlp.traces.endpoint";
   static final String OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "otel.exporter.otlp.logs.endpoint";
@@ -258,6 +263,12 @@ public final class AwsApplicationSignalsCustomizerProvider
         if (configProps.getString(OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT) == null) {
           propsOverride.put(
               OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT, "http://localhost:4316/v1/metrics");
+        }
+        if (configProps.getString(APPLICATION_SIGNALS_CUSTOM_METRICS_EXPORTER_ENDPOINT_CONFIG)
+            == null) {
+          propsOverride.put(
+              APPLICATION_SIGNALS_CUSTOM_METRICS_EXPORTER_ENDPOINT_CONFIG,
+              "http://localhost:4318/v1/metrics");
         }
         if (configProps.getString(OTEL_EXPORTER_OTLP_PROTOCOL) == null) {
           propsOverride.put(OTEL_EXPORTER_OTLP_PROTOCOL, "http/protobuf");
@@ -425,10 +436,46 @@ public final class AwsApplicationSignalsCustomizerProvider
                   View.builder().setAggregation(Aggregation.drop()).build())
               .build();
 
+      // Construct custom metrics MeterProvider -> port 4317/4318
+      // Only created when service.name is available in the Resource.
+      // Uses a minimal Resource with only service.name + optional deployment.environment
+      // to prevent other OTEL_RESOURCE_ATTRIBUTES from becoming CW dimensions.
+      Resource customResource = buildCustomMetricsResource(ResourceHolder.getResource());
+
       // Construct and set application signals metrics processor
       AwsSpanMetricsProcessorBuilder awsSpanMetricsProcessorBuilder =
           AwsSpanMetricsProcessorBuilder.create(
               meterProvider, ResourceHolder.getResource(), meterProvider::forceFlush);
+
+      String serviceName = customResource.getAttribute(CUSTOM_METRIC_SERVICE_KEY);
+      if (serviceName != null && !serviceName.isEmpty()) {
+        MetricExporter customMetricsExporter =
+            ApplicationSignalsExporterProvider.INSTANCE.createCustomMetricsExporter(configProps);
+        MetricReader customMetricReader =
+            PeriodicMetricReader.builder(customMetricsExporter).setInterval(exportInterval).build();
+        SdkMeterProvider customMeterProvider =
+            SdkMeterProvider.builder()
+                .setResource(customResource)
+                .registerMetricReader(customMetricReader)
+                .build();
+        awsSpanMetricsProcessorBuilder.setCustomMeterProvider(customMeterProvider);
+
+        // Register shutdown hook so buffered custom metrics are flushed on application exit.
+        // The standard meterProvider is managed by the OTel SDK lifecycle, but this custom one
+        // is not registered with the SDK and needs its own shutdown hook.
+        Runtime.getRuntime()
+            .addShutdownHook(
+                new Thread(
+                    () -> {
+                      customMeterProvider.forceFlush().join(10, java.util.concurrent.TimeUnit.SECONDS);
+                      customMeterProvider.shutdown().join(10, java.util.concurrent.TimeUnit.SECONDS);
+                    },
+                    "custom-metrics-shutdown"));
+      } else {
+        logger.log(
+            Level.WARNING,
+            "service.name not found in Resource. Custom dimension metrics will be disabled.");
+      }
       if (this.sampler != null) {
         awsSpanMetricsProcessorBuilder.setSampler(this.sampler);
       }
@@ -650,6 +697,24 @@ public final class AwsApplicationSignalsCustomizerProvider
     return yamlMapper.readValue(config, AwsXrayAdaptiveSamplingConfig.class);
   }
 
+  /**
+   * Build a minimal Resource for the custom metrics MeterProvider with only {@code Service} from
+   * the application Resource.
+   *
+   * <p>Only {@code Service} is included to prevent cloud.*, host.*, process.*, telemetry.*, and
+   * deployment.environment from becoming CloudWatch dimensions via resource_to_telemetry_conversion.
+   */
+  static Resource buildCustomMetricsResource(Resource appResource) {
+    AttributesBuilder builder = Attributes.builder();
+
+    String serviceName = appResource.getAttribute(ServiceAttributes.SERVICE_NAME);
+    if (serviceName != null && !serviceName.isEmpty()) {
+      builder.put(CUSTOM_METRIC_SERVICE_KEY, serviceName);
+    }
+
+    return Resource.create(builder.build());
+  }
+
   private enum ApplicationSignalsExporterProvider {
     INSTANCE;
 
@@ -698,6 +763,49 @@ public final class AwsApplicationSignalsCustomizerProvider
       }
       throw new ConfigurationException(
           "Unsupported AWS Application Signals export protocol: " + protocol);
+    }
+
+    public MetricExporter createCustomMetricsExporter(ConfigProperties configProps) {
+      String protocol =
+          OtlpConfigUtil.getOtlpProtocol(OtlpConfigUtil.DATA_TYPE_METRICS, configProps);
+      logger.log(
+          Level.FINE,
+          String.format("AWS Application Signals custom metrics export protocol: %s", protocol));
+
+      String customMetricsEndpoint;
+      if (protocol.equals(OtlpConfigUtil.PROTOCOL_HTTP_PROTOBUF)) {
+        customMetricsEndpoint =
+            configProps.getString(
+                APPLICATION_SIGNALS_CUSTOM_METRICS_EXPORTER_ENDPOINT_CONFIG,
+                "http://localhost:4318/v1/metrics");
+        logger.log(
+            Level.FINE,
+            String.format(
+                "AWS Application Signals custom metrics export endpoint: %s",
+                customMetricsEndpoint));
+        return OtlpHttpMetricExporter.builder()
+            .setEndpoint(customMetricsEndpoint)
+            .setDefaultAggregationSelector(this::getAggregation)
+            .setAggregationTemporalitySelector(CloudWatchTemporalitySelector.alwaysDelta())
+            .build();
+      } else if (protocol.equals(OtlpConfigUtil.PROTOCOL_GRPC)) {
+        customMetricsEndpoint =
+            configProps.getString(
+                APPLICATION_SIGNALS_CUSTOM_METRICS_EXPORTER_ENDPOINT_CONFIG,
+                "http://localhost:4317");
+        logger.log(
+            Level.FINE,
+            String.format(
+                "AWS Application Signals custom metrics export endpoint: %s",
+                customMetricsEndpoint));
+        return OtlpGrpcMetricExporter.builder()
+            .setEndpoint(customMetricsEndpoint)
+            .setDefaultAggregationSelector(this::getAggregation)
+            .setAggregationTemporalitySelector(CloudWatchTemporalitySelector.alwaysDelta())
+            .build();
+      }
+      throw new ConfigurationException(
+          "Unsupported AWS Application Signals custom metrics export protocol: " + protocol);
     }
 
     private Aggregation getAggregation(InstrumentType instrumentType) {

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java
@@ -132,4 +132,7 @@ final class AwsAttributeKeys {
 
   static final AttributeKey<Boolean> AWS_TRACE_LAMBDA_MULTIPLE_SERVER =
       AttributeKey.booleanKey("aws.trace.lambda.multiple-server");
+
+  static final String AWS_APPLICATION_SIGNALS_CUSTOM_DIM_PREFIX =
+      "aws.application_signals.custom.dim.";
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
@@ -17,12 +17,15 @@ package software.amazon.opentelemetry.javaagent.providers;
 
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_STATUS_CODE;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_LOCAL_OPERATION;
 import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_REMOTE_SERVICE;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.getKeyValueWithFallback;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.awsxray.AwsXrayRemoteSampler;
@@ -33,9 +36,14 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import javax.annotation.concurrent.Immutable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This processor will generate metrics based on span data. It depends on a {@link
@@ -53,8 +61,9 @@ import javax.annotation.concurrent.Immutable;
  * <p>For highest fidelity metrics, this processor should be coupled with the {@link
  * AlwaysRecordSampler}, which will result in 100% of spans being sent to the processor.
  */
-@Immutable
 public final class AwsSpanMetricsProcessor implements SpanProcessor {
+
+  private static final Logger logger = Logger.getLogger(AwsSpanMetricsProcessor.class.getName());
 
   private static final double NANOS_TO_MILLIS = 1_000_000.0;
 
@@ -64,14 +73,23 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   private static final int FAULT_CODE_LOWER_BOUND = 500;
   private static final int FAULT_CODE_UPPER_BOUND = 599;
 
+  // Max custom dimensions per span to prevent cardinality explosion in CloudWatch.
+  // Each custom dim generates 2 metric recordings (with and without Operation).
+  private static final int MAX_CUSTOM_DIMS_PER_SPAN = 10;
+
   // EC2 Metadata API IP Address
   // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instancedata-inside-access
   private final String EC2_METADATA_API_IP = "169.254.169.254";
 
-  // Metric instruments
+  // Metric instruments (standard AppSignals -> port 4315/4316)
   private final LongHistogram errorHistogram;
   private final LongHistogram faultHistogram;
   private final DoubleHistogram latencyHistogram;
+
+  // Custom metrics histograms (-> port 4317/4318), nullable
+  private final LongHistogram customErrorHistogram;
+  private final LongHistogram customFaultHistogram;
+  private final DoubleHistogram customLatencyHistogram;
 
   private final MetricAttributeGenerator generator;
   private final Resource resource;
@@ -79,11 +97,35 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
 
   private Sampler sampler;
 
+  // traceId -> accumulated custom dims from any span in the trace.
+  // Bounded: entries are evicted after PENDING_DIMS_TTL_NANOS to prevent memory leaks
+  // when local root spans end before all child spans (async frameworks).
+  private static final long PENDING_DIMS_TTL_NANOS = 5 * 60 * 1_000_000_000L; // 5 minutes
+  private static final int PENDING_DIMS_MAX_SIZE = 10_000;
+  private static final long EVICTION_INTERVAL_NANOS = 60 * 1_000_000_000L; // 1 minute
+
+  private final ConcurrentHashMap<String, PendingDimEntry> pendingCustomDims =
+      new ConcurrentHashMap<>();
+  private final AtomicLong lastEvictionNanos = new AtomicLong(System.nanoTime());
+
+  private static final class PendingDimEntry {
+    final Map<String, String> dims;
+    final long createdNanos;
+
+    PendingDimEntry(Map<String, String> dims) {
+      this.dims = dims;
+      this.createdNanos = System.nanoTime();
+    }
+  }
+
   /** Use {@link AwsSpanMetricsProcessorBuilder} to construct this processor. */
   static AwsSpanMetricsProcessor create(
       LongHistogram errorHistogram,
       LongHistogram faultHistogram,
       DoubleHistogram latencyHistogram,
+      LongHistogram customErrorHistogram,
+      LongHistogram customFaultHistogram,
+      DoubleHistogram customLatencyHistogram,
       MetricAttributeGenerator generator,
       Resource resource,
       Sampler sampler,
@@ -92,6 +134,9 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
         errorHistogram,
         faultHistogram,
         latencyHistogram,
+        customErrorHistogram,
+        customFaultHistogram,
+        customLatencyHistogram,
         generator,
         resource,
         sampler,
@@ -102,6 +147,9 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
       LongHistogram errorHistogram,
       LongHistogram faultHistogram,
       DoubleHistogram latencyHistogram,
+      LongHistogram customErrorHistogram,
+      LongHistogram customFaultHistogram,
+      DoubleHistogram customLatencyHistogram,
       MetricAttributeGenerator generator,
       Resource resource,
       Sampler sampler,
@@ -109,6 +157,9 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
     this.errorHistogram = errorHistogram;
     this.faultHistogram = faultHistogram;
     this.latencyHistogram = latencyHistogram;
+    this.customErrorHistogram = customErrorHistogram;
+    this.customFaultHistogram = customFaultHistogram;
+    this.customLatencyHistogram = customLatencyHistogram;
     this.generator = generator;
     this.resource = resource;
     this.sampler = sampler;
@@ -131,17 +182,103 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   @Override
   public void onEnd(ReadableSpan span) {
     SpanData spanData = span.toSpanData();
+    SpanContext ownSpanContext = spanData.getSpanContext();
+    String traceId = ownSpanContext != null ? ownSpanContext.getTraceId() : null;
 
     // If OTEL_AWS_HTTP_OPERATION_PATHS is configured, wrap the span with the overridden name
     // so that metrics use the configured operation path instead of the original span name.
     spanData = AwsSpanProcessingUtil.applyOperationPathSpanName(spanData);
 
-    Map<String, Attributes> attributeMap =
-        generator.generateMetricAttributeMapFromSpan(spanData, resource);
+    // Extract custom dims from this span's attributes and accumulate under traceId.
+    // Any span in the trace can contribute custom dims regardless of depth or kind.
+    Map<String, String> ownCustomDims = CustomDimensionExtractor.extract(spanData.getAttributes());
+    boolean isLocalRoot = traceId != null && AwsSpanProcessingUtil.isLocalRoot(spanData);
 
-    for (Map.Entry<String, Attributes> attribute : attributeMap.entrySet()) {
+    if (!ownCustomDims.isEmpty() && traceId != null) {
+      pendingCustomDims.compute(
+          traceId,
+          (key, existing) -> {
+            if (existing == null) {
+              return new PendingDimEntry(new HashMap<>(ownCustomDims));
+            }
+            Map<String, String> merged = new HashMap<>(existing.dims);
+            merged.putAll(ownCustomDims);
+            return new PendingDimEntry(merged);
+          });
+    }
+
+    // For local root spans, atomically read-and-remove to avoid race with late child merges.
+    // Uses compute() so the read and remove happen in a single atomic operation.
+    Map<String, String> allCustomDims = null;
+    if (isLocalRoot) {
+      PendingDimEntry[] holder = new PendingDimEntry[1];
+      pendingCustomDims.compute(
+          traceId,
+          (key, existing) -> {
+            holder[0] = existing;
+            return null; // remove
+          });
+      allCustomDims = holder[0] != null ? holder[0].dims : null;
+    }
+
+    // Periodically evict stale entries to prevent memory leaks from orphaned traces
+    evictStaleEntries();
+
+    // Always generate standard Application Signals metrics -> port 4315/4316
+    Map<String, Attributes> standardAttributeMap =
+        generator.generateMetricAttributeMapFromSpan(spanData, resource);
+    for (Map.Entry<String, Attributes> attribute : standardAttributeMap.entrySet()) {
       recordMetrics(span, spanData, attribute.getValue());
     }
+
+    // Generate custom dimension metrics -> port 4317/4318
+    // Only for SERVICE-type spans (SERVER or local root), not DEPENDENCY
+    if (allCustomDims != null && !allCustomDims.isEmpty()) {
+      if (!AwsSpanProcessingUtil.shouldGenerateServiceMetricAttributes(spanData)) {
+        logger.log(
+            Level.WARNING,
+            "Custom dims {0} discarded: span ''{1}'' (kind={2}) does not qualify for "
+                + "service metric generation. BUSINESS configs are ineffective for this span.",
+            new Object[] {allCustomDims.keySet(), spanData.getName(), spanData.getKind()});
+      } else {
+        // Get Operation from the standard SERVICE_METRIC attributes
+        Attributes serviceAttrs = standardAttributeMap.get(MetricAttributeGenerator.SERVICE_METRIC);
+        String operation = serviceAttrs != null ? serviceAttrs.get(AWS_LOCAL_OPERATION) : null;
+
+        if (allCustomDims.size() > MAX_CUSTOM_DIMS_PER_SPAN) {
+          logger.log(
+              Level.WARNING,
+              "Span ''{0}'' has {1} custom dims, exceeding cap of {2}. Only first {2} will be processed.",
+              new Object[] {spanData.getName(), allCustomDims.size(), MAX_CUSTOM_DIMS_PER_SPAN});
+        }
+
+        // For EACH custom dim separately, generate 2 recordings
+        int count = 0;
+        for (Map.Entry<String, String> dim : allCustomDims.entrySet()) {
+          if (count >= MAX_CUSTOM_DIMS_PER_SPAN) {
+            break;
+          }
+          count++;
+
+          String dimName = dim.getKey();
+          String dimValue = dim.getValue();
+
+          // Set A: {Operation=<value>, <dimName>=<dimValue>}
+          if (operation != null) {
+            AttributesBuilder withOpBuilder = Attributes.builder();
+            withOpBuilder.put("Operation", operation);
+            withOpBuilder.put(dimName, dimValue);
+            recordCustomMetrics(span, spanData, withOpBuilder.build());
+          }
+
+          // Set B: {<dimName>=<dimValue>}
+          Attributes withoutOp =
+              Attributes.of(io.opentelemetry.api.common.AttributeKey.stringKey(dimName), dimValue);
+          recordCustomMetrics(span, spanData, withoutOp);
+        }
+      }
+    }
+
     if (sampler != null) {
       ((AwsXrayRemoteSampler) sampler).adaptSampling(span, spanData);
     }
@@ -155,7 +292,11 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   // The logic to record error and fault should be kept in sync with the aws-xray exporter whenever
   // possible except for the throttle
   // https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsxrayexporter/internal/translator/cause.go#L121-L160
-  private void recordErrorOrFault(SpanData spanData, Attributes attributes) {
+  private void recordErrorOrFault(
+      SpanData spanData,
+      Attributes attributes,
+      LongHistogram errorHist,
+      LongHistogram faultHist) {
     Long httpStatusCode =
         getKeyValueWithFallback(spanData, HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE);
     StatusCode statusCode = spanData.getStatus().getStatusCode();
@@ -168,20 +309,20 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
         || httpStatusCode < ERROR_CODE_LOWER_BOUND
         || httpStatusCode > FAULT_CODE_UPPER_BOUND) {
       if (StatusCode.ERROR.equals(statusCode)) {
-        errorHistogram.record(0, attributes);
-        faultHistogram.record(1, attributes);
+        errorHist.record(0, attributes);
+        faultHist.record(1, attributes);
       } else {
-        errorHistogram.record(0, attributes);
-        faultHistogram.record(0, attributes);
+        errorHist.record(0, attributes);
+        faultHist.record(0, attributes);
       }
     } else if (httpStatusCode >= ERROR_CODE_LOWER_BOUND
         && httpStatusCode <= ERROR_CODE_UPPER_BOUND) {
-      errorHistogram.record(1, attributes);
-      faultHistogram.record(0, attributes);
+      errorHist.record(1, attributes);
+      faultHist.record(0, attributes);
     } else if (httpStatusCode >= FAULT_CODE_LOWER_BOUND
         && httpStatusCode <= FAULT_CODE_UPPER_BOUND) {
-      errorHistogram.record(0, attributes);
-      faultHistogram.record(1, attributes);
+      errorHist.record(0, attributes);
+      faultHist.record(1, attributes);
     }
   }
 
@@ -194,9 +335,33 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   private void recordMetrics(ReadableSpan span, SpanData spanData, Attributes attributes) {
     // Only record metrics if non-empty attributes are returned.
     if (!attributes.isEmpty() && !isEc2MetadataSpan((attributes))) {
-      recordErrorOrFault(spanData, attributes);
+      recordErrorOrFault(spanData, attributes, errorHistogram, faultHistogram);
       recordLatency(span, attributes);
     }
+  }
+
+  private void recordCustomMetrics(ReadableSpan span, SpanData spanData, Attributes attributes) {
+    if (!attributes.isEmpty() && !isEc2MetadataSpan(attributes) && customErrorHistogram != null) {
+      double latencyMillis = span.getLatencyNanos() / NANOS_TO_MILLIS;
+      logger.log(
+          Level.FINER,
+          "Recording custom metric -> port 4317/4318: span=[{0}], latency={1}ms, attributes={2}",
+          new Object[] {spanData.getName(), latencyMillis, attributes});
+      recordErrorOrFault(spanData, attributes, customErrorHistogram, customFaultHistogram);
+      recordCustomLatency(span, attributes);
+    } else if (customErrorHistogram == null) {
+      logger.log(
+          Level.FINE,
+          "Custom metric histograms not configured (null). "
+              + "Custom dim metrics will be skipped for span [{0}].",
+          spanData.getName());
+    }
+  }
+
+  private void recordCustomLatency(ReadableSpan span, Attributes attributes) {
+    long nanos = span.getLatencyNanos();
+    double millis = nanos / NANOS_TO_MILLIS;
+    customLatencyHistogram.record(millis, attributes);
   }
 
   private boolean isEc2MetadataSpan(Attributes attributes) {
@@ -206,5 +371,49 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
     }
 
     return false;
+  }
+
+  /**
+   * Evict stale entries from pendingCustomDims that exceeded TTL. Also enforces a hard size cap.
+   * Runs at most once per EVICTION_INTERVAL_NANOS to avoid overhead on every span.
+   */
+  private void evictStaleEntries() {
+    long now = System.nanoTime();
+    long lastEviction = lastEvictionNanos.get();
+    if (now - lastEviction < EVICTION_INTERVAL_NANOS) {
+      return;
+    }
+    if (!lastEvictionNanos.compareAndSet(lastEviction, now)) {
+      return; // Another thread is handling eviction
+    }
+
+    int evicted = 0;
+    Iterator<Map.Entry<String, PendingDimEntry>> it = pendingCustomDims.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry<String, PendingDimEntry> entry = it.next();
+      if (now - entry.getValue().createdNanos > PENDING_DIMS_TTL_NANOS) {
+        it.remove();
+        evicted++;
+      }
+    }
+
+    // Hard size cap as safety net
+    if (pendingCustomDims.size() > PENDING_DIMS_MAX_SIZE) {
+      int excess = pendingCustomDims.size() - PENDING_DIMS_MAX_SIZE;
+      Iterator<String> keyIt = pendingCustomDims.keySet().iterator();
+      while (keyIt.hasNext() && excess > 0) {
+        keyIt.next();
+        keyIt.remove();
+        excess--;
+        evicted++;
+      }
+    }
+
+    if (evicted > 0) {
+      logger.log(
+          Level.FINE,
+          "Evicted {0} stale entries from pendingCustomDims, remaining: {1}",
+          new Object[] {evicted, pendingCustomDims.size()});
+    }
   }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorBuilder.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorBuilder.java
@@ -54,6 +54,7 @@ public final class AwsSpanMetricsProcessorBuilder {
   private MetricAttributeGenerator generator = DEFAULT_GENERATOR;
   private Sampler sampler;
   private String scopeName = DEFAULT_SCOPE_NAME;
+  private MeterProvider customMeterProvider;
 
   public static AwsSpanMetricsProcessorBuilder create(
       MeterProvider meterProvider,
@@ -104,6 +105,12 @@ public final class AwsSpanMetricsProcessorBuilder {
     return this;
   }
 
+  @CanIgnoreReturnValue
+  public AwsSpanMetricsProcessorBuilder setCustomMeterProvider(MeterProvider customMeterProvider) {
+    this.customMeterProvider = customMeterProvider;
+    return this;
+  }
+
   public AwsSpanMetricsProcessor build() {
     Meter meter = meterProvider.get(scopeName);
     LongHistogram errorHistogram = meter.histogramBuilder(ERROR).ofLongs().build();
@@ -111,10 +118,23 @@ public final class AwsSpanMetricsProcessorBuilder {
     DoubleHistogram latencyHistogram =
         meter.histogramBuilder(LATENCY).setUnit(LATENCY_UNITS).build();
 
+    LongHistogram customErrorHistogram = null;
+    LongHistogram customFaultHistogram = null;
+    DoubleHistogram customLatencyHistogram = null;
+    if (customMeterProvider != null) {
+      Meter customMeter = customMeterProvider.get(scopeName);
+      customErrorHistogram = customMeter.histogramBuilder(ERROR).ofLongs().build();
+      customFaultHistogram = customMeter.histogramBuilder(FAULT).ofLongs().build();
+      customLatencyHistogram = customMeter.histogramBuilder(LATENCY).setUnit(LATENCY_UNITS).build();
+    }
+
     return AwsSpanMetricsProcessor.create(
         errorHistogram,
         faultHistogram,
         latencyHistogram,
+        customErrorHistogram,
+        customFaultHistogram,
+        customLatencyHistogram,
         generator,
         resource,
         sampler,

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/CustomDimensionExtractor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/CustomDimensionExtractor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys.AWS_APPLICATION_SIGNALS_CUSTOM_DIM_PREFIX;
+
+import io.opentelemetry.api.common.Attributes;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Utility class for extracting custom dimension values from span attributes */
+final class CustomDimensionExtractor {
+
+  private CustomDimensionExtractor() {}
+
+  /**
+   * Extract custom dimension values from span attributes Format:
+   * aws.application_signals.custom.dim.CarrierId → {"CarrierId": "Fedex"}
+   *
+   * @param spanAttributes The span's attributes
+   * @return Map of custom dimension name to value
+   */
+  static Map<String, String> extract(Attributes spanAttributes) {
+    Map<String, String> customDims = new HashMap<>();
+
+    spanAttributes.forEach(
+        (key, value) -> {
+          String keyName = key.getKey();
+          if (keyName.startsWith(AWS_APPLICATION_SIGNALS_CUSTOM_DIM_PREFIX) && value != null) {
+            String dimName = keyName.substring(AWS_APPLICATION_SIGNALS_CUSTOM_DIM_PREFIX.length());
+            if (!dimName.isEmpty()) {
+              customDims.put(dimName, value.toString());
+            }
+          }
+        });
+
+    return customDims;
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorTest.java
@@ -78,6 +78,9 @@ class AwsSpanMetricsProcessorTest {
   private LongHistogram errorHistogramMock;
   private LongHistogram faultHistogramMock;
   private DoubleHistogram latencyHistogramMock;
+  private LongHistogram customErrorHistogramMock;
+  private LongHistogram customFaultHistogramMock;
+  private DoubleHistogram customLatencyHistogramMock;
   private MetricAttributeGenerator generatorMock;
   private AwsXrayRemoteSampler samplerMock;
   private AwsSpanMetricsProcessor awsSpanMetricsProcessor;
@@ -93,6 +96,9 @@ class AwsSpanMetricsProcessorTest {
     errorHistogramMock = mock(LongHistogram.class);
     faultHistogramMock = mock(LongHistogram.class);
     latencyHistogramMock = mock(DoubleHistogram.class);
+    customErrorHistogramMock = mock(LongHistogram.class);
+    customFaultHistogramMock = mock(LongHistogram.class);
+    customLatencyHistogramMock = mock(DoubleHistogram.class);
     generatorMock = mock(MetricAttributeGenerator.class);
     samplerMock = mock(AwsXrayRemoteSampler.class);
 
@@ -101,6 +107,9 @@ class AwsSpanMetricsProcessorTest {
             errorHistogramMock,
             faultHistogramMock,
             latencyHistogramMock,
+            customErrorHistogramMock,
+            customFaultHistogramMock,
+            customLatencyHistogramMock,
             generatorMock,
             testResource,
             samplerMock,
@@ -463,6 +472,13 @@ class AwsSpanMetricsProcessorTest {
     when(mockSpanData.getParentSpanContext()).thenReturn(parentSpanContext);
     when(mockSpanData.getStatus()).thenReturn(statusData);
 
+    // Mock own SpanContext with a traceId so custom dim logic works
+    SpanContext ownSpanContext = mock(SpanContext.class);
+    when(ownSpanContext.getTraceId()).thenReturn("default-test-trace-id");
+    when(ownSpanContext.getSpanId()).thenReturn("default-test-span-id");
+    when(ownSpanContext.isValid()).thenReturn(true);
+    when(mockSpanData.getSpanContext()).thenReturn(ownSpanContext);
+
     when(readableSpanMock.toSpanData()).thenReturn(mockSpanData);
 
     return readableSpanMock;
@@ -663,5 +679,328 @@ class AwsSpanMetricsProcessorTest {
           .generateMetricAttributeMapFromSpan(spanCaptor.capture(), eq(testResource));
       assertThat(spanCaptor.getValue().getName()).isEqualTo("GET /api/users/{userId}/stats");
     }
+  }
+
+  // ===== Tests for Custom Dimension Metrics (Simplified, no dim_sets) =====
+
+  @Test
+  public void testCustomDim_SingleDimTriggersCustomMetrics() {
+    // A SERVER span with one custom RED dim should produce 2 custom metric recordings
+    // (with Operation + without Operation) plus standard metrics
+    Attributes spanAttributes =
+        Attributes.builder().put("aws.application_signals.custom.dim.CarrierId", "Fedex").build();
+
+    ReadableSpan readableSpanMock =
+        buildReadableSpanMock(spanAttributes, SpanKind.SERVER, null, StatusData.ok());
+
+    // Build metric attributes with Operation so custom metrics can use it
+    Map<String, Attributes> metricAttributesMap = new HashMap<>();
+    metricAttributesMap.put(
+        SERVICE_METRIC, Attributes.of(AwsAttributeKeys.AWS_LOCAL_OPERATION, "GET /api"));
+    configureMocksForOnEnd(readableSpanMock, metricAttributesMap);
+
+    awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+    // Standard histograms should receive 1 recording (SERVICE_METRIC)
+    verify(errorHistogramMock, times(1)).record(eq(0L), any(Attributes.class));
+    verify(faultHistogramMock, times(1)).record(eq(0L), any(Attributes.class));
+    verify(latencyHistogramMock, times(1)).record(eq(TEST_LATENCY_MILLIS), any(Attributes.class));
+
+    // Custom histograms: 2 recordings (with Operation, without Operation)
+    verify(customErrorHistogramMock, times(2)).record(eq(0L), any(Attributes.class));
+    verify(customFaultHistogramMock, times(2)).record(eq(0L), any(Attributes.class));
+    verify(customLatencyHistogramMock, times(2))
+        .record(eq(TEST_LATENCY_MILLIS), any(Attributes.class));
+  }
+
+  @Test
+  public void testCustomDim_NoCustomDimsNoCustomMetrics() {
+    // No custom dims -> no custom metrics
+    Attributes spanAttributes = buildSpanAttributes(CONTAINS_NO_ATTRIBUTES);
+    ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
+    Map<String, Attributes> metricAttributesMap =
+        buildMetricAttributes(CONTAINS_ATTRIBUTES, readableSpanMock.toSpanData());
+    configureMocksForOnEnd(readableSpanMock, metricAttributesMap);
+
+    awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+    // Standard histograms should receive metrics
+    verify(errorHistogramMock, times(1))
+        .record(eq(0L), eq(metricAttributesMap.get(SERVICE_METRIC)));
+    // Custom histograms should NOT receive metrics
+    verifyNoInteractions(customErrorHistogramMock);
+    verifyNoInteractions(customFaultHistogramMock);
+    verifyNoInteractions(customLatencyHistogramMock);
+  }
+
+  @Test
+  public void testCustomDim_ClientSpanNoCustomMetrics() {
+    // CLIENT span with custom dims -> no custom metrics (only SERVICE type generates custom)
+    SpanContext mockSpanContext = mock(SpanContext.class);
+    when(mockSpanContext.isValid()).thenReturn(true);
+    when(mockSpanContext.isRemote()).thenReturn(false);
+
+    Attributes spanAttributes =
+        Attributes.builder().put("aws.application_signals.custom.dim.CarrierId", "Fedex").build();
+
+    ReadableSpan readableSpanMock =
+        buildReadableSpanMock(spanAttributes, SpanKind.CLIENT, mockSpanContext, StatusData.ok());
+    Map<String, Attributes> metricAttributesMap =
+        buildMetricAttributes(CONTAINS_ATTRIBUTES, readableSpanMock.toSpanData());
+    configureMocksForOnEnd(readableSpanMock, metricAttributesMap);
+
+    awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+    // Standard histograms should receive metrics (dependency)
+    verify(errorHistogramMock, times(1)).record(eq(0L), any(Attributes.class));
+    // Custom histograms should NOT (CLIENT is DEPENDENCY, not SERVICE)
+    verifyNoInteractions(customErrorHistogramMock);
+    verifyNoInteractions(customFaultHistogramMock);
+    verifyNoInteractions(customLatencyHistogramMock);
+  }
+
+  @Test
+  public void testCustomDim_MultipleDims_SeparateDimSets() {
+    // 2 custom dims -> 4 recordings (2 per dim: with/without Operation)
+    Attributes spanAttributes =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.CarrierId", "Fedex")
+            .put("aws.application_signals.custom.dim.Region", "US-West")
+            .build();
+
+    ReadableSpan readableSpanMock =
+        buildReadableSpanMock(spanAttributes, SpanKind.SERVER, null, StatusData.ok());
+
+    Map<String, Attributes> metricAttributesMap = new HashMap<>();
+    metricAttributesMap.put(
+        SERVICE_METRIC, Attributes.of(AwsAttributeKeys.AWS_LOCAL_OPERATION, "GET /api"));
+    configureMocksForOnEnd(readableSpanMock, metricAttributesMap);
+
+    awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+    // Standard: 1 recording
+    verify(errorHistogramMock, times(1)).record(eq(0L), any(Attributes.class));
+
+    // Custom: 4 recordings (2 dims * 2 sets each)
+    verify(customErrorHistogramMock, times(4)).record(eq(0L), any(Attributes.class));
+    verify(customFaultHistogramMock, times(4)).record(eq(0L), any(Attributes.class));
+    verify(customLatencyHistogramMock, times(4))
+        .record(eq(TEST_LATENCY_MILLIS), any(Attributes.class));
+  }
+
+  @Test
+  public void testCustomDim_NullCustomHistograms_NoCrash() {
+    // Null custom histograms should not crash, standard metrics still generated
+    AwsSpanMetricsProcessor processorWithoutCustom =
+        AwsSpanMetricsProcessor.create(
+            errorHistogramMock,
+            faultHistogramMock,
+            latencyHistogramMock,
+            null,
+            null,
+            null,
+            generatorMock,
+            testResource,
+            samplerMock,
+            this::forceFlushAction);
+
+    Attributes spanAttributes =
+        Attributes.builder().put("aws.application_signals.custom.dim.CarrierId", "Fedex").build();
+
+    ReadableSpan readableSpanMock =
+        buildReadableSpanMock(spanAttributes, SpanKind.SERVER, null, StatusData.ok());
+    Map<String, Attributes> metricAttributesMap = new HashMap<>();
+    metricAttributesMap.put(
+        SERVICE_METRIC, Attributes.of(AwsAttributeKeys.AWS_LOCAL_OPERATION, "GET /api"));
+    configureMocksForOnEnd(readableSpanMock, metricAttributesMap);
+
+    processorWithoutCustom.onEnd(readableSpanMock);
+
+    // Standard histograms should still receive metrics
+    verify(errorHistogramMock, times(1)).record(eq(0L), any(Attributes.class));
+    verify(faultHistogramMock, times(1)).record(eq(0L), any(Attributes.class));
+    verify(latencyHistogramMock, times(1)).record(eq(TEST_LATENCY_MILLIS), any(Attributes.class));
+  }
+
+  @Test
+  public void testCustomDim_StandardMetricsAlwaysGenerated() {
+    // Standard metrics always generated regardless of custom dims
+    Attributes spanAttributes =
+        Attributes.builder().put("aws.application_signals.custom.dim.CarrierId", "Fedex").build();
+
+    ReadableSpan readableSpanMock =
+        buildReadableSpanMock(spanAttributes, SpanKind.SERVER, null, StatusData.ok());
+    Map<String, Attributes> metricAttributesMap =
+        buildMetricAttributes(CONTAINS_ATTRIBUTES, readableSpanMock.toSpanData());
+    configureMocksForOnEnd(readableSpanMock, metricAttributesMap);
+
+    awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+    // Standard histograms should receive metrics
+    verify(errorHistogramMock, times(1))
+        .record(eq(0L), eq(metricAttributesMap.get(SERVICE_METRIC)));
+    verify(faultHistogramMock, times(1))
+        .record(eq(0L), eq(metricAttributesMap.get(SERVICE_METRIC)));
+    verify(latencyHistogramMock, times(1))
+        .record(eq(TEST_LATENCY_MILLIS), eq(metricAttributesMap.get(SERVICE_METRIC)));
+  }
+
+  @Test
+  public void testCustomDim_TraceIdPropagation_ChildToParent() {
+    // Child INTERNAL span has custom dim, parent SERVER span (same traceId, local root)
+    // should pick up dims and generate custom metrics
+    String sharedTraceId = "trace-id-aabbccdd";
+
+    // Child span context (not local root: parent valid + not remote)
+    SpanContext childOwnCtx = mock(SpanContext.class);
+    when(childOwnCtx.getTraceId()).thenReturn(sharedTraceId);
+    when(childOwnCtx.getSpanId()).thenReturn("child-span-id");
+    when(childOwnCtx.isValid()).thenReturn(true);
+
+    SpanContext childParentCtx = mock(SpanContext.class);
+    when(childParentCtx.isValid()).thenReturn(true);
+    when(childParentCtx.isRemote()).thenReturn(false);
+
+    Attributes childAttrs =
+        Attributes.builder().put("aws.application_signals.custom.dim.CarrierId", "Fedex").build();
+    SpanData childData = mock(SpanData.class);
+    when(childData.getAttributes()).thenReturn(childAttrs);
+    when(childData.getKind()).thenReturn(SpanKind.INTERNAL);
+    when(childData.getParentSpanContext()).thenReturn(childParentCtx);
+    when(childData.getSpanContext()).thenReturn(childOwnCtx);
+    when(childData.getStatus()).thenReturn(StatusData.ok());
+    when(childData.getName()).thenReturn("getCarrierId");
+    ReadableSpan childMock = mock(ReadableSpan.class);
+    when(childMock.getLatencyNanos()).thenReturn(TEST_LATENCY_NANOS);
+    when(childMock.toSpanData()).thenReturn(childData);
+    when(generatorMock.generateMetricAttributeMapFromSpan(eq(childData), eq(testResource)))
+        .thenReturn(new HashMap<>());
+
+    // Process child -> stores CarrierId under traceId
+    awsSpanMetricsProcessor.onEnd(childMock);
+    verifyNoInteractions(customErrorHistogramMock);
+
+    // Parent SERVER span (local root: parent invalid)
+    SpanContext parentOwnCtx = mock(SpanContext.class);
+    when(parentOwnCtx.getTraceId()).thenReturn(sharedTraceId);
+    when(parentOwnCtx.getSpanId()).thenReturn("parent-span-id");
+    when(parentOwnCtx.isValid()).thenReturn(true);
+
+    SpanData parentData = mock(SpanData.class);
+    when(parentData.getAttributes()).thenReturn(Attributes.empty());
+    when(parentData.getKind()).thenReturn(SpanKind.SERVER);
+    when(parentData.getParentSpanContext()).thenReturn(SpanContext.getInvalid());
+    when(parentData.getSpanContext()).thenReturn(parentOwnCtx);
+    when(parentData.getStatus()).thenReturn(StatusData.ok());
+    when(parentData.getName()).thenReturn("GET /api");
+    ReadableSpan parentMock = mock(ReadableSpan.class);
+    when(parentMock.getLatencyNanos()).thenReturn(TEST_LATENCY_NANOS);
+    when(parentMock.toSpanData()).thenReturn(parentData);
+
+    Map<String, Attributes> parentMetricAttrs = new HashMap<>();
+    parentMetricAttrs.put(
+        SERVICE_METRIC, Attributes.of(AwsAttributeKeys.AWS_LOCAL_OPERATION, "GET /api"));
+    when(generatorMock.generateMetricAttributeMapFromSpan(eq(parentData), eq(testResource)))
+        .thenReturn(parentMetricAttrs);
+
+    // Process parent (local root) -> picks up dims by traceId
+    awsSpanMetricsProcessor.onEnd(parentMock);
+
+    // 1 dim * 2 sets = 2 custom recordings
+    verify(customErrorHistogramMock, times(2)).record(eq(0L), any(Attributes.class));
+    verify(customFaultHistogramMock, times(2)).record(eq(0L), any(Attributes.class));
+    verify(customLatencyHistogramMock, times(2))
+        .record(eq(TEST_LATENCY_MILLIS), any(Attributes.class));
+  }
+
+  @Test
+  public void testCustomDim_TraceIdPropagation_MultipleChildren() {
+    // Two children with different dims, same traceId -> parent gets both
+    String sharedTraceId = "trace-id-11223344";
+
+    // Child 1
+    SpanContext child1Ctx = mock(SpanContext.class);
+    when(child1Ctx.getTraceId()).thenReturn(sharedTraceId);
+    when(child1Ctx.getSpanId()).thenReturn("child1-id");
+    when(child1Ctx.isValid()).thenReturn(true);
+    SpanContext child1ParentCtx = mock(SpanContext.class);
+    when(child1ParentCtx.isValid()).thenReturn(true);
+    when(child1ParentCtx.isRemote()).thenReturn(false);
+
+    Attributes child1Attrs =
+        Attributes.of(
+            AttributeKey.stringKey("aws.application_signals.custom.dim.CarrierId"), "Fedex");
+    SpanData child1Data = mock(SpanData.class);
+    when(child1Data.getAttributes()).thenReturn(child1Attrs);
+    when(child1Data.getKind()).thenReturn(SpanKind.INTERNAL);
+    when(child1Data.getParentSpanContext()).thenReturn(child1ParentCtx);
+    when(child1Data.getSpanContext()).thenReturn(child1Ctx);
+    when(child1Data.getStatus()).thenReturn(StatusData.ok());
+    when(child1Data.getName()).thenReturn("child1");
+    ReadableSpan child1Mock = mock(ReadableSpan.class);
+    when(child1Mock.getLatencyNanos()).thenReturn(TEST_LATENCY_NANOS);
+    when(child1Mock.toSpanData()).thenReturn(child1Data);
+    when(generatorMock.generateMetricAttributeMapFromSpan(eq(child1Data), eq(testResource)))
+        .thenReturn(new HashMap<>());
+
+    // Child 2
+    SpanContext child2Ctx = mock(SpanContext.class);
+    when(child2Ctx.getTraceId()).thenReturn(sharedTraceId);
+    when(child2Ctx.getSpanId()).thenReturn("child2-id");
+    when(child2Ctx.isValid()).thenReturn(true);
+    SpanContext child2ParentCtx = mock(SpanContext.class);
+    when(child2ParentCtx.isValid()).thenReturn(true);
+    when(child2ParentCtx.isRemote()).thenReturn(false);
+
+    Attributes child2Attrs =
+        Attributes.of(
+            AttributeKey.stringKey("aws.application_signals.custom.dim.Region"), "US-West");
+    SpanData child2Data = mock(SpanData.class);
+    when(child2Data.getAttributes()).thenReturn(child2Attrs);
+    when(child2Data.getKind()).thenReturn(SpanKind.INTERNAL);
+    when(child2Data.getParentSpanContext()).thenReturn(child2ParentCtx);
+    when(child2Data.getSpanContext()).thenReturn(child2Ctx);
+    when(child2Data.getStatus()).thenReturn(StatusData.ok());
+    when(child2Data.getName()).thenReturn("child2");
+    ReadableSpan child2Mock = mock(ReadableSpan.class);
+    when(child2Mock.getLatencyNanos()).thenReturn(TEST_LATENCY_NANOS);
+    when(child2Mock.toSpanData()).thenReturn(child2Data);
+    when(generatorMock.generateMetricAttributeMapFromSpan(eq(child2Data), eq(testResource)))
+        .thenReturn(new HashMap<>());
+
+    awsSpanMetricsProcessor.onEnd(child1Mock);
+    awsSpanMetricsProcessor.onEnd(child2Mock);
+    verifyNoInteractions(customErrorHistogramMock);
+
+    // Parent SERVER span (local root, same traceId)
+    SpanContext parentCtx = mock(SpanContext.class);
+    when(parentCtx.getTraceId()).thenReturn(sharedTraceId);
+    when(parentCtx.getSpanId()).thenReturn("parent-id");
+    when(parentCtx.isValid()).thenReturn(true);
+
+    SpanData parentData = mock(SpanData.class);
+    when(parentData.getAttributes()).thenReturn(Attributes.empty());
+    when(parentData.getKind()).thenReturn(SpanKind.SERVER);
+    when(parentData.getParentSpanContext()).thenReturn(SpanContext.getInvalid());
+    when(parentData.getSpanContext()).thenReturn(parentCtx);
+    when(parentData.getStatus()).thenReturn(StatusData.ok());
+    when(parentData.getName()).thenReturn("GET /api");
+    ReadableSpan parentMock = mock(ReadableSpan.class);
+    when(parentMock.getLatencyNanos()).thenReturn(TEST_LATENCY_NANOS);
+    when(parentMock.toSpanData()).thenReturn(parentData);
+
+    Map<String, Attributes> parentMetricAttrs = new HashMap<>();
+    parentMetricAttrs.put(
+        SERVICE_METRIC, Attributes.of(AwsAttributeKeys.AWS_LOCAL_OPERATION, "GET /api"));
+    when(generatorMock.generateMetricAttributeMapFromSpan(eq(parentData), eq(testResource)))
+        .thenReturn(parentMetricAttrs);
+
+    awsSpanMetricsProcessor.onEnd(parentMock);
+
+    // 2 dims * 2 sets = 4 custom recordings
+    verify(customErrorHistogramMock, times(4)).record(eq(0L), any(Attributes.class));
+    verify(customFaultHistogramMock, times(4)).record(eq(0L), any(Attributes.class));
+    verify(customLatencyHistogramMock, times(4))
+        .record(eq(TEST_LATENCY_MILLIS), any(Attributes.class));
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/CustomDimensionExtractorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/CustomDimensionExtractorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.api.common.Attributes;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CustomDimensionExtractorTest {
+
+  @Test
+  void testExtractSingleCustomDimension() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.CarrierId", "Fedex")
+            .put("aws.local.service", "payment-service")
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(1, result.size());
+    assertEquals("Fedex", result.get("CarrierId"));
+  }
+
+  @Test
+  void testExtractMultipleCustomDimensions() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.CarrierId", "Fedex")
+            .put("aws.application_signals.custom.dim.Region", "US-West")
+            .put("aws.application_signals.custom.dim.TenantId", "tenant-123")
+            .put("aws.local.service", "payment-service")
+            .put("aws.local.operation", "ProcessPayment")
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(3, result.size());
+    assertEquals("Fedex", result.get("CarrierId"));
+    assertEquals("US-West", result.get("Region"));
+    assertEquals("tenant-123", result.get("TenantId"));
+  }
+
+  @Test
+  void testExtractNoCustomDimensions() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.local.service", "payment-service")
+            .put("aws.local.operation", "ProcessPayment")
+            .put("http.method", "POST")
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testExtractEmptyAttributes() {
+    Attributes attrs = Attributes.empty();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testExtractIgnoresNonCustomDimAttributes() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.CarrierId", "Fedex")
+            .put("aws.application_signals.dim_sets", "Service:Operation")
+            .put("aws.local.service", "payment-service")
+            .put("custom.dimension.NotInPrefix", "ignored")
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(1, result.size());
+    assertEquals("Fedex", result.get("CarrierId"));
+    assertFalse(result.containsKey("NotInPrefix"));
+  }
+
+  @Test
+  void testExtractWithEmptyDimensionName() {
+    // Edge case: attribute key ends with prefix but has no dimension name
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.", "ShouldBeIgnored")
+            .put("aws.application_signals.custom.dim.ValidName", "ValidValue")
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(1, result.size());
+    assertEquals("ValidValue", result.get("ValidName"));
+  }
+
+  @Test
+  void testExtractWithNumericValues() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.RequestCount", 42L)
+            .put("aws.application_signals.custom.dim.ErrorRate", 0.05)
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(2, result.size());
+    assertEquals("42", result.get("RequestCount"));
+    assertEquals("0.05", result.get("ErrorRate"));
+  }
+
+  @Test
+  void testExtractWithBooleanValues() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.IsProduction", true)
+            .put("aws.application_signals.custom.dim.HasErrors", false)
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(2, result.size());
+    assertEquals("true", result.get("IsProduction"));
+    assertEquals("false", result.get("HasErrors"));
+  }
+
+  @Test
+  void testExtractWithSpecialCharactersInDimensionName() {
+    Attributes attrs =
+        Attributes.builder()
+            .put("aws.application_signals.custom.dim.Carrier-Id_v2", "Fedex")
+            .put("aws.application_signals.custom.dim.Region.US", "West")
+            .build();
+
+    Map<String, String> result = CustomDimensionExtractor.extract(attrs);
+
+    assertEquals(2, result.size());
+    assertEquals("Fedex", result.get("Carrier-Id_v2"));
+    assertEquals("West", result.get("Region.US"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add custom dimension RED metrics triggered by `aws.application_signals.custom.dim.*` span attributes
- Custom dims from any span in a trace propagate to the local root span via traceId-based accumulation for custom service metric generation
- Each dim produces two metric recordings: `{Operation, dim}` and `{dim}`, emitted via a separate MeterProvider on port 4317/4318 as custom metric, in addition to existing Application Signals metrics
- Dual MeterProvider with minimal Resource isolation (only `service.name` + optional `deployment.environment`) to prevent other resource attributes from becoming CloudWatch dimensions

Example: when `aws.application_signals.custom.dim.CarrierId="xxx"` is recorded in any span, extra custom service metrics will be emitted with dimension sets `[Service, Environment, Operation, CarrierId]` and `[Service, Environment, CarrierId]`.

## Test plan
- [x] Unit tests for `CustomDimensionExtractor` (9 tests)
- [x] Unit tests for custom dim metrics in `AwsSpanMetricsProcessorTest` (8 tests)
- [x] TraceId-based upward propagation: single child, multiple children
- [x] Null custom histograms safety (no crash when service.name missing)
- [x] CLIENT span exclusion (only SERVICE-type spans generate custom metrics)
- [x] All 480 existing tests pass
- [x] E2E: deploy to EC2, verify CW dimensions `[service.name, deployment.environment, Operation, CarrierId]`