### PR TITLE
Add sign-public-ecr-image job to release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -528,3 +528,53 @@ jobs:
              ${{ env.ARTIFACT_NAME }}.sha256 \
              layer.zip \
              layer.zip.sha256
+
+  sign-public-ecr-image:
+    runs-on: ubuntu-latest
+    needs: publish-sdk
+    steps:
+      - name: Configure AWS Credentials for public ECR
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
+          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
+
+      # Install notation CLI with AWS Signer plugin
+      - name: Install notation CLI with AWS Signer plugin
+        run: |
+          curl -Lo aws-signer-notation-cli_amd64.deb https://d2hvyiie56hcat.cloudfront.net/linux/amd64/installer/deb/latest/aws-signer-notation-cli_amd64.deb
+          sudo dpkg -i aws-signer-notation-cli_amd64.deb
+          notation version
+          notation plugin ls
+
+      # Query ECR signing profile ARN
+      - name: Query ECR Signing Profile ARN
+        id: ecr-signing-profile
+        run: |
+          PROFILE_ARN=$(aws signer list-signing-profiles --region ${{ env.AWS_PUBLIC_ECR_REGION }} --query "profiles[?profileName=='ADOTECRSigningProfile'].arn" --output text 2>/dev/null)
+          if [ -n "$PROFILE_ARN" ]; then
+            echo "profile_arn=$PROFILE_ARN" >> $GITHUB_OUTPUT
+            echo "Found ECR signing profile: $PROFILE_ARN"
+          else
+            echo "ECR signing profile 'ADOTECRSigningProfile' not found"
+            exit 0
+          fi
+
+      # Login to Public ECR
+      - name: Log in to AWS public ECR
+        if: steps.ecr-signing-profile.outputs.profile_arn != ''
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: public.ecr.aws
+
+      # Sign Public ECR Image
+      - name: Sign Public ECR Image
+        if: steps.ecr-signing-profile.outputs.profile_arn != ''
+        run: |
+          # Sign the released public ECR image
+          notation sign ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }} \
+            --plugin com.amazonaws.signer.notation.plugin \
+            --id ${{ steps.ecr-signing-profile.outputs.profile_arn }}
+          echo "Successfully signed public ECR image"
+          echo "Image: ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }}"
+          echo "Profile ARN: ${{ steps.ecr-signing-profile.outputs.profile_arn }}"


### PR DESCRIPTION
## Summary

Backports the `sign-public-ecr-image` job from [aws-otel-python-instrumentation release/v0.14.x](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/release/v0.14.x/.github/workflows/release-build.yml) to the Java instrumentation release workflow.

## Changes

Added `sign-public-ecr-image` job in `.github/workflows/release-build.yml` that:
1. Configures AWS credentials using `AWS_ASSUME_ROLE_ARN_RELEASE`
2. Installs notation CLI with AWS Signer plugin
3. Queries `ADOTECRSigningProfile` signing profile ARN (gracefully skips if not found)
4. Logs in to public ECR and signs the released image `PUBLIC_REPOSITORY:v$VERSION`

The job runs after `publish-sdk` which pushes the multi-arch image to public ECR.