### PR TITLE
Change expiration dates for CVE-2026-33870 and CVE-2026-33871

### DIFF
--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -11,7 +11,7 @@
 vulnerabilities:
   - id: CVE-2026-33870
     statement: "Netty HTTP/1.1 Request Smuggling. Fix: bump netty-bom to 4.1.132.Final. https://github.com/aws-observability/aws-otel-java-instrumentation/issues/1346"
-    expired_at: 2026-04-14
+    expired_at: 2026-04-21
   - id: CVE-2026-33871
     statement: "Netty HTTP/2 CONTINUATION frame flood DoS. Fix: bump netty-bom to 4.1.132.Final. https://github.com/aws-observability/aws-otel-java-instrumentation/issues/1346"
-    expired_at: 2026-04-14
+    expired_at: 2026-04-21


### PR DESCRIPTION
*Description of changes:*
Updated expiration dates for CVE vulnerabilities in trivyignore.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
