### PR TITLE
add OSS Index authentication to dependency-check

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -40,11 +40,13 @@ jobs:
           role-to-assume: ${{ secrets.SECRET_MANAGER_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
-      - name: Get NVD API key for dependency scan
+      - name: Get secrets for dependency scan
         uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 #v2.0.10
         id: nvd_api_key
         with:
-          secret-ids: ${{ secrets.NVD_API_KEY_SECRET_ARN }}
+          secret-ids: |
+            ${{ secrets.NVD_API_KEY_SECRET_ARN }}
+            OSS_INDEX, ${{ secrets.OSS_INDEX_SECRET_ARN }}
           parse-json-secrets: true
 
       - name: Publish patched dependencies to maven local
@@ -67,7 +69,7 @@ jobs:
                     curl -Ls "https://github.com/dependency-check/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc &&
                     gpg --verify dependency-check.zip.asc &&
                     unzip dependency-check.zip &&
-                    ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} -s "otelagent/build/libs/aws-opentelemetry-agent-*-SNAPSHOT.jar"'
+                    ./dependency-check/bin/dependency-check.sh --failOnCVSS 0 --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} --ossIndexUsername ${{ env.OSS_INDEX_USERNAME }} --ossIndexPassword ${{ env.OSS_INDEX_PASSWORD }} -s "otelagent/build/libs/aws-opentelemetry-agent-*-SNAPSHOT.jar"'
           cleanup: 'rm -f ./dependency-check.zip && rm -f ./dependency-check.zip.asc && rm -rf ./dependency-check || true'
           max_retry: 5
           sleep_time: 60


### PR DESCRIPTION
Sonatype OSS Index now requires authentication. Without credentials, dependency-check fails with exit code 14 due to rate limiting.

Validated in https://github.com/aws/aws-xray-daemon/pull/272
Passing run: https://github.com/aws/aws-xray-daemon/actions/runs/23265738194/job/67645958161 ("[INFO] Finished Sonatype OSS Index Analyzer (0 seconds)")