### PR TITLE
Release build patch

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,7 +8,7 @@ on:
       aws_region:
         description: 'Deploy lambda layer to aws regions'
         required: true
-        default: 'us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1, af-south-1, ap-east-1, ap-south-2, ap-southeast-3, ap-southeast-4, eu-central-2, eu-south-1, eu-south-2, il-central-1, me-central-1, me-south-1, ap-southeast-5, ap-southeast-7, mx-central-1, ca-west-1, cn-north-1, cn-northwest-1'
+        default: 'us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1, af-south-1, ap-east-1, ap-east-2, ap-south-2, ap-southeast-3, ap-southeast-4, ap-southeast-6, eu-central-2, eu-south-1, eu-south-2, il-central-1, me-central-1, ap-southeast-5, ap-southeast-7, mx-central-1, ca-west-1, cn-north-1, cn-northwest-1'
 
 env:
   AWS_PUBLIC_ECR_REGION: us-east-1
@@ -127,112 +127,9 @@ jobs:
           name: layer.zip
           path: lambda-layer/build/distributions/${{ env.LAYER_ARTIFACT_NAME }}
 
-  publish-sdk:
-    runs-on: ubuntu-latest
-    needs: [build-sdk, build-layer]
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version-file: .java-version
-          distribution: 'temurin'
-      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
-      
-      - name: Publish patched dependencies to maven local
-        uses: ./.github/actions/patch-dependencies
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
-
-      - name: Log in to AWS ECR
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-        with:
-          registry: public.ecr.aws
-
-      # build the artifact again so that its in the output path expected for building the docker image.
-      - name: Build release with Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa #v2
-        with:
-          arguments: build integrationTests -PlocalDocker=true -Prelease.version=${{ env.VERSION }} --stacktrace
-
-      - name: Configure AWS Credentials for public ECR
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
-
-      - name: Log in to AWS ECR
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-        with:
-          registry: public.ecr.aws
-
-      - name: Configure AWS Credentials for Private ECR
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
-
-      - name: Log in to AWS private ECR
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-        with:
-          registry: ${{ env.PRIVATE_REGISTRY }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #3.6.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
-        with:
-          driver-opts: image=moby/buildkit:v0.15.1
-
-      - name: Build image for testing
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-        with:
-          push: false
-          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
-          context: .
-          platforms: linux/amd64
-          tags: ${{ env.TEST_TAG }}
-          load: true
-
-      - name: Test docker image
-        env:
-          VERSION: ${{ env.VERSION }}
-        shell: bash
-        run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "$VERSION"
-
-      - name: Build and push image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-        with:
-          push: true
-          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
-          context: .
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
-            ${{ env.PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
-
-      - name: Build and Publish release with Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
-        with:
-          arguments: build final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ env.VERSION }} --stacktrace
-        env:
-          PUBLISH_TOKEN_USERNAME: ${{ secrets.PUBLISH_TOKEN_USERNAME }}
-          PUBLISH_TOKEN_PASSWORD: ${{ secrets.PUBLISH_TOKEN_PASSWORD }}
-          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   publish-layer-prod:
     runs-on: ubuntu-latest
-    needs: [build-layer, publish-sdk]
+    needs: build-layer
     strategy:
       matrix:
         aws_region: ${{ fromJson(needs.build-layer.outputs.aws_regions_json) }}
@@ -265,86 +162,18 @@ jobs:
           role-duration-seconds: 1200
           aws-region: ${{ matrix.aws_region }}
 
-      - name: Get s3 bucket name for release
-        run: |
-          echo BUCKET_NAME=java-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
-
-      - name: download layer.zip
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-        with:
-          name: layer.zip
-
-      - name: Upload to S3 and Sign
-        continue-on-error: true
-        run: |
-          aws s3 mb s3://${{ env.BUCKET_NAME }}
-          aws s3 cp ${{ env.LAYER_ARTIFACT_NAME }} s3://${{ env.BUCKET_NAME }}
-          
-          # Sign the layer
-          echo "Checking for signing profile..."
-          PROFILE=$(aws signer list-signing-profiles --query "profiles[?profileName=='ADOTLambdaLayerSigningProfile'].arn" --output text 2>/dev/null)
-          [ -z "$PROFILE" ] && echo "No signing profile found, skipping" && exit 0
-          
-          echo "Starting signing job..."
-          JOB_ID=$(aws signer start-signing-job \
-            --source "s3={bucketName=${{ env.BUCKET_NAME }},key=${{ env.LAYER_ARTIFACT_NAME }},version=null}" \
-            --destination "s3={bucketName=${{ env.BUCKET_NAME }},prefix=signed-}" \
-            --profile-name ADOTLambdaLayerSigningProfile \
-            --query 'jobId' --output text 2>/dev/null) || exit 0
-          [ -z "$JOB_ID" ] && echo "No job ID returned" && exit 0
-          echo "Job ID: $JOB_ID"
-          
-          echo "Waiting for signing job to complete..."
-          aws signer wait successful-signing-job --job-id "$JOB_ID" || exit 0
-          echo "Signing completed"
-          
-          echo "Moving signed layer..."
-          SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text 2>/dev/null)
-          echo "SIGNED value: '$SIGNED'"
-          if [ -n "$SIGNED" ]; then
-            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }} --clobber"
-            echo "Signed layer moved successfully"
-          else
-            echo "No SIGNED value returned, skipping move"
-          fi
-      
-      - name: Publish Layer Version
+      - name: Get latest layer ARN
         run: |
           layerARN=$(
-            aws lambda publish-layer-version \
+            aws lambda list-layer-versions \
               --layer-name ${{ env.LAYER_NAME }} \
-              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=${{ env.LAYER_ARTIFACT_NAME }} \
-              --compatible-runtimes java11 java17 java21 \
-              --compatible-architectures "arm64" "x86_64" \
-              --license-info "Apache-2.0" \
-              --description "AWS Distro of OpenTelemetry Lambda Layer for Java Runtime" \
-              --query 'LayerVersionArn' \
+              --query 'max_by(LayerVersions, &Version).LayerVersionArn' \
               --output text
           )
           echo $layerARN
