### PR TITLE
feat(release branch patch): allow HTTP operations to be configurable via environment variab…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- Support environment-configured endpoint visibility for HTTP operation names
+  ([#1352](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1352))
 - Bump Netty to 4.1.132.Final to fix CVE-2026-33870 and CVE-2026-33871
   ([#1348](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1348))
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributesSpanExporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributesSpanExporter.java
@@ -88,6 +88,11 @@ public class AwsMetricAttributesSpanExporter implements SpanExporter {
     List<SpanData> modifiedSpans = new ArrayList<>();
 
     for (SpanData span : spans) {
+      // If OTEL_AWS_HTTP_OPERATION_PATHS is configured and matches, wrap the span with the
+      // overridden name so that the exported trace carries the correct span name. This ensures
+      // getIngressOperation (called below) derives aws.local.operation from the overridden name.
+      span = AwsSpanProcessingUtil.applyOperationPathSpanName(span);
+
       // If the map has no items, no modifications are required. If there is one item, it means the
       // span either produces Service or Dependency metric attributes, and in either case we want to
       // modify the span with them. If there are two items, the span produces both Service and

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessor.java
@@ -132,6 +132,10 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   public void onEnd(ReadableSpan span) {
     SpanData spanData = span.toSpanData();
 
+    // If OTEL_AWS_HTTP_OPERATION_PATHS is configured, wrap the span with the overridden name
+    // so that metrics use the configured operation path instead of the original span name.
+    spanData = AwsSpanProcessingUtil.applyOperationPathSpanName(spanData);
+
     Map<String, Attributes> attributeMap =
         generator.generateMetricAttributeMapFromSpan(spanData, resource);
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtil.java
@@ -43,10 +43,12 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.data.DelegatingSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -77,6 +79,153 @@ final class AwsSpanProcessingUtil {
   static final AttributeKey<String> OTEL_SCOPE_NAME = AttributeKey.stringKey("otel.scope.name");
   static final String LAMBDA_SCOPE_PREFIX = "io.opentelemetry.aws-lambda-";
   static final String SERVLET_SCOPE_PREFIX = "io.opentelemetry.servlet-";
+
+  // Environment variable for configurable operation name paths
+  static final String OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG = "OTEL_AWS_HTTP_OPERATION_PATHS";
+
+  // Parsed and sorted (longest first) operation paths from env var, computed once
+  private static volatile List<String> operationPaths;
+
+  /**
+   * Parse the OTEL_AWS_HTTP_OPERATION_PATHS env var into a sorted list of path templates (longest
+   * first). Returns an empty list if the env var is not set.
+   */
+  static List<String> getOperationPaths() {
+    if (operationPaths == null) {
+      synchronized (AwsSpanProcessingUtil.class) {
+        if (operationPaths == null) {
+          String config = System.getenv(OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG);
+          if (config == null || config.trim().isEmpty()) {
+            operationPaths = Collections.emptyList();
+          } else {
+            List<String> paths = new ArrayList<>();
+            for (String path : config.split(",")) {
+              String trimmed = path.trim();
+              if (!trimmed.isEmpty()) {
+                paths.add(trimmed);
+              }
+            }
+            // Sort longest first so longest prefix match wins. For patterns with the same
+            // number of segments, the original configuration order is preserved (stable sort).
+            paths.sort(
+                (a, b) -> {
+                  int aSegments = a.split("/").length;
+                  int bSegments = b.split("/").length;
+                  return Integer.compare(bSegments, aSegments);
+                });
+            operationPaths = Collections.unmodifiableList(paths);
+          }
+        }
+      }
+    }
+    return operationPaths;
+  }
+
+  // Visible for testing — allows tests to reset the cached paths
+  static void resetOperationPaths() {
+    synchronized (AwsSpanProcessingUtil.class) {
+      operationPaths = null;
+    }
+  }
+
+  /**
+   * If OTEL_AWS_HTTP_OPERATION_PATHS is configured and a pattern matches the span's URL path,
+   * returns a wrapped SpanData with the span name overridden to "METHOD /path/template". Returns
+   * the original span unchanged if no config is set or no pattern matches.
+   */
+  static SpanData applyOperationPathSpanName(SpanData span) {
+    List<String> paths = getOperationPaths();
+    if (paths.isEmpty()) {
+      return span;
+    }
+
+    String urlPath = getUrlPath(span);
+    if (urlPath == null || urlPath.isEmpty()) {
+      return span;
+    }
+
+    // Strip query string and fragment (relevant for http.target)
+    int idx = urlPath.indexOf('?');
+    if (idx >= 0) {
+      urlPath = urlPath.substring(0, idx);
+    }
+    idx = urlPath.indexOf('#');
+    if (idx >= 0) {
+      urlPath = urlPath.substring(0, idx);
+    }
+
+    // Normalize trailing slashes
+    while (urlPath.endsWith("/") && urlPath.length() > 1) {
+      urlPath = urlPath.substring(0, urlPath.length() - 1);
+    }
+
+    String[] urlSegments = urlPath.split("/", -1);
+    for (String pattern : paths) {
+      String normalizedPattern = pattern;
+      while (normalizedPattern.endsWith("/") && normalizedPattern.length() > 1) {
+        normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length() - 1);
+      }
+      if (segmentsMatch(urlSegments, normalizedPattern.split("/", -1))) {
+        String httpMethod = getHttpMethod(span);
+        String newName = httpMethod != null ? httpMethod + " " + pattern : pattern;
+        return new DelegatingSpanData(span) {
+          @Override
+          public String getName() {
+            return newName;
+          }
+        };
+      }
+    }
+    return span;
+  }
+
+  /** Return the URL path from server span attributes, preferring url.path over http.target. */
+  private static String getUrlPath(SpanData span) {
+    if (isKeyPresent(span, URL_PATH)) {
+      return span.getAttributes().get(URL_PATH);
+    }
+    if (isKeyPresent(span, HTTP_TARGET)) {
+      return span.getAttributes().get(HTTP_TARGET);
+    }
+    return null;
+  }
+
+  /**
+   * Check if URL segments match a pattern's segments. Only pattern segments can be wildcards
+   * ({param}, :param, or *) — URL segments are always treated as literals. A wildcard pattern
+   * segment matches any non-empty URL segment. The pattern acts as a prefix — extra URL segments
+   * after the pattern are allowed.
+   */
+  private static boolean segmentsMatch(String[] urlSegments, String[] patternSegments) {
+    for (int i = 0; i < patternSegments.length; i++) {
+      if (i >= urlSegments.length) {
+        return false;
+      }
+      String ps = patternSegments[i];
+      String us = urlSegments[i];
+
+      // Pattern wildcard matches any non-empty URL segment
+      if (isWildcardSegment(ps)) {
+        if (us.isEmpty()) {
+          return false;
+        }
+        continue;
+      }
+
+      // Both literal — must be equal
+      if (!ps.equals(us)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** A segment is a wildcard if it uses {param}, :param, or * format. */
+  private static boolean isWildcardSegment(String segment) {
+    return (segment.startsWith("{") && segment.endsWith("}"))
+        || segment.startsWith(":")
+        || segment.equals("*");
+  }
 
   static List<String> getDialectKeywords() {
     try (InputStream jsonFile =
@@ -123,6 +272,7 @@ final class AwsSpanProcessingUtil {
       }
       return getFunctionNameFromEnv() + "/FunctionHandler";
     }
+
     String operation = span.getName();
     if (shouldUseInternalOperation(span)) {
       operation = INTERNAL_OPERATION;
@@ -130,6 +280,16 @@ final class AwsSpanProcessingUtil {
       operation = generateIngressOperation(span);
     }
     return operation;
+  }
+
+  /** Get the HTTP method from the span, checking new and deprecated semconv attributes. */
+  private static String getHttpMethod(SpanData span) {
+    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
+      return span.getAttributes().get(HTTP_REQUEST_METHOD);
+    } else if (isKeyPresent(span, HTTP_METHOD)) {
+      return span.getAttributes().get(HTTP_METHOD);
+    }
+    return null;
   }
 
   // define a function so that we can mock it in unit test
@@ -256,11 +416,8 @@ final class AwsSpanProcessingUtil {
     if (operation == null || operation.equals(UNKNOWN_OPERATION)) {
       return false;
     }
-    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
-      return !operation.equals(httpMethod);
-    } else if (isKeyPresent(span, HTTP_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_METHOD);
+    String httpMethod = getHttpMethod(span);
+    if (httpMethod != null) {
       return !operation.equals(httpMethod);
     }
     return true;

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanMetricsProcessorTest.java
@@ -15,7 +15,9 @@
 
 package software.amazon.opentelemetry.javaagent.providers;
 
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -624,5 +626,42 @@ class AwsSpanMetricsProcessorTest {
         .record(eq(0L), eq(metricAttributesMap.get(DEPENDENCY_METRIC)));
     verify(latencyHistogramMock, times(wantedDependencyMetricInvocation))
         .record(eq(TEST_LATENCY_MILLIS), eq(metricAttributesMap.get(DEPENDENCY_METRIC)));
+  }
+
+  @Test
+  public void testOnEndAppliesOperationPathSpanNameBeforeMetrics() {
+    // Build a span with url.path that matches a configured operation path
+    Attributes spanAttributes =
+        Attributes.builder()
+            .put(URL_PATH, "/api/users/42/stats")
+            .put(HTTP_REQUEST_METHOD, "GET")
+            .put(HTTP_RESPONSE_STATUS_CODE, 200L)
+            .build();
+    ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
+
+    try (org.mockito.MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        org.mockito.Mockito.mockStatic(
+            AwsSpanProcessingUtil.class,
+            org.mockito.Mockito.withSettings()
+                .defaultAnswer(org.mockito.Mockito.CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(java.util.List.of("/api/users/{userId}/stats"));
+
+      // Capture the SpanData passed to the generator
+      org.mockito.ArgumentCaptor<io.opentelemetry.sdk.trace.data.SpanData> spanCaptor =
+          org.mockito.ArgumentCaptor.forClass(io.opentelemetry.sdk.trace.data.SpanData.class);
+      Map<String, Attributes> metricAttributesMap =
+          buildMetricAttributes(CONTAINS_ATTRIBUTES, readableSpanMock.toSpanData());
+      when(generatorMock.generateMetricAttributeMapFromSpan(any(), eq(testResource)))
+          .thenReturn(metricAttributesMap);
+
+      awsSpanMetricsProcessor.onEnd(readableSpanMock);
+
+      // Verify the generator received a span with the overridden name
+      verify(generatorMock)
+          .generateMetricAttributeMapFromSpan(spanCaptor.capture(), eq(testResource));
+      assertThat(spanCaptor.getValue().getName()).isEqualTo("GET /api/users/{userId}/stats");
+    }
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsSpanProcessingUtilTest.java
@@ -17,6 +17,8 @@ package software.amazon.opentelemetry.javaagent.providers;
 
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.UrlAttributes.URL_PATH;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
@@ -647,5 +649,375 @@ public class AwsSpanProcessingUtilTest {
     when(span.getKind()).thenReturn(SpanKind.CLIENT);
 
     assertFalse(AwsSpanProcessingUtil.isServletServerSpan(span));
+  }
+
+  // Helper to call the private segmentsMatch method via reflection
+  private static boolean segmentsMatch(String[] urlSegments, String[] patternSegments) {
+    try {
+      java.lang.reflect.Method method =
+          AwsSpanProcessingUtil.class.getDeclaredMethod(
+              "segmentsMatch", String[].class, String[].class);
+      method.setAccessible(true);
+      return (boolean) method.invoke(null, urlSegments, patternSegments);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static boolean matchSegments(String urlPath, String pattern) {
+    return segmentsMatch(urlPath.split("/", -1), pattern.split("/", -1));
+  }
+
+  // Helper to call the private getUrlPath method via reflection
+  private static String getUrlPath(SpanData span) {
+    try {
+      java.lang.reflect.Method method =
+          AwsSpanProcessingUtil.class.getDeclaredMethod("getUrlPath", SpanData.class);
+      method.setAccessible(true);
+      return (String) method.invoke(null, span);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // --- getUrlPath: attribute priority ---
+
+  @Test
+  public void testGetUrlPath_prefersUrlPathOverHttpTarget() {
+    when(attributesMock.get(URL_PATH)).thenReturn("/from/url-path");
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/from/http-target");
+    assertThat(getUrlPath(spanDataMock)).isEqualTo("/from/url-path");
+  }
+
+  @Test
+  public void testGetUrlPath_fallsBackToHttpTarget() {
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/from/http-target");
+    assertThat(getUrlPath(spanDataMock)).isEqualTo("/from/http-target");
+  }
+
+  @Test
+  public void testGetUrlPath_returnsNullWhenNeitherPresent() {
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn(null);
+    assertThat(getUrlPath(spanDataMock)).isNull();
+  }
+
+  // --- segmentsMatch: exact literal matching ---
+
+  @Test
+  public void testSegmentsMatch_exactMatch() {
+    assertThat(matchSegments("/api/contests", "/api/contests")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_noMatch() {
+    assertThat(matchSegments("/api/players", "/api/contests")).isFalse();
+  }
+
+  @Test
+  public void testSegmentsMatch_extraUrlSegmentsAllowed() {
+    assertThat(matchSegments("/api/contests/123/extra", "/api/contests")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_patternLongerThanUrl() {
+    assertThat(matchSegments("/api", "/api/contests/{id}")).isFalse();
+  }
+
+  // --- segmentsMatch: {param} wildcard in pattern ---
+
+  @Test
+  public void testSegmentsMatch_curlyBraceMatchesLiteral() {
+    assertThat(matchSegments("/api/contests/123", "/api/contests/{id}")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_curlyBraceMatchesDeepPath() {
+    assertThat(matchSegments("/api/contests/123/leaderboard", "/api/contests/{id}/leaderboard"))
+        .isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_curlyBraceDoesNotMatchEmpty() {
+    assertThat(matchSegments("/api/contests/", "/api/contests/{id}")).isFalse();
+  }
+
+  // --- segmentsMatch: :param wildcard in pattern ---
+
+  @Test
+  public void testSegmentsMatch_colonParamMatchesLiteral() {
+    assertThat(matchSegments("/api/users/42", "/api/users/:userId")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_colonParamMatchesDeepPath() {
+    assertThat(matchSegments("/api/users/42/stats", "/api/users/:userId/stats")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_colonParamDoesNotMatchEmpty() {
+    assertThat(matchSegments("/api/users/", "/api/users/:userId")).isFalse();
+  }
+
+  // --- segmentsMatch: * wildcard in pattern ---
+
+  @Test
+  public void testSegmentsMatch_trailingStarMatchesRemaining() {
+    assertThat(matchSegments("/api/contests/123/anything/else", "/api/contests/*")).isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_midStarMatchesSingleSegment() {
+    assertThat(matchSegments("/api/contests/123/leaderboard", "/api/contests/*/leaderboard"))
+        .isTrue();
+  }
+
+  @Test
+  public void testSegmentsMatch_starDoesNotMatchEmpty() {
+    assertThat(matchSegments("/api/contests/", "/api/contests/*/leaderboard")).isFalse();
+  }
+
+  // --- applyOperationPathSpanName: integration tests ---
+
+  @Test
+  public void testApplyOperationPathSpanName_matchesUrlPath() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/123/leaderboard");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(
+              List.of("/api/contests/{id}/leaderboard", "/api/contests/{id}", "/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests/{id}/leaderboard");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_matchesParameterizedUrl() {
+    when(spanDataMock.getName()).thenReturn("GET /api/users/:userId/stats");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/users/42/stats");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/users/{userId}/stats", "/api/users/{userId}", "/api/users"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/users/{userId}/stats");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_matchesHttpTarget() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/api/teams/5?include=roster");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/teams/{id}", "/api/teams"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/teams/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_httpTargetWithFragment() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn(null);
+    when(attributesMock.get(HTTP_TARGET)).thenReturn("/api/teams/5#section");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/teams/{id}"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/teams/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_sameLengthPatternsFirstConfigWins() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/v1/user1");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      // Both patterns have 3 segments — first one in config order should win
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/v1/{userId}", "/api/{version}/user1"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/v1/{userId}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_noMatch_returnsOriginal() {
+    when(spanDataMock.getName()).thenReturn("GET /unknown");
+    when(attributesMock.get(URL_PATH)).thenReturn("/unknown/path");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests/{id}"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result).isSameAs(spanDataMock);
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_emptyConfig_returnsOriginal() {
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic.when(AwsSpanProcessingUtil::getOperationPaths).thenReturn(List.of());
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result).isSameAs(spanDataMock);
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_longestMatchWins() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/42");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      // Sorted longest first
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(
+              List.of(
+                  "/api/contests/{id}/leaderboard", "/api/contests/{id}", "/api/contests", "/api"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests/{id}");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_queryStringStripped() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests?page=1&size=10");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_noHttpMethod() {
+    when(spanDataMock.getName()).thenReturn("/api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn(null);
+    when(attributesMock.get(HTTP_METHOD)).thenReturn(null);
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("/api/contests");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_trailingSlashNormalized() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      assertThat(result.getName()).isEqualTo("GET /api/contests");
+    }
+  }
+
+  @Test
+  public void testApplyOperationPathSpanName_patternTrailingSlashNormalized() {
+    when(spanDataMock.getName()).thenReturn("GET /api");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests");
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      // Pattern has trailing slash
+      utilStatic
+          .when(AwsSpanProcessingUtil::getOperationPaths)
+          .thenReturn(List.of("/api/contests/"));
+
+      SpanData result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      // Matches, and preserves the original pattern format in the name
+      assertThat(result.getName()).isEqualTo("GET /api/contests/");
+    }
+  }
+
+  // --- getIngressOperation: uses span name (no longer reads operation paths directly) ---
+
+  @Test
+  public void testGetIngressOperation_validSpanName_usedDirectly() {
+    when(spanDataMock.getName()).thenReturn("GET /api/contests/{id}");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic.when(AwsSpanProcessingUtil::getOperationPaths).thenReturn(List.of());
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("GET /api/contests/{id}");
+    }
+  }
+
+  @Test
+  public void testGetIngressOperation_invalidSpanName_fallsBackToUrlTruncation() {
+    when(spanDataMock.getName()).thenReturn("GET");
+    when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
+    when(attributesMock.get(HTTP_REQUEST_METHOD)).thenReturn("GET");
+    when(attributesMock.get(URL_PATH)).thenReturn("/api/contests/123");
+
+    try (MockedStatic<AwsSpanProcessingUtil> utilStatic =
+        mockStatic(AwsSpanProcessingUtil.class, withSettings().defaultAnswer(CALLS_REAL_METHODS))) {
+      utilStatic.when(AwsSpanProcessingUtil::getOperationPaths).thenReturn(List.of());
+
+      String actual = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
+      assertThat(actual).isEqualTo("GET /api");
+    }
   }
 }


### PR DESCRIPTION
Backpatch #1352 to release 2.26.x branch.

*Issue #, if available:*

*Description of changes:*
When HTTP span names don't contain a URL path, we generate the HTTP operation by truncating the URL path to only the first trailing value to preserve low cardinality (i.e. /api/v1/users -> /api). This can result in overly broad operation groupings for services with endpoint paths of various depths.

This PR introduces an environment variable configuration, `OTEL_AWS_HTTP_OPERATION_PATHS`, which allows users to configure their own HTTP endpoint paths. If this variable is provided, the span name's URL path will resolve to the longest matching path. Wildcards are supported with the following syntaxes: `{version}`, `:version`, or simply `*`. This way, users can decide how their service endpoint are grouped into operation names shown in CloudWatch.

Added unit and integration tests to verify behavior, and did some E2E testing with an instrumented HTTP server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
