### PR TITLE
[Java]feat: Run auto-instrumentation init container as non-root user

### DIFF
--- a/.github/scripts/test-adot-javaagent-image.sh
+++ b/.github/scripts/test-adot-javaagent-image.sh
@@ -6,6 +6,7 @@ TEST_TAG=$1
 ADOT_JAVA_VERSION=$2
 
 docker volume create operator-volume
+docker run --mount source=operator-volume,dst=/otel-auto-instrumentation public.ecr.aws/amazonlinux/amazonlinux:latest chmod 777 /otel-auto-instrumentation
 docker run --mount source=operator-volume,dst=/otel-auto-instrumentation ${TEST_TAG} cp /javaagent.jar /otel-auto-instrumentation/javaagent.jar
 docker run -dt --mount source=operator-volume,dst=/otel-auto-instrumentation --name temp  public.ecr.aws/amazonlinux/amazonlinux:latest
 FILENAME=$(docker exec temp /bin/bash -c "ls /otel-auto-instrumentation")

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,3 +52,5 @@ COPY --from=builder /usr/src/cp-utility/bin/cp-utility /bin/cp
 
 
 COPY --chmod=go+r ./otelagent/build/libs/aws-opentelemetry-agent-${ADOT_JAVA_VERSION}.jar /javaagent.jar
+
+USER 65534:65534


### PR DESCRIPTION
## Problem
Customers enforcing `runAsNonRoot: true` via Pod Security Standards cannot use ADOT auto-instrumentation. Kubernetes checks the image metadata for a USER directive, finds none (defaults to UID 0 / root), and rejects the pod with: 
`Error: container has runAsNonRoot and image will run as root`

## Summary
Enables customers using the Kubernetes Restricted Pod Security Standard to use ADOT auto-instrumentation
Without this change, customers enforcing runAsNonRoot: true at the namespace or pod level cannot use ADOT auto-instrumentation because Kubernetes rejects the init container with:
`container has runAsNonRoot and image will run as root`

Follows the upstream OTel Operator fix (open-telemetry/opentelemetry-operator#2272)

## Changes
 Add `USER 65534:65534` to the auto-instrumentation Dockerfile so the init container runs as non-root by default

## Testing

Validated on EKS cluster (us-east-1, EKS v1.34.6) with CW Observability add-on v5.3.1

For more in-depth analysis please see [Test Results](https://quip-amazon.com/2WlNA0XUepQA/Test-Results)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