-          echo "LAYER_ARN=${layerARN}" >> $GITHUB_ENV
           mkdir ${{ env.LAYER_NAME }}
           echo $layerARN > ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
           cat ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
-          
-          # Output SigningProfileVersionArn
-          aws lambda get-layer-version-by-arn \
-            --arn $layerARN \
-            --output json | jq -r '.Content.SigningProfileVersionArn'
-
-      - name: public layer
-        run: |
-          layerVersion=$(
-            aws lambda list-layer-versions \
-              --layer-name ${{ env.LAYER_NAME }} \
-              --query 'max_by(LayerVersions, &Version).Version'
-          )
-          aws lambda add-layer-version-permission \
-            --layer-name ${{ env.LAYER_NAME }} \
-            --version-number $layerVersion \
-            --principal "*" \
-            --statement-id publish \
-            --action lambda:GetLayerVersion
 
       - name: upload layer arn artifact
         if: ${{ success() }}
@@ -352,11 +181,6 @@ jobs:
         with:
           name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
-
-      - name: clean s3
-        if: always()
-        run: |
-          aws s3 rb --force s3://${{ env.BUCKET_NAME }}
 
   generate-lambda-release-note:
     runs-on: ubuntu-latest
@@ -508,53 +332,3 @@ jobs:
              ${{ env.ARTIFACT_NAME }}.sha256 \
              layer.zip \
              layer.zip.sha256
-
-  sign-public-ecr-image:
-    runs-on: ubuntu-latest
-    needs: publish-sdk
-    steps:
-      - name: Configure AWS Credentials for public ECR
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_RELEASE }}
-          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
-
-      # Install notation CLI with AWS Signer plugin
-      - name: Install notation CLI with AWS Signer plugin
-        run: |
-          curl -Lo aws-signer-notation-cli_amd64.deb https://d2hvyiie56hcat.cloudfront.net/linux/amd64/installer/deb/latest/aws-signer-notation-cli_amd64.deb
-          sudo dpkg -i aws-signer-notation-cli_amd64.deb
-          notation version
-          notation plugin ls
-
-      # Query ECR signing profile ARN
-      - name: Query ECR Signing Profile ARN
-        id: ecr-signing-profile
-        run: |
-          PROFILE_ARN=$(aws signer list-signing-profiles --region ${{ env.AWS_PUBLIC_ECR_REGION }} --query "profiles[?profileName=='ADOTECRSigningProfile'].arn" --output text 2>/dev/null)
-          if [ -n "$PROFILE_ARN" ]; then
-            echo "profile_arn=$PROFILE_ARN" >> $GITHUB_OUTPUT
-            echo "Found ECR signing profile: $PROFILE_ARN"
-          else
-            echo "ECR signing profile 'ADOTECRSigningProfile' not found"
-            exit 0
-          fi
-
-      # Login to Public ECR
-      - name: Log in to AWS public ECR
-        if: steps.ecr-signing-profile.outputs.profile_arn != ''
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-        with:
-          registry: public.ecr.aws
-
-      # Sign Public ECR Image
-      - name: Sign Public ECR Image
-        if: steps.ecr-signing-profile.outputs.profile_arn != ''
-        run: |
-          # Sign the released public ECR image
-          notation sign ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }} \
-            --plugin com.amazonaws.signer.notation.plugin \
-            --id ${{ steps.ecr-signing-profile.outputs.profile_arn }}
-          echo "Successfully signed public ECR image"
-          echo "Image: ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }}"
-          echo "Profile ARN: ${{ steps.ecr-signing-profile.outputs.profile_arn }}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The previous release build timed out due to outage in me-south-1: https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/24852179034. The generate-release-note and publish-github jobs did not run.

This PR updates the workflow to skip the publish-sdk job and have publish-layer fetch the existing latest layer versions that were already published, and then run the remaining steps as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
