### PR TITLE
Add Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   claude-review:
     if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
         with:
-          fetch-depth: 0
+          fetch-depth: 50
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #5.0.0
@@ -45,6 +46,6 @@ jobs:
           direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr *),Bash(gh api *)"
+            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/*/reviews*)"
           prompt: |
             Review this PR for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #5.0.0
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.TELEGEN_AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ vars.AWS_DEFAULT_REGION || 'us-east-1' }}
 
       - name: Run Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,53 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION || 'us-east-1' }}
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@1b422b3517b51140e4484faab676c5e68b914866 #v1.0.73
+        with:
+          use_bedrock: "true"
+          direct_api: "true"
+          show_full_output: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr *),Bash(gh api *),Bash(python3 *),Bash(awk *)"
+          prompt: |
+            Review this PR for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,19 +7,17 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    #   - "**/*.java"
+    #   - "**/*.gradle"
+    #   - "**/*.kt"
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -31,13 +29,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION || 'us-east-1' }}
+          aws-region: ${{ vars.AWS_DEFAULT_REGION || 'us-east-1' }}
 
       - name: Run Claude Code Review
         id: claude-review
@@ -45,9 +43,8 @@ jobs:
         with:
           use_bedrock: "true"
           direct_api: "true"
-          show_full_output: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr *),Bash(gh api *),Bash(python3 *),Bash(awk *)"
+            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr *),Bash(gh api *)"
           prompt: |
             Review this PR for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines.


### PR DESCRIPTION
## Summary
- Adds a Claude Code review workflow that automatically reviews PRs for bugs, security issues, and code quality
- Uses Bedrock with OIDC authentication via `TELEGEN_AWS_ASSUME_ROLE_ARN` secret
- Triggers on PR open, sync, ready_for_review, and reopen events targeting `main`
- Includes concurrency control, draft PR filtering, and a 15-minute timeout

## Test plan
- [x] Set the `TELEGEN_AWS_ASSUME_ROLE_ARN` repo secret with the appropriate IAM role ARN
- [x] Open a test PR to verify the workflow triggers and Claude posts review comments