### PR TITLE
add trivy suppressions for Netty CVEs

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -14,3 +14,12 @@ vulnerabilities:
   - id: CVE-2026-41417
     statement: "Netty request-line validation bypass via setUri() enables CRLF injection/request smuggling. Low risk for ADOT Java agent (URIs are operator-configured, no attacker-controlled input reaches setUri()). Fix: bump netty-bom to 4.1.133.Final. https://nvd.nist.gov/vuln/detail/CVE-2026-41417"
     expired_at: 2026-05-22
+  - id: CVE-2026-42583
+    statement: "Netty Lz4FrameDecoder resource exhaustion. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42583"
+    expired_at: 2026-05-22
+  - id: CVE-2026-42584
+    statement: "Netty HttpClientCodec response desynchronization. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42584"
+    expired_at: 2026-05-22
+  - id: CVE-2026-42587
+    statement: "Netty HttpContentDecompressor maxAllocation bypass with br/zstd/snappy Content-Encoding leads to decompression bomb. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42587"
+    expired_at: 2026-05-22

--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -12,3 +12,12 @@ vulnerabilities:
   - id: CVE-2026-41417
     statement: "Netty request-line validation bypass via setUri() enables CRLF injection/request smuggling. Low risk for ADOT Java agent (URIs are operator-configured, no attacker-controlled input reaches setUri()). Fix: bump netty-bom to 4.1.133.Final. https://nvd.nist.gov/vuln/detail/CVE-2026-41417"
     expired_at: 2026-05-22
+  - id: CVE-2026-42583
+    statement: "Netty Lz4FrameDecoder resource exhaustion. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42583"
+    expired_at: 2026-05-22
+  - id: CVE-2026-42584
+    statement: "Netty HttpClientCodec response desynchronization. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42584"
+    expired_at: 2026-05-22
+  - id: CVE-2026-42587
+    statement: "Netty HttpContentDecompressor maxAllocation bypass with br/zstd/snappy Content-Encoding leads to decompression bomb. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42587"
+    expired_at: 2026-05-22


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update *trivyignore.yaml files with additional CVEs detected by [daily high scan](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/25672578031) workflow. Expires the week of our next planned release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
