### PR TITLE
feat: Use ECR API to tag platform images instead of docker buildx ima…

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -256,7 +256,7 @@ jobs:
 
           # Tag attestation manifests (architecture=unknown) with their sha hex
           for DIGEST in $(echo "$MANIFEST_INDEX" | jq -r '.manifests[] | select(.platform.architecture=="unknown") | .digest'); do
-            SHA_HEX=$(echo "$DIGEST" | sed 's/sha256://')
+            SHA_HEX="${DIGEST#sha256:}"
             MANIFEST=$(aws ecr batch-get-image \
               --repository-name "${REPO_NAME}" \
               --image-ids imageDigest="${DIGEST}" \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -208,27 +208,7 @@ jobs:
         shell: bash
         run: .github/scripts/test-adot-javaagent-image.sh "${{ env.TEST_TAG }}" "$VERSION"
 
-      - name: Build and push amd64 image to private ECR
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-        with:
-          push: true
-          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
-          context: .
-          platforms: linux/amd64
-          tags: |
-            ${{ env.PRIVATE_REPOSITORY }}:v${{ env.VERSION }}-amd64
-
-      - name: Build and push arm64 image to private ECR
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-        with:
-          push: true
-          build-args: "ADOT_JAVA_VERSION=${{ env.VERSION }}"
-          context: .
-          platforms: linux/arm64
-          tags: |
-            ${{ env.PRIVATE_REPOSITORY }}:v${{ env.VERSION }}-arm64
-
-      - name: Build and push multi-arch image
+      - name: Build and push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: true
@@ -238,6 +218,58 @@ jobs:
           tags: |
             ${{ env.PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
             ${{ env.PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
+
+      - name: Tag platform images in private ECR
+        env:
+          REPO_NAME: adot-autoinstrumentation-java
+        run: |
+          VERSION="${{ env.VERSION }}"
+          REGION="${{ env.AWS_PRIVATE_ECR_REGION }}"
+          # Read the manifest index for the multi-arch tag we just pushed
+          MANIFEST_INDEX=$(aws ecr batch-get-image \
+            --repository-name "${REPO_NAME}" \
+            --image-ids imageTag="v${VERSION}" \
+            --region "${REGION}" \
+            --query 'images[0].imageManifest' \
+            --output text)
+
+          # Tag platform images (amd64, arm64) with v$VERSION-$arch
+          for arch in amd64 arm64; do
+            DIGEST=$(echo "$MANIFEST_INDEX" | jq -r ".manifests[] | select(.platform.architecture==\"${arch}\") | .digest")
+            if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+              echo "No ${arch} image found in manifest index, skipping"
+              continue
+            fi
+            MANIFEST=$(aws ecr batch-get-image \
+              --repository-name "${REPO_NAME}" \
+              --image-ids imageDigest="${DIGEST}" \
+              --region "${REGION}" \
+              --query 'images[0].imageManifest' \
+              --output text)
+            aws ecr put-image \
+              --repository-name "${REPO_NAME}" \
+              --image-tag "v${VERSION}-${arch}" \
+              --image-manifest "$MANIFEST" \
+              --region "${REGION}" > /dev/null
+            echo "Tagged ${DIGEST} as v${VERSION}-${arch}"
+          done
+
+          # Tag attestation manifests (architecture=unknown) with their sha hex
+          for DIGEST in $(echo "$MANIFEST_INDEX" | jq -r '.manifests[] | select(.platform.architecture=="unknown") | .digest'); do
+            SHA_HEX=$(echo "$DIGEST" | sed 's/sha256://')
+            MANIFEST=$(aws ecr batch-get-image \
+              --repository-name "${REPO_NAME}" \
+              --image-ids imageDigest="${DIGEST}" \
+              --region "${REGION}" \
+              --query 'images[0].imageManifest' \
+              --output text)
+            aws ecr put-image \
+              --repository-name "${REPO_NAME}" \
+              --image-tag "${SHA_HEX}" \
+              --image-manifest "$MANIFEST" \
+              --region "${REGION}" > /dev/null
+            echo "Tagged ${DIGEST} as ${SHA_HEX} (attestation)"
+          done
 
       - name: Build and Publish release with Gradle
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0


### PR DESCRIPTION
…getools

*Issue #, if available:*

*Description of changes:*
1. Removes the two single-platform build/push steps
2. Keeps the single multi-arch docker/build-push-action push to both private and public ECR
3. Adds a new step that uses aws ecr batch-get-image + aws ecr put-image to tag the platform digests inside the manifest index with v$VERSION-amd64 / v$VERSION-arm64, and tags attestation manifests (architecture=unknown) with their sha hex

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
