### PR TITLE
feat: allow HTTP operations to be configurable via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- Support environment-configured endpoint visibility for HTTP operation names
+  ([#1352](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1352))
 - Bump Netty to 4.1.132.Final to fix CVE-2026-33870 and CVE-2026-33871
   ([#1348](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1348))
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributesSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributesSpanExporter.java
@@ -91,7 +91,6 @@ public class AwsMetricAttributesSpanExporter implements SpanExporter {
       // If OTEL_AWS_HTTP_OPERATION_PATHS is configured and matches, wrap the span with the
       // overridden name so that the exported trace carries the correct span name. This ensures
       // getIngressOperation (called below) derives aws.local.operation from the overridden name.
-      // Note: metrics are handled separately in AwsSpanMetricsProcessor.onEnd().
       span = AwsSpanProcessingUtil.applyOperationPathSpanName(span);
 
       // If the map has no items, no modifications are required. If there is one item, it means the

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributesSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributesSpanExporter.java
@@ -88,6 +88,12 @@ public class AwsMetricAttributesSpanExporter implements SpanExporter {
     List<SpanData> modifiedSpans = new ArrayList<>();
 
     for (SpanData span : spans) {
+      // If OTEL_AWS_HTTP_OPERATION_PATHS is configured and matches, wrap the span with the
+      // overridden name so that the exported trace carries the correct span name. This ensures
+      // getIngressOperation (called below) derives aws.local.operation from the overridden name.
+      // Note: metrics are handled separately in AwsSpanMetricsProcessor.onEnd().
+      span = AwsSpanProcessingUtil.applyOperationPathSpanName(span);
+
       // If the map has no items, no modifications are required. If there is one item, it means the
       // span either produces Service or Dependency metric attributes, and in either case we want to
       // modify the span with them. If there are two items, the span produces both Service and

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
@@ -132,6 +132,10 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   public void onEnd(ReadableSpan span) {
     SpanData spanData = span.toSpanData();
 
+    // If OTEL_AWS_HTTP_OPERATION_PATHS is configured, wrap the span with the overridden name
+    // so that metrics use the configured operation path instead of the original span name.
+    spanData = AwsSpanProcessingUtil.applyOperationPathSpanName(spanData);
+
     Map<String, Attributes> attributeMap =
         generator.generateMetricAttributeMapFromSpan(spanData, resource);
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -43,8 +43,8 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.data.DelegatingSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.HttpAttributes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -84,16 +84,14 @@ final class AwsSpanProcessingUtil {
   // Environment variable for configurable operation name paths
   static final String OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG = "OTEL_AWS_HTTP_OPERATION_PATHS";
 
-  private static final Logger logger =
-      Logger.getLogger(AwsSpanProcessingUtil.class.getName());
+  private static final Logger logger = Logger.getLogger(AwsSpanProcessingUtil.class.getName());
 
   // Parsed and sorted (longest first) operation paths from env var, computed once
   private static volatile List<String> operationPaths;
 
   /**
-   * Parse the OTEL_AWS_HTTP_OPERATION_PATHS env var into a sorted list of path prefixes (longest
-   * first). Curly-brace segments like {version} are converted to regex patterns for matching.
-   * Returns an empty list if the env var is not set.
+   * Parse the OTEL_AWS_HTTP_OPERATION_PATHS env var into a sorted list of path templates (longest
+   * first). Returns an empty list if the env var is not set.
    */
   static List<String> getOperationPaths() {
     if (operationPaths == null) {
@@ -111,11 +109,12 @@ final class AwsSpanProcessingUtil {
               }
             }
             // Sort longest first so longest prefix match wins
-            paths.sort((a, b) -> {
-              int aSegments = a.split("/").length;
-              int bSegments = b.split("/").length;
-              return Integer.compare(bSegments, aSegments);
-            });
+            paths.sort(
+                (a, b) -> {
+                  int aSegments = a.split("/").length;
+                  int bSegments = b.split("/").length;
+                  return Integer.compare(bSegments, aSegments);
+                });
             operationPaths = Collections.unmodifiableList(paths);
           }
         }
@@ -132,65 +131,150 @@ final class AwsSpanProcessingUtil {
   }
 
   /**
-   * Match a URL path against the configured operation paths. Returns the matched operation path
-   * template (e.g., "/api/{version}/users") or null if no match. Curly-brace segments in the
-   * configured path match any single path segment in the URL.
+   * If OTEL_AWS_HTTP_OPERATION_PATHS is configured and a pattern matches the span's URL path,
+   * returns a wrapped SpanData with the span name overridden to "METHOD /path/template". Returns
+   * the original span unchanged if no config is set or no pattern matches.
+   *
+   * <p>The URL path is extracted from url.path, http.target, url.full, or http.url (in that order).
+   * For full URLs, the path component is extracted.
+   *
+   * <p>Pattern segments can use {param}, :param, or * as wildcards that match any single path
+   * segment. A trailing /* matches any remaining segments.
    */
-  static String matchOperationPath(String urlPath) {
-    if (urlPath == null || urlPath.isEmpty()) {
-      return null;
-    }
-    // Strip query string and fragment
-    int queryIdx = urlPath.indexOf('?');
-    if (queryIdx >= 0) {
-      urlPath = urlPath.substring(0, queryIdx);
-    }
-    int fragIdx = urlPath.indexOf('#');
-    if (fragIdx >= 0) {
-      urlPath = urlPath.substring(0, fragIdx);
+  static SpanData applyOperationPathSpanName(SpanData span) {
+    List<String> paths = getOperationPaths();
+    if (paths.isEmpty()) {
+      return span;
     }
 
-    for (String pattern : getOperationPaths()) {
-      if (pathMatchesPattern(urlPath, pattern)) {
-        return pattern;
+    String urlPath = extractUrlPath(span);
+    if (urlPath == null || urlPath.isEmpty()) {
+      return span;
+    }
+
+    // Strip query string and fragment
+    int idx = urlPath.indexOf('?');
+    if (idx >= 0) {
+      urlPath = urlPath.substring(0, idx);
+    }
+    idx = urlPath.indexOf('#');
+    if (idx >= 0) {
+      urlPath = urlPath.substring(0, idx);
+    }
+
+    // Normalize trailing slashes
+    while (urlPath.endsWith("/") && urlPath.length() > 1) {
+      urlPath = urlPath.substring(0, urlPath.length() - 1);
+    }
+
+    // Find the first matching pattern (list is sorted longest first)
+    String[] urlSegments = urlPath.split("/", -1);
+    for (String pattern : paths) {
+      String normalizedPattern = pattern;
+      while (normalizedPattern.endsWith("/") && normalizedPattern.length() > 1) {
+        normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length() - 1);
+      }
+      if (segmentsMatch(urlSegments, normalizedPattern.split("/", -1))) {
+        String httpMethod = getHttpMethod(span);
+        String newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
+        return new DelegatingSpanData(span) {
+          @Override
+          public String getName() {
+            return newName;
+          }
+        };
+      }
+    }
+    return span;
+  }
+
+  /**
+   * Extract the URL path from span attributes for matching against configured operation paths.
+   * Checks http.route first (already a low-cardinality template), then url.path and http.target
+   * (just the path), then falls back to url.full and http.url (full URLs) and extracts the path.
+   */
+  private static String extractUrlPath(SpanData span) {
+    // Prefer http.route — it's already a template with placeholders like :param
+    AttributeKey<String> httpRoute = AttributeKey.stringKey("http.route");
+    if (isKeyPresent(span, httpRoute)) {
+      return span.getAttributes().get(httpRoute);
+    }
+    // Then try attributes that are just the path
+    if (isKeyPresent(span, URL_PATH)) {
+      return span.getAttributes().get(URL_PATH);
+    }
+    if (isKeyPresent(span, HTTP_TARGET)) {
+      return span.getAttributes().get(HTTP_TARGET);
+    }
+    // Fall back to full URLs — extract the path component
+    String fullUrl = null;
+    AttributeKey<String> urlFull = AttributeKey.stringKey("url.full");
+    AttributeKey<String> httpUrl = AttributeKey.stringKey("http.url");
+    if (isKeyPresent(span, urlFull)) {
+      fullUrl = span.getAttributes().get(urlFull);
+    } else if (isKeyPresent(span, httpUrl)) {
+      fullUrl = span.getAttributes().get(httpUrl);
+    }
+    if (fullUrl != null) {
+      int schemeEnd = fullUrl.indexOf("://");
+      if (schemeEnd >= 0) {
+        int pathStart = fullUrl.indexOf('/', schemeEnd + 3);
+        if (pathStart >= 0) {
+          return fullUrl.substring(pathStart);
+        }
       }
     }
     return null;
   }
 
   /**
-   * Check if a URL path matches a pattern. Patterns can contain curly-brace segments like
-   * {id} which match any single path segment. The pattern acts as a prefix — if all pattern
-   * segments match the corresponding URL segments, it's a match even if the URL has additional
-   * trailing segments. A trailing /* in the pattern explicitly matches any remaining segments.
+   * Check if URL segments match a pattern's segments. Both the URL and pattern can contain wildcard
+   * segments. A segment is a wildcard if it uses {param}, :param, or * format. Two wildcard
+   * segments always match each other. A wildcard matches any non-empty literal segment. Two literal
+   * segments must be equal. The pattern acts as a prefix — extra URL segments after the pattern are
+   * allowed. A trailing * in the pattern matches all remaining segments.
    */
-  private static boolean pathMatchesPattern(String urlPath, String pattern) {
-    String[] urlSegments = urlPath.split("/", -1);
-    String[] patternSegments = pattern.split("/", -1);
-
+  private static boolean segmentsMatch(String[] urlSegments, String[] patternSegments) {
     for (int i = 0; i < patternSegments.length; i++) {
       if (i >= urlSegments.length) {
         return false;
       }
       String ps = patternSegments[i];
-      // Wildcard matches remaining
-      if (ps.equals("*")) {
+      String us = urlSegments[i];
+
+      // Trailing * in pattern matches everything remaining
+      if (ps.equals("*") && i == patternSegments.length - 1) {
         return true;
       }
-      // Curly-brace segment matches any non-empty segment
-      if (ps.startsWith("{") && ps.endsWith("}")) {
-        if (urlSegments[i].isEmpty()) {
+
+      boolean patternIsWildcard = isWildcardSegment(ps);
+      boolean urlIsWildcard = isWildcardSegment(us);
+
+      // Two wildcards always match
+      if (patternIsWildcard && urlIsWildcard) {
+        continue;
+      }
+      // Wildcard matches any non-empty literal
+      if (patternIsWildcard || urlIsWildcard) {
+        String literal = patternIsWildcard ? us : ps;
+        if (literal.isEmpty()) {
           return false;
         }
         continue;
       }
-      // Literal match
-      if (!ps.equals(urlSegments[i])) {
+      // Both literal — must be equal
+      if (!ps.equals(us)) {
         return false;
       }
     }
-    // All pattern segments matched — URL may have extra trailing segments, that's fine
     return true;
+  }
+
+  /** A segment is a wildcard if it uses {param}, :param, or * format. */
+  private static boolean isWildcardSegment(String segment) {
+    return (segment.startsWith("{") && segment.endsWith("}"))
+        || segment.startsWith(":")
+        || segment.equals("*");
   }
 
   static List<String> getDialectKeywords() {
@@ -227,26 +311,6 @@ final class AwsSpanProcessingUtil {
       return getFunctionNameFromEnv() + "/FunctionHandler";
     }
 
-    // Priority 1: Check OTEL_AWS_HTTP_OPERATION_PATHS configuration
-    if (!getOperationPaths().isEmpty()) {
-      String urlPath = getUrlPath(span);
-      if (urlPath != null) {
-        String matchedPath = matchOperationPath(urlPath);
-        if (matchedPath != null) {
-          String httpMethod = getHttpMethod(span);
-          return httpMethod != null ? httpMethod + " " + matchedPath : matchedPath;
-        }
-      }
-    }
-
-    // Priority 2: Check http.route (OTel standard low-cardinality route template)
-    String httpRoute = span.getAttributes().get(HttpAttributes.HTTP_ROUTE);
-    if (httpRoute != null && !httpRoute.isEmpty()) {
-      String httpMethod = getHttpMethod(span);
-      return httpMethod != null ? httpMethod + " " + httpRoute : httpRoute;
-    }
-
-    // Priority 3: Existing logic — span.name or generateIngressOperation fallback
     String operation = span.getName();
     if (shouldUseInternalOperation(span)) {
       operation = INTERNAL_OPERATION;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -135,12 +135,6 @@ final class AwsSpanProcessingUtil {
    * If OTEL_AWS_HTTP_OPERATION_PATHS is configured and a pattern matches the span's URL path,
    * returns a wrapped SpanData with the span name overridden to "METHOD /path/template". Returns
    * the original span unchanged if no config is set or no pattern matches.
-   *
-   * <p>The URL path is extracted from url.path, http.target, url.full, or http.url (in that order).
-   * For full URLs, the path component is extracted.
-   *
-   * <p>Pattern segments can use {param}, :param, or * as wildcards that match any single path
-   * segment. A trailing /* matches any remaining segments.
    */
   static SpanData applyOperationPathSpanName(SpanData span) {
     List<String> paths = getOperationPaths();
@@ -148,75 +142,62 @@ final class AwsSpanProcessingUtil {
       return span;
     }
 
-    String urlPath = extractUrlPath(span);
-    if (urlPath == null || urlPath.isEmpty()) {
-      return span;
-    }
-
-    // Strip query string and fragment
-    int idx = urlPath.indexOf('?');
-    if (idx >= 0) {
-      urlPath = urlPath.substring(0, idx);
-    }
-    idx = urlPath.indexOf('#');
-    if (idx >= 0) {
-      urlPath = urlPath.substring(0, idx);
-    }
-
-    // Normalize trailing slashes
-    while (urlPath.endsWith("/") && urlPath.length() > 1) {
-      urlPath = urlPath.substring(0, urlPath.length() - 1);
-    }
-
-    // Find the first matching pattern (list is sorted longest first)
-    String[] urlSegments = urlPath.split("/", -1);
-    for (String pattern : paths) {
-      String normalizedPattern = pattern;
-      while (normalizedPattern.endsWith("/") && normalizedPattern.length() > 1) {
-        normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length() - 1);
+    for (String urlPath : getUrlPathCandidates(span)) {
+      if (urlPath == null || urlPath.isEmpty()) {
+        continue;
       }
-      if (segmentsMatch(urlSegments, normalizedPattern.split("/", -1))) {
-        String httpMethod = getHttpMethod(span);
-        String newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
-        return new DelegatingSpanData(span) {
-          @Override
-          public String getName() {
-            return newName;
-          }
-        };
+
+      // Strip query string and fragment (relevant for http.target)
+      int idx = urlPath.indexOf('?');
+      if (idx >= 0) {
+        urlPath = urlPath.substring(0, idx);
+      }
+      idx = urlPath.indexOf('#');
+      if (idx >= 0) {
+        urlPath = urlPath.substring(0, idx);
+      }
+
+      // Normalize trailing slashes
+      while (urlPath.endsWith("/") && urlPath.length() > 1) {
+        urlPath = urlPath.substring(0, urlPath.length() - 1);
+      }
+
+      String[] urlSegments = urlPath.split("/", -1);
+      for (String pattern : paths) {
+        String normalizedPattern = pattern;
+        while (normalizedPattern.endsWith("/") && normalizedPattern.length() > 1) {
+          normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length() - 1);
+        }
+        if (segmentsMatch(urlSegments, normalizedPattern.split("/", -1))) {
+          String httpMethod = getHttpMethod(span);
+          String newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
+          return new DelegatingSpanData(span) {
+            @Override
+            public String getName() {
+              return newName;
+            }
+          };
+        }
       }
     }
     return span;
   }
 
   /**
-   * Extract the URL path from span attributes for matching against configured operation paths.
-   * Checks http.route first (already a low-cardinality template), then url.path (just the path),
-   * then http.target (path + query string, which gets stripped later).
+   * Return URL path candidates from server span attributes: url.path, then http.target
    */
-  private static String extractUrlPath(SpanData span) {
-    // Prefer http.route — it's already a template with placeholders like :param
-    AttributeKey<String> httpRoute = AttributeKey.stringKey("http.route");
-    if (isKeyPresent(span, httpRoute)) {
-      return span.getAttributes().get(httpRoute);
-    }
-    // url.path contains just the path, no query string
-    if (isKeyPresent(span, URL_PATH)) {
-      return span.getAttributes().get(URL_PATH);
-    }
-    // http.target may include query string/fragment — stripped later in caller
-    if (isKeyPresent(span, HTTP_TARGET)) {
-      return span.getAttributes().get(HTTP_TARGET);
-    }
-    return null;
+  private static String[] getUrlPathCandidates(SpanData span) {
+    return new String[] {
+      isKeyPresent(span, URL_PATH) ? span.getAttributes().get(URL_PATH) : null,
+      isKeyPresent(span, HTTP_TARGET) ? span.getAttributes().get(HTTP_TARGET) : null,
+    };
   }
 
   /**
-   * Check if URL segments match a pattern's segments. Both the URL and pattern can contain wildcard
-   * segments. A segment is a wildcard if it uses {param}, :param, or * format. Two wildcard
-   * segments always match each other. A wildcard matches any non-empty literal segment. Two literal
-   * segments must be equal. The pattern acts as a prefix — extra URL segments after the pattern are
-   * allowed. A trailing * in the pattern matches all remaining segments.
+   * Check if URL segments match a pattern's segments. Only pattern segments can be wildcards
+   * ({param}, :param, or *) — URL segments are always treated as literals. A wildcard pattern
+   * segment matches any non-empty URL segment. The pattern acts as a prefix — extra URL segments
+   * after the pattern are allowed.
    */
   private static boolean segmentsMatch(String[] urlSegments, String[] patternSegments) {
     for (int i = 0; i < patternSegments.length; i++) {
@@ -226,26 +207,14 @@ final class AwsSpanProcessingUtil {
       String ps = patternSegments[i];
       String us = urlSegments[i];
 
-      // Trailing * in pattern matches everything remaining
-      if (ps.equals("*") && i == patternSegments.length - 1) {
-        return true;
-      }
-
-      boolean patternIsWildcard = isWildcardSegment(ps);
-      boolean urlIsWildcard = isWildcardSegment(us);
-
-      // Two wildcards always match
-      if (patternIsWildcard && urlIsWildcard) {
-        continue;
-      }
-      // Wildcard matches any non-empty literal
-      if (patternIsWildcard || urlIsWildcard) {
-        String literal = patternIsWildcard ? us : ps;
-        if (literal.isEmpty()) {
+      // Pattern wildcard matches any non-empty URL segment
+      if (isWildcardSegment(ps)) {
+        if (us.isEmpty()) {
           return false;
         }
         continue;
       }
+
       // Both literal — must be equal
       if (!ps.equals(us)) {
         return false;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -50,7 +50,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /** Utility class designed to support shared logic across AWS Span Processors. */
@@ -83,8 +82,6 @@ final class AwsSpanProcessingUtil {
 
   // Environment variable for configurable operation name paths
   static final String OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG = "OTEL_AWS_HTTP_OPERATION_PATHS";
-
-  private static final Logger logger = Logger.getLogger(AwsSpanProcessingUtil.class.getName());
 
   // Parsed and sorted (longest first) operation paths from env var, computed once
   private static volatile List<String> operationPaths;
@@ -183,9 +180,7 @@ final class AwsSpanProcessingUtil {
     return span;
   }
 
-  /**
-   * Return URL path candidates from server span attributes: url.path, then http.target
-   */
+  /** Return URL path candidates from server span attributes: url.path, then http.target */
   private static String[] getUrlPathCandidates(SpanData span) {
     return new String[] {
       isKeyPresent(span, URL_PATH) ? span.getAttributes().get(URL_PATH) : null,
@@ -253,6 +248,18 @@ final class AwsSpanProcessingUtil {
    */
   static String getIngressOperation(SpanData span) {
     if (isLambdaEnvironment()) {
+      /*
+       * By default the local operation of a Lambda span is hard-coded to "<FunctionName>/FunctionHandler".
+       * To dynamically override this at runtime—such as when running a custom server inside your Lambda—
+       * you can set the span attribute "aws.lambda.local.operation.override" before ending the span. For example:
+       *
+       *   // Obtain the current Span and override its operation name
+       *   Span.current().setAttribute(
+       *       "aws.lambda.local.operation.override",
+       *       "MyServiceOperation");
+       *
+       * The code below will detect that override and use it instead of the default.
+       */
       String operationOverride = span.getAttributes().get(AWS_LAMBDA_LOCAL_OPERATION_OVERRIDE);
       if (operationOverride != null) {
         return operationOverride;
@@ -271,16 +278,6 @@ final class AwsSpanProcessingUtil {
       operation = generateIngressOperation(span);
     }
     return operation;
-  }
-
-  /** Get the URL path from the span, checking new and deprecated semconv attributes. */
-  private static String getUrlPath(SpanData span) {
-    if (isKeyPresent(span, URL_PATH)) {
-      return span.getAttributes().get(URL_PATH);
-    } else if (isKeyPresent(span, HTTP_TARGET)) {
-      return span.getAttributes().get(HTTP_TARGET);
-    }
-    return null;
   }
 
   /** Get the HTTP method from the span, checking new and deprecated semconv attributes. */
@@ -417,11 +414,8 @@ final class AwsSpanProcessingUtil {
     if (operation == null || operation.equals(UNKNOWN_OPERATION)) {
       return false;
     }
-    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
-      return !operation.equals(httpMethod);
-    } else if (isKeyPresent(span, HTTP_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_METHOD);
+    String httpMethod = getHttpMethod(span);
+    if (httpMethod != null) {
       return !operation.equals(httpMethod);
     }
     return true;

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -139,53 +139,55 @@ final class AwsSpanProcessingUtil {
       return span;
     }
 
-    for (String urlPath : getUrlPathCandidates(span)) {
-      if (urlPath == null || urlPath.isEmpty()) {
-        continue;
-      }
+    String urlPath = getUrlPath(span);
+    if (urlPath == null || urlPath.isEmpty()) {
+      return span;
+    }
 
-      // Strip query string and fragment (relevant for http.target)
-      int idx = urlPath.indexOf('?');
-      if (idx >= 0) {
-        urlPath = urlPath.substring(0, idx);
-      }
-      idx = urlPath.indexOf('#');
-      if (idx >= 0) {
-        urlPath = urlPath.substring(0, idx);
-      }
+    // Strip query string and fragment (relevant for http.target)
+    int idx = urlPath.indexOf('?');
+    if (idx >= 0) {
+      urlPath = urlPath.substring(0, idx);
+    }
+    idx = urlPath.indexOf('#');
+    if (idx >= 0) {
+      urlPath = urlPath.substring(0, idx);
+    }
 
-      // Normalize trailing slashes
-      while (urlPath.endsWith("/") && urlPath.length() > 1) {
-        urlPath = urlPath.substring(0, urlPath.length() - 1);
-      }
+    // Normalize trailing slashes
+    while (urlPath.endsWith("/") && urlPath.length() > 1) {
+      urlPath = urlPath.substring(0, urlPath.length() - 1);
+    }
 
-      String[] urlSegments = urlPath.split("/", -1);
-      for (String pattern : paths) {
-        String normalizedPattern = pattern;
-        while (normalizedPattern.endsWith("/") && normalizedPattern.length() > 1) {
-          normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length() - 1);
-        }
-        if (segmentsMatch(urlSegments, normalizedPattern.split("/", -1))) {
-          String httpMethod = getHttpMethod(span);
-          String newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
-          return new DelegatingSpanData(span) {
-            @Override
-            public String getName() {
-              return newName;
-            }
-          };
-        }
+    String[] urlSegments = urlPath.split("/", -1);
+    for (String pattern : paths) {
+      String normalizedPattern = pattern;
+      while (normalizedPattern.endsWith("/") && normalizedPattern.length() > 1) {
+        normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length() - 1);
+      }
+      if (segmentsMatch(urlSegments, normalizedPattern.split("/", -1))) {
+        String httpMethod = getHttpMethod(span);
+        String newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
+        return new DelegatingSpanData(span) {
+          @Override
+          public String getName() {
+            return newName;
+          }
+        };
       }
     }
     return span;
   }
 
-  /** Return URL path candidates from server span attributes: url.path, then http.target */
-  private static String[] getUrlPathCandidates(SpanData span) {
-    return new String[] {
-      isKeyPresent(span, URL_PATH) ? span.getAttributes().get(URL_PATH) : null,
-      isKeyPresent(span, HTTP_TARGET) ? span.getAttributes().get(HTTP_TARGET) : null,
-    };
+  /** Return the URL path from server span attributes, preferring url.path over http.target. */
+  private static String getUrlPath(SpanData span) {
+    if (isKeyPresent(span, URL_PATH)) {
+      return span.getAttributes().get(URL_PATH);
+    }
+    if (isKeyPresent(span, HTTP_TARGET)) {
+      return span.getAttributes().get(HTTP_TARGET);
+    }
+    return null;
   }
 
   /**

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -108,7 +108,8 @@ final class AwsSpanProcessingUtil {
                 paths.add(trimmed);
               }
             }
-            // Sort longest first so longest prefix match wins
+            // Sort longest first so longest prefix match wins. For patterns with the same
+            // number of segments, the original configuration order is preserved (stable sort).
             paths.sort(
                 (a, b) -> {
                   int aSegments = a.split("/").length;
@@ -190,8 +191,8 @@ final class AwsSpanProcessingUtil {
 
   /**
    * Extract the URL path from span attributes for matching against configured operation paths.
-   * Checks http.route first (already a low-cardinality template), then url.path and http.target
-   * (just the path), then falls back to url.full and http.url (full URLs) and extracts the path.
+   * Checks http.route first (already a low-cardinality template), then url.path (just the path),
+   * then http.target (path + query string, which gets stripped later).
    */
   private static String extractUrlPath(SpanData span) {
     // Prefer http.route — it's already a template with placeholders like :param
@@ -199,30 +200,13 @@ final class AwsSpanProcessingUtil {
     if (isKeyPresent(span, httpRoute)) {
       return span.getAttributes().get(httpRoute);
     }
-    // Then try attributes that are just the path
+    // url.path contains just the path, no query string
     if (isKeyPresent(span, URL_PATH)) {
       return span.getAttributes().get(URL_PATH);
     }
+    // http.target may include query string/fragment — stripped later in caller
     if (isKeyPresent(span, HTTP_TARGET)) {
       return span.getAttributes().get(HTTP_TARGET);
-    }
-    // Fall back to full URLs — extract the path component
-    String fullUrl = null;
-    AttributeKey<String> urlFull = AttributeKey.stringKey("url.full");
-    AttributeKey<String> httpUrl = AttributeKey.stringKey("http.url");
-    if (isKeyPresent(span, urlFull)) {
-      fullUrl = span.getAttributes().get(urlFull);
-    } else if (isKeyPresent(span, httpUrl)) {
-      fullUrl = span.getAttributes().get(httpUrl);
-    }
-    if (fullUrl != null) {
-      int schemeEnd = fullUrl.indexOf("://");
-      if (schemeEnd >= 0) {
-        int pathStart = fullUrl.indexOf('/', schemeEnd + 3);
-        if (pathStart >= 0) {
-          return fullUrl.substring(pathStart);
-        }
-      }
     }
     return null;
   }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -44,10 +44,13 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.HttpAttributes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /** Utility class designed to support shared logic across AWS Span Processors. */
@@ -78,6 +81,118 @@ final class AwsSpanProcessingUtil {
   static final String LAMBDA_SCOPE_PREFIX = "io.opentelemetry.aws-lambda-";
   static final String SERVLET_SCOPE_PREFIX = "io.opentelemetry.servlet-";
 
+  // Environment variable for configurable operation name paths
+  static final String OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG = "OTEL_AWS_HTTP_OPERATION_PATHS";
+
+  private static final Logger logger =
+      Logger.getLogger(AwsSpanProcessingUtil.class.getName());
+
+  // Parsed and sorted (longest first) operation paths from env var, computed once
+  private static volatile List<String> operationPaths;
+
+  /**
+   * Parse the OTEL_AWS_HTTP_OPERATION_PATHS env var into a sorted list of path prefixes (longest
+   * first). Curly-brace segments like {version} are converted to regex patterns for matching.
+   * Returns an empty list if the env var is not set.
+   */
+  static List<String> getOperationPaths() {
+    if (operationPaths == null) {
+      synchronized (AwsSpanProcessingUtil.class) {
+        if (operationPaths == null) {
+          String config = System.getenv(OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG);
+          if (config == null || config.trim().isEmpty()) {
+            operationPaths = Collections.emptyList();
+          } else {
+            List<String> paths = new ArrayList<>();
+            for (String path : config.split(",")) {
+              String trimmed = path.trim();
+              if (!trimmed.isEmpty()) {
+                paths.add(trimmed);
+              }
+            }
+            // Sort longest first so longest prefix match wins
+            paths.sort((a, b) -> {
+              int aSegments = a.split("/").length;
+              int bSegments = b.split("/").length;
+              return Integer.compare(bSegments, aSegments);
+            });
+            operationPaths = Collections.unmodifiableList(paths);
+          }
+        }
+      }
+    }
+    return operationPaths;
+  }
+
+  // Visible for testing — allows tests to reset the cached paths
+  static void resetOperationPaths() {
+    synchronized (AwsSpanProcessingUtil.class) {
+      operationPaths = null;
+    }
+  }
+
+  /**
+   * Match a URL path against the configured operation paths. Returns the matched operation path
+   * template (e.g., "/api/{version}/users") or null if no match. Curly-brace segments in the
+   * configured path match any single path segment in the URL.
+   */
+  static String matchOperationPath(String urlPath) {
+    if (urlPath == null || urlPath.isEmpty()) {
+      return null;
+    }
+    // Strip query string and fragment
+    int queryIdx = urlPath.indexOf('?');
+    if (queryIdx >= 0) {
+      urlPath = urlPath.substring(0, queryIdx);
+    }
+    int fragIdx = urlPath.indexOf('#');
+    if (fragIdx >= 0) {
+      urlPath = urlPath.substring(0, fragIdx);
+    }
+
+    for (String pattern : getOperationPaths()) {
+      if (pathMatchesPattern(urlPath, pattern)) {
+        return pattern;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Check if a URL path matches a pattern. Patterns can contain curly-brace segments like
+   * {id} which match any single path segment. The pattern acts as a prefix — if all pattern
+   * segments match the corresponding URL segments, it's a match even if the URL has additional
+   * trailing segments. A trailing /* in the pattern explicitly matches any remaining segments.
+   */
+  private static boolean pathMatchesPattern(String urlPath, String pattern) {
+    String[] urlSegments = urlPath.split("/", -1);
+    String[] patternSegments = pattern.split("/", -1);
+
+    for (int i = 0; i < patternSegments.length; i++) {
+      if (i >= urlSegments.length) {
+        return false;
+      }
+      String ps = patternSegments[i];
+      // Wildcard matches remaining
+      if (ps.equals("*")) {
+        return true;
+      }
+      // Curly-brace segment matches any non-empty segment
+      if (ps.startsWith("{") && ps.endsWith("}")) {
+        if (urlSegments[i].isEmpty()) {
+          return false;
+        }
+        continue;
+      }
+      // Literal match
+      if (!ps.equals(urlSegments[i])) {
+        return false;
+      }
+    }
+    // All pattern segments matched — URL may have extra trailing segments, that's fine
+    return true;
+  }
+
   static List<String> getDialectKeywords() {
     try (InputStream jsonFile =
         AwsSpanProcessingUtil.class
@@ -101,18 +216,6 @@ final class AwsSpanProcessingUtil {
    */
   static String getIngressOperation(SpanData span) {
     if (isLambdaEnvironment()) {
-      /*
-       * By default the local operation of a Lambda span is hard-coded to "<FunctionName>/FunctionHandler".
-       * To dynamically override this at runtime—such as when running a custom server inside your Lambda—
-       * you can set the span attribute "aws.lambda.local.operation.override" before ending the span. For example:
-       *
-       *   // Obtain the current Span and override its operation name
-       *   Span.current().setAttribute(
-       *       "aws.lambda.local.operation.override",
-       *       "MyServiceOperation");
-       *
-       * The code below will detect that override and use it instead of the default.
-       */
       String operationOverride = span.getAttributes().get(AWS_LAMBDA_LOCAL_OPERATION_OVERRIDE);
       if (operationOverride != null) {
         return operationOverride;
@@ -123,6 +226,27 @@ final class AwsSpanProcessingUtil {
       }
       return getFunctionNameFromEnv() + "/FunctionHandler";
     }
+
+    // Priority 1: Check OTEL_AWS_HTTP_OPERATION_PATHS configuration
+    if (!getOperationPaths().isEmpty()) {
+      String urlPath = getUrlPath(span);
+      if (urlPath != null) {
+        String matchedPath = matchOperationPath(urlPath);
+        if (matchedPath != null) {
+          String httpMethod = getHttpMethod(span);
+          return httpMethod != null ? httpMethod + " " + matchedPath : matchedPath;
+        }
+      }
+    }
+
+    // Priority 2: Check http.route (OTel standard low-cardinality route template)
+    String httpRoute = span.getAttributes().get(HttpAttributes.HTTP_ROUTE);
+    if (httpRoute != null && !httpRoute.isEmpty()) {
+      String httpMethod = getHttpMethod(span);
+      return httpMethod != null ? httpMethod + " " + httpRoute : httpRoute;
+    }
+
+    // Priority 3: Existing logic — span.name or generateIngressOperation fallback
     String operation = span.getName();
     if (shouldUseInternalOperation(span)) {
       operation = INTERNAL_OPERATION;
@@ -130,6 +254,26 @@ final class AwsSpanProcessingUtil {
       operation = generateIngressOperation(span);
     }
     return operation;
+  }
+
+  /** Get the URL path from the span, checking new and deprecated semconv attributes. */
+  private static String getUrlPath(SpanData span) {
+    if (isKeyPresent(span, URL_PATH)) {
+      return span.getAttributes().get(URL_PATH);
+    } else if (isKeyPresent(span, HTTP_TARGET)) {
+      return span.getAttributes().get(HTTP_TARGET);
+    }
+    return null;
+  }
+
+  /** Get the HTTP method from the span, checking new and deprecated semconv attributes. */
+  private static String getHttpMethod(SpanData span) {
+    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
+      return span.getAttributes().get(HTTP_REQUEST_METHOD);
+    } else if (isKeyPresent(span, HTTP_METHOD)) {
+      return span.getAttributes().get(HTTP_METHOD);
+    }
+    return null;
   }
 
   // define a function so that we can mock it in unit test

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorTest.java
@@ -15,7 +15,9 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -624,5 +626,42 @@ class AwsSpanMetricsProcessorTest {
         .record(eq(0L), eq(metricAttributesMap.get(DEPENDENCY_METRIC)));
     verify(latencyHistogramMock, times(wantedDependencyMetricInvocation))
         .record(eq(TEST_LATENCY_MILLIS), eq(metricAttributesMap.get(DEPENDENCY_METRIC)));
+  }
+
+  @Test
+  public void testOnEndAppliesOperationPathSpanNameBeforeMetrics() {
+    // Build a span with url.path that matches a configured operation path
+    Attributes spanAttributes =
+        Attributes.builder()
+            .put(URL_PATH, "/api/users/42/stats")
+            .put(HTTP_REQUEST_METHOD, "GET")
+            .put(HTTP_RESPONSE_STATUS_CODE, 200L)
+            .build();
+    ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
+
+    try (org.mockito.MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        org.mockito.Mockito.mockStatic(
+            AwsSpanProcessingUtil.class,
+            org.mockito.Mockito.withSettings()
+                .defaultAnswer(org.mockito.Mockito.CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(java.util.List.of("/api/users/{userId}/stats"));
+
+      // Capture the SpanData passed to the generator
+      org.mockito.ArgumentCaptor<io.opentelemetry.sdk.trace.data.SpanData> spanCaptor =
+          org.mockito.ArgumentCaptor.forClass(io.opentelemetry.sdk.trace.data.SpanData.class);
+      Map<String, Attributes> metricAttributesMap =
+          buildMetricAttributes(CONTAINS_ATTRIBUTES, readableSpanMock.toSpanData());
+      when(generatorMock.generateMetricAttributeMapFromSpan(any(), eq(testResource)))
+          .thenReturn(metricAttributesMap);
+
+      awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+      // Verify the generator received a span with the overridden name
+      verify(generatorMock)
+          .generateMetricAttributeMapFromSpan(spanCaptor.capture(), eq(testResource));
+      assertThat(spanCaptor.getValue().getName()).isEqualTo("GET /api/users/{userId}/stats");
+    }
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -810,13 +810,11 @@ public class AwsSpanProcessingUtilTest {
   }
 
   @Test
-  public void testApplyOperationPathSpanName_matchesFullUrl() {
+  public void testApplyOperationPathSpanName_matchesHttpTarget() {
     when(spanDataMock.getName()).thenReturn("GET /api");
     when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn(null);
-    when(attributesMock.get(HTTP_TARGET)).thenReturn(null);
-    when(attributesMock.get(AttributeKey.stringKey("url.full")))
-        .thenReturn("http://localhost:8080/api/teams/5");
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/api/teams/5?include=roster");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
     try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
@@ -827,6 +825,44 @@ public class AwsSpanProcessingUtilTest {
 
       SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
       assertThat(result.getName()).isEqualTo("GET /api/teams/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_httpTargetWithFragment() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/api/teams/5#section");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/teams/{id}"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/teams/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_sameLengthPatternsFirstConfigWins() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/v1/user1");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      // Both patterns have 3 segments — first one in config order should win
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/v1/{userId}", "/api/{version}/user1"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/v1/{userId}");
     }
   }
 

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -651,10 +651,6 @@ public class AwsSpanProcessingUtilTest {
     assertFalse(AwsSpanProcessingUtil.isServletServerSpan(span));
   }
 
-  // ============================================================================
-  // Tests for OTEL_AWS_HTTP_OPERATION_PATHS and applyOperationPathSpanName
-  // ============================================================================
-
   // Helper to call the private segmentsMatch method via reflection
   private static boolean segmentsMatch(String[] urlSegments, String[] patternSegments) {
     try {
@@ -670,6 +666,41 @@ public class AwsSpanProcessingUtilTest {
 
   private static boolean matchSegments(String urlPath, String pattern) {
     return segmentsMatch(urlPath.split("/", -1), pattern.split("/", -1));
+  }
+
+  // Helper to call the private getUrlPath method via reflection
+  private static String getUrlPath(SpanData span) {
+    try {
+      java.lang.reflect.Method method =
+          AwsSpanProcessingUtil.class.getDeclaredMethod("getUrlPath", SpanData.class);
+      method.setAccessible(true);
+      return (String) method.invoke(null, span);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // --- getUrlPath: attribute priority ---
+
+  @Test
+  public void testGetUrlPath_prefersUrlPathOverHttpTarget() {
+    when(attributesMock.get(URL_PATH)).thenReturn("/from/url-path");
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/from/http-target");
+    assertThat(getUrlPath(spanDataMock)).isEqualTo("/from/url-path");
+  }
+
+  @Test
+  public void testGetUrlPath_fallsBackToHttpTarget() {
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/from/http-target");
+    assertThat(getUrlPath(spanDataMock)).isEqualTo("/from/http-target");
+  }
+
+  @Test
+  public void testGetUrlPath_returnsNullWhenNeitherPresent() {
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn(null);
+    assertThat(getUrlPath(spanDataMock)).isNull();
   }
 
   // --- segmentsMatch: exact literal matching ---
@@ -745,38 +776,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testSegmentsMatch_starDoesNotMatchEmpty() {
     assertThat(matchSegments("/api/contests/", "/api/contests/*/leaderboard")).isFalse();
-  }
-
-  // --- segmentsMatch: wildcard in URL (e.g., http.route with :param) ---
-
-  @Test
-  public void testSegmentsMatch_urlColonParamMatchedByPatternWildcard() {
-    // Config {userId} wildcard matches URL literal :userId
-    assertThat(matchSegments("/api/users/:userId/stats", "/api/users/{userId}/stats")).isTrue();
-  }
-
-  @Test
-  public void testSegmentsMatch_urlColonParamMatchedByPatternStar() {
-    assertThat(matchSegments("/api/users/:userId/stats", "/api/users/*/stats")).isTrue();
-  }
-
-  @Test
-  public void testSegmentsMatch_urlColonParamNotMatchedByLiteralPattern() {
-    // Literal "john" does NOT match :userId — they're different strings
-    assertThat(matchSegments("/api/users/:userId/stats", "/api/users/john/stats")).isFalse();
-  }
-
-  @Test
-  public void testSegmentsMatch_mixedWildcardsInPattern() {
-    assertThat(matchSegments("/api/v2/users/42", "/api/*/users/{userId}")).isTrue();
-  }
-
-  @Test
-  public void testSegmentsMatch_urlWildcardMatchesShorterLiteralConfig() {
-    // Prefix match: config /api/v1 matches route /api/:version/hi
-    // because {version} in config would match, but /api/v1 is literal —
-    // :version != v1 as literals, so this should NOT match
-    assertThat(matchSegments("/api/:version/hi", "/api/v1")).isFalse();
   }
 
   // --- applyOperationPathSpanName: integration tests ---

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -648,4 +648,187 @@ public class AwsSpanProcessingUtilTest {
 
     assertFalse(AwsSpanProcessingUtil.isServletServerSpan(span));
   }
+
+  // ============================================================================
+  // Tests for OTEL_AWS_HTTP_OPERATION_PATHS and http.route support
+  // ============================================================================
+
+  @Test
+  public void testMatchOperationPath_exactMatch() {
+    assertThat(pathMatchesPattern("/api/contests", "/api/contests")).isTrue();
+  }
+
+  @Test
+  public void testMatchOperationPath_noMatch() {
+    assertThat(pathMatchesPattern("/api/players", "/api/contests")).isFalse();
+  }
+
+  @Test
+  public void testMatchOperationPath_curlyBraceSegment() {
+    assertThat(pathMatchesPattern("/api/contests/123", "/api/contests/{id}"))
+        .isTrue();
+    assertThat(
+            pathMatchesPattern(
+                "/api/contests/123/leaderboard", "/api/contests/{id}/leaderboard"))
+        .isTrue();
+  }
+
+  @Test
+  public void testMatchOperationPath_curlyBraceDoesNotMatchEmpty() {
+    assertThat(pathMatchesPattern("/api/contests/", "/api/contests/{id}"))
+        .isFalse();
+  }
+
+  @Test
+  public void testMatchOperationPath_extraSegmentsInUrl() {
+    // /api/contests/123/extra should match /api/contests/{id} as a prefix
+    assertThat(
+            pathMatchesPattern("/api/contests/123/extra", "/api/contests/{id}"))
+        .isTrue();
+  }
+
+  @Test
+  public void testMatchOperationPath_wildcardMatchesRemaining() {
+    assertThat(
+            pathMatchesPattern(
+                "/api/contests/123/anything/else", "/api/contests/*"))
+        .isTrue();
+  }
+
+  @Test
+  public void testMatchOperationPath_nullUrl() {
+    assertThat(AwsSpanProcessingUtil.matchOperationPath(null)).isNull();
+  }
+
+  @Test
+  public void testMatchOperationPath_emptyUrl() {
+    assertThat(AwsSpanProcessingUtil.matchOperationPath("")).isNull();
+  }
+
+  @Test
+  public void testMatchOperationPath_stripsQueryString() {
+    // Need to set up operation paths first
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests"));
+      assertThat(AwsSpanProcessingUtil.matchOperationPath("/api/contests?page=1"))
+          .isEqualTo("/api/contests");
+    }
+  }
+
+  @Test
+  public void testGetIngressOperation_withOperationPaths() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/123/leaderboard");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(
+              List.of(
+                  "/api/contests/{id}/leaderboard",
+                  "/api/contests/{id}",
+                  "/api/contests",
+                  "/api"));
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("GET /api/contests/{id}/leaderboard");
+    }
+  }
+
+  @Test
+  public void testGetIngressOperation_withOperationPaths_longestMatchWins() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/42");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(
+              List.of(
+                  "/api/contests/{id}/leaderboard",
+                  "/api/contests/{id}",
+                  "/api/contests",
+                  "/api"));
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("GET /api/contests/{id}");
+    }
+  }
+
+  @Test
+  public void testGetIngressOperation_withOperationPaths_noMatch_fallsBackToHttpRoute() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(URL_PATH)).thenReturn("/unknown/path");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+    when(attributesMock.get(io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE))
+        .thenReturn("/unknown/{id}");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests/{id}"));
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("GET /unknown/{id}");
+    }
+  }
+
+  @Test
+  public void testGetIngressOperation_httpRouteFallback_noConfig() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+    when(attributesMock.get(io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE))
+        .thenReturn("/api/contests/{id}");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of());
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("GET /api/contests/{id}");
+    }
+  }
+
+  @Test
+  public void testGetIngressOperation_noConfigNoHttpRoute_existingBehavior() {
+    when(spanDataMock.getName()).thenReturn("ValidSpanName");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of());
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("ValidSpanName");
+    }
+  }
+
+  // Make pathMatchesPattern accessible for direct testing
+  private static boolean pathMatchesPattern(String urlPath, String pattern) {
+    try {
+      java.lang.reflect.Method method =
+          AwsSpanProcessingUtil.class.getDeclaredMethod(
+              "pathMatchesPattern", String.class, String.class);
+      method.setAccessible(true);
+      return (boolean) method.invoke(null, urlPath, pattern);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -37,7 +37,6 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.MAX_KEYWORD_LENGTH;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.getDialectKeywords;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -751,23 +750,33 @@ public class AwsSpanProcessingUtilTest {
   // --- segmentsMatch: wildcard in URL (e.g., http.route with :param) ---
 
   @Test
-  public void testSegmentsMatch_urlColonParamMatchesPatternCurlyBrace() {
+  public void testSegmentsMatch_urlColonParamMatchedByPatternWildcard() {
+    // Config {userId} wildcard matches URL literal :userId
     assertThat(matchSegments("/api/users/:userId/stats", "/api/users/{userId}/stats")).isTrue();
   }
 
   @Test
-  public void testSegmentsMatch_urlColonParamMatchesPatternStar() {
+  public void testSegmentsMatch_urlColonParamMatchedByPatternStar() {
     assertThat(matchSegments("/api/users/:userId/stats", "/api/users/*/stats")).isTrue();
   }
 
   @Test
-  public void testSegmentsMatch_urlCurlyBraceMatchesPatternColonParam() {
-    assertThat(matchSegments("/api/users/{userId}/stats", "/api/users/:userId/stats")).isTrue();
+  public void testSegmentsMatch_urlColonParamNotMatchedByLiteralPattern() {
+    // Literal "john" does NOT match :userId — they're different strings
+    assertThat(matchSegments("/api/users/:userId/stats", "/api/users/john/stats")).isFalse();
   }
 
   @Test
-  public void testSegmentsMatch_twoWildcardsAlwaysMatch() {
-    assertThat(matchSegments("/api/{version}/users/:id", "/api/*/users/{userId}")).isTrue();
+  public void testSegmentsMatch_mixedWildcardsInPattern() {
+    assertThat(matchSegments("/api/v2/users/42", "/api/*/users/{userId}")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_urlWildcardMatchesShorterLiteralConfig() {
+    // Prefix match: config /api/v1 matches route /api/:version/hi
+    // because {version} in config would match, but /api/v1 is literal —
+    // :version != v1 as literals, so this should NOT match
+    assertThat(matchSegments("/api/:version/hi", "/api/v1")).isFalse();
   }
 
   // --- applyOperationPathSpanName: integration tests ---
@@ -775,7 +784,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_matchesUrlPath() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/123/leaderboard");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -792,10 +800,9 @@ public class AwsSpanProcessingUtilTest {
   }
 
   @Test
-  public void testApplyOperationPathSpanName_matchesHttpRoute() {
+  public void testApplyOperationPathSpanName_matchesParameterizedUrl() {
     when(spanDataMock.getName()).thenReturn("GET /api/users/:userId/stats");
-    when(attributesMock.get(AttributeKey.stringKey("http.route")))
-        .thenReturn("/api/users/:userId/stats");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/users/42/stats");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
     try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
@@ -812,7 +819,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_matchesHttpTarget() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn(null);
     when(attributesMock.get(HTTP_TARGET)).thenReturn("/api/teams/5?include=roster");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
@@ -831,7 +837,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_httpTargetWithFragment() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn(null);
     when(attributesMock.get(HTTP_TARGET)).thenReturn("/api/teams/5#section");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
@@ -850,7 +855,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_sameLengthPatternsFirstConfigWins() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/v1/user1");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -869,7 +873,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_noMatch_returnsOriginal() {
     when(spanDataMock.getName()).thenReturn("GET /unknown");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/unknown/path");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -898,7 +901,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_longestMatchWins() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/42");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -919,7 +921,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_queryStringStripped() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests?page=1&size=10");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -937,7 +938,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_noHttpMethod() {
     when(spanDataMock.getName()).thenReturn("/api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn(null);
     when(attributesMock.get(HTTP_METHOD)).thenReturn(null);
@@ -956,7 +956,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_trailingSlashNormalized() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -974,7 +973,6 @@ public class AwsSpanProcessingUtilTest {
   @Test
   public void testApplyOperationPathSpanName_patternTrailingSlashNormalized() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -17,6 +17,8 @@ package software.amazon.opentelemetry.javaagent.providers;
 
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
@@ -35,6 +37,7 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsAttributeKeys
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.MAX_KEYWORD_LENGTH;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.getDialectKeywords;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -650,78 +653,129 @@ public class AwsSpanProcessingUtilTest {
   }
 
   // ============================================================================
-  // Tests for OTEL_AWS_HTTP_OPERATION_PATHS and http.route support
+  // Tests for OTEL_AWS_HTTP_OPERATION_PATHS and applyOperationPathSpanName
   // ============================================================================
 
-  @Test
-  public void testMatchOperationPath_exactMatch() {
-    assertThat(pathMatchesPattern("/api/contests", "/api/contests")).isTrue();
-  }
-
-  @Test
-  public void testMatchOperationPath_noMatch() {
-    assertThat(pathMatchesPattern("/api/players", "/api/contests")).isFalse();
-  }
-
-  @Test
-  public void testMatchOperationPath_curlyBraceSegment() {
-    assertThat(pathMatchesPattern("/api/contests/123", "/api/contests/{id}"))
-        .isTrue();
-    assertThat(
-            pathMatchesPattern(
-                "/api/contests/123/leaderboard", "/api/contests/{id}/leaderboard"))
-        .isTrue();
-  }
-
-  @Test
-  public void testMatchOperationPath_curlyBraceDoesNotMatchEmpty() {
-    assertThat(pathMatchesPattern("/api/contests/", "/api/contests/{id}"))
-        .isFalse();
-  }
-
-  @Test
-  public void testMatchOperationPath_extraSegmentsInUrl() {
-    // /api/contests/123/extra should match /api/contests/{id} as a prefix
-    assertThat(
-            pathMatchesPattern("/api/contests/123/extra", "/api/contests/{id}"))
-        .isTrue();
-  }
-
-  @Test
-  public void testMatchOperationPath_wildcardMatchesRemaining() {
-    assertThat(
-            pathMatchesPattern(
-                "/api/contests/123/anything/else", "/api/contests/*"))
-        .isTrue();
-  }
-
-  @Test
-  public void testMatchOperationPath_nullUrl() {
-    assertThat(AwsSpanProcessingUtil.matchOperationPath(null)).isNull();
-  }
-
-  @Test
-  public void testMatchOperationPath_emptyUrl() {
-    assertThat(AwsSpanProcessingUtil.matchOperationPath("")).isNull();
-  }
-
-  @Test
-  public void testMatchOperationPath_stripsQueryString() {
-    // Need to set up operation paths first
-    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
-        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
-      utilStatic
-          .when(AwsSpanProcessingUtil::getOperationPaths)
-          .thenReturn(List.of("/api/contests"));
-      assertThat(AwsSpanProcessingUtil.matchOperationPath("/api/contests?page=1"))
-          .isEqualTo("/api/contests");
+  // Helper to call the private segmentsMatch method via reflection
+  private static boolean segmentsMatch(String[] urlSegments, String[] patternSegments) {
+    try {
+      java.lang.reflect.Method method =
+          AwsSpanProcessingUtil.class.getDeclaredMethod(
+              "segmentsMatch", String[].class, String[].class);
+      method.setAccessible(true);
+      return (boolean) method.invoke(null, urlSegments, patternSegments);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 
+  private static boolean matchSegments(String urlPath, String pattern) {
+    return segmentsMatch(urlPath.split("/", -1), pattern.split("/", -1));
+  }
+
+  // --- segmentsMatch: exact literal matching ---
+
   @Test
-  public void testGetIngressOperation_withOperationPaths() {
+  public void testSegmentsMatch_exactMatch() {
+    assertThat(matchSegments("/api/contests", "/api/contests")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_noMatch() {
+    assertThat(matchSegments("/api/players", "/api/contests")).isFalse();
+  }
+
+  @Test
+  public void testSegmentsMatch_extraUrlSegmentsAllowed() {
+    assertThat(matchSegments("/api/contests/123/extra", "/api/contests")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_patternLongerThanUrl() {
+    assertThat(matchSegments("/api", "/api/contests/{id}")).isFalse();
+  }
+
+  // --- segmentsMatch: {param} wildcard in pattern ---
+
+  @Test
+  public void testSegmentsMatch_curlyBraceMatchesLiteral() {
+    assertThat(matchSegments("/api/contests/123", "/api/contests/{id}")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_curlyBraceMatchesDeepPath() {
+    assertThat(matchSegments("/api/contests/123/leaderboard", "/api/contests/{id}/leaderboard"))
+        .isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_curlyBraceDoesNotMatchEmpty() {
+    assertThat(matchSegments("/api/contests/", "/api/contests/{id}")).isFalse();
+  }
+
+  // --- segmentsMatch: :param wildcard in pattern ---
+
+  @Test
+  public void testSegmentsMatch_colonParamMatchesLiteral() {
+    assertThat(matchSegments("/api/users/42", "/api/users/:userId")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_colonParamMatchesDeepPath() {
+    assertThat(matchSegments("/api/users/42/stats", "/api/users/:userId/stats")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_colonParamDoesNotMatchEmpty() {
+    assertThat(matchSegments("/api/users/", "/api/users/:userId")).isFalse();
+  }
+
+  // --- segmentsMatch: * wildcard in pattern ---
+
+  @Test
+  public void testSegmentsMatch_trailingStarMatchesRemaining() {
+    assertThat(matchSegments("/api/contests/123/anything/else", "/api/contests/*")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_midStarMatchesSingleSegment() {
+    assertThat(matchSegments("/api/contests/123/leaderboard", "/api/contests/*/leaderboard"))
+        .isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_starDoesNotMatchEmpty() {
+    assertThat(matchSegments("/api/contests/", "/api/contests/*/leaderboard")).isFalse();
+  }
+
+  // --- segmentsMatch: wildcard in URL (e.g., http.route with :param) ---
+
+  @Test
+  public void testSegmentsMatch_urlColonParamMatchesPatternCurlyBrace() {
+    assertThat(matchSegments("/api/users/:userId/stats", "/api/users/{userId}/stats")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_urlColonParamMatchesPatternStar() {
+    assertThat(matchSegments("/api/users/:userId/stats", "/api/users/*/stats")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_urlCurlyBraceMatchesPatternColonParam() {
+    assertThat(matchSegments("/api/users/{userId}/stats", "/api/users/:userId/stats")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_twoWildcardsAlwaysMatch() {
+    assertThat(matchSegments("/api/{version}/users/:id", "/api/*/users/{userId}")).isTrue();
+  }
+
+  // --- applyOperationPathSpanName: integration tests ---
+
+  @Test
+  public void testApplyOperationPathSpanName_matchesUrlPath() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/123/leaderboard");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
@@ -730,48 +784,58 @@ public class AwsSpanProcessingUtilTest {
       utilStatic
           .when(AwsSpanProcessingUtil::getOperationPaths)
           .thenReturn(
-              List.of(
-                  "/api/contests/{id}/leaderboard",
-                  "/api/contests/{id}",
-                  "/api/contests",
-                  "/api"));
+              List.of("/api/contests/{id}/leaderboard", "/api/contests/{id}", "/api/contests"));
 
-      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
-      assertThat(actual).isEqualTo("GET /api/contests/{id}/leaderboard");
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests/{id}/leaderboard");
     }
   }
 
   @Test
-  public void testGetIngressOperation_withOperationPaths_longestMatchWins() {
-    when(spanDataMock.getName()).thenReturn("GET /api");
-    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
-    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/42");
+  public void testApplyOperationPathSpanName_matchesHttpRoute() {
+    when(spanDataMock.getName()).thenReturn("GET /api/users/:userId/stats");
+    when(attributesMock.get(AttributeKey.stringKey("http.route")))
+        .thenReturn("/api/users/:userId/stats");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
     try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
         mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
       utilStatic
           .when(AwsSpanProcessingUtil::getOperationPaths)
-          .thenReturn(
-              List.of(
-                  "/api/contests/{id}/leaderboard",
-                  "/api/contests/{id}",
-                  "/api/contests",
-                  "/api"));
+          .thenReturn(List.of("/api/users/{userId}/stats", "/api/users/{userId}", "/api/users"));
 
-      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
-      assertThat(actual).isEqualTo("GET /api/contests/{id}");
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/users/{userId}/stats");
     }
   }
 
   @Test
-  public void testGetIngressOperation_withOperationPaths_noMatch_fallsBackToHttpRoute() {
+  public void testApplyOperationPathSpanName_matchesFullUrl() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn(null);
+    when(attributesMock.get(AttributeKey.stringKey("url.full")))
+        .thenReturn("http://localhost:8080/api/teams/5");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/teams/{id}", "/api/teams"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/teams/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_noMatch_returnsOriginal() {
+    when(spanDataMock.getName()).thenReturn("GET /unknown");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
     when(attributesMock.get(URL_PATH)).thenReturn("/unknown/path");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
-    when(attributesMock.get(io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE))
-        .thenReturn("/unknown/{id}");
 
     try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
         mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
@@ -779,24 +843,129 @@ public class AwsSpanProcessingUtilTest {
           .when(AwsSpanProcessingUtil::getOperationPaths)
           .thenReturn(List.of("/api/contests/{id}"));
 
-      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
-      assertThat(actual).isEqualTo("GET /unknown/{id}");
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result).isSameAs(spanDataMock);
     }
   }
 
   @Test
-  public void testGetIngressOperation_httpRouteFallback_noConfig() {
+  public void testApplyOperationPathSpanName_emptyConfig_returnsOriginal() {
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic.when(AwsSpanProcessingUtil::getOperationPaths).thenReturn(List.of());
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result).isSameAs(spanDataMock);
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_longestMatchWins() {
     when(spanDataMock.getName()).thenReturn("GET /api");
-    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/42");
     when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
-    when(attributesMock.get(io.opentelemetry.semconv.HttpAttributes.HTTP_ROUTE))
-        .thenReturn("/api/contests/{id}");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      // Sorted longest first
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(
+              List.of(
+                  "/api/contests/{id}/leaderboard", "/api/contests/{id}", "/api/contests", "/api"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_queryStringStripped() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests?page=1&size=10");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
 
     try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
         mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
       utilStatic
           .when(AwsSpanProcessingUtil::getOperationPaths)
-          .thenReturn(List.of());
+          .thenReturn(List.of("/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_noHttpMethod() {
+    when(spanDataMock.getName()).thenReturn("/api");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn(null);
+    when(attributesMock.get(HTTP_METHOD)).thenReturn(null);
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("/api/contests");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_trailingSlashNormalized() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_patternTrailingSlashNormalized() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(AttributeKey.stringKey("http.route"))).thenReturn(null);
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      // Pattern has trailing slash
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests/"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      // Matches, and preserves the original pattern format in the name
+      assertThat(result.getName()).isEqualTo("GET /api/contests/");
+    }
+  }
+
+  // --- getIngressOperation: uses span name (no longer reads operation paths directly) ---
+
+  @Test
+  public void testGetIngressOperation_validSpanName_usedDirectly() {
+    when(spanDataMock.getName()).thenReturn("GET /api/contests/{id}");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic.when(AwsSpanProcessingUtil::getOperationPaths).thenReturn(List.of());
 
       String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
       assertThat(actual).isEqualTo("GET /api/contests/{id}");
@@ -804,31 +973,18 @@ public class AwsSpanProcessingUtilTest {
   }
 
   @Test
-  public void testGetIngressOperation_noConfigNoHttpRoute_existingBehavior() {
-    when(spanDataMock.getName()).thenReturn("ValidSpanName");
+  public void testGetIngressOperation_invalidSpanName_fallsBackToUrlTruncation() {
+    when(spanDataMock.getName()).thenReturn("GET");
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/123");
 
     try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
         mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
-      utilStatic
-          .when(AwsSpanProcessingUtil::getOperationPaths)
-          .thenReturn(List.of());
+      utilStatic.when(AwsSpanProcessingUtil::getOperationPaths).thenReturn(List.of());
 
       String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
-      assertThat(actual).isEqualTo("ValidSpanName");
-    }
-  }
-
-  // Make pathMatchesPattern accessible for direct testing
-  private static boolean pathMatchesPattern(String urlPath, String pattern) {
-    try {
-      java.lang.reflect.Method method =
-          AwsSpanProcessingUtil.class.getDeclaredMethod(
-              "pathMatchesPattern", String.class, String.class);
-      method.setAccessible(true);
-      return (boolean) method.invoke(null, urlPath, pattern);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+      assertThat(actual).isEqualTo("GET /api");
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When HTTP span names don't contain a URL path, we generate the HTTP operation by truncating the URL path to only the first trailing value to preserve low cardinality (i.e. /api/v1/users -> /api). This can result in overly broad operation groupings for services with endpoint paths of various depths.

This PR introduces an environment variable configuration, `OTEL_AWS_HTTP_OPERATION_PATHS`, which allows users to configure their own HTTP endpoint paths. If this variable is provided, the span name's URL path will resolve to the longest matching path. Wildcards are supported with the following syntaxes: `{version}`, `:version`, or simply `*`. This way, users can decide how their service endpoint are grouped into operation names shown in CloudWatch.

Added unit and integration tests to verify behavior, and did some E2E testing with an instrumented HTTP server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
