### PR TITLE
Disable main build status check in release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -36,23 +36,23 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
-      - name: Check main build status
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name=="Java Agent Main Build") | .id')
-          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '[.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}")] | sort_by(.created_at) | .[-1] | {conclusion, status}')
-          STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
-          CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
+      # - name: Check main build status
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name=="Java Agent Main Build") | .id')
+      #     LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '[.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}")] | sort_by(.created_at) | .[-1] | {conclusion, status}')
+      #     STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
+      #     CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
           
-          if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
-            echo "Main build is still running (status: $STATUS). Cannot proceed with release."
-            exit 1
-          elif [ "$CONCLUSION" != "success" ]; then
-            echo "Latest main build on branch ${{ github.ref_name }} conclusion: $CONCLUSION"
-            exit 1
-          fi
-          echo "Main build succeeded, proceeding with release"
+      #     if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
+      #       echo "Main build is still running (status: $STATUS). Cannot proceed with release."
+      #       exit 1
+      #     elif [ "$CONCLUSION" != "success" ]; then
+      #       echo "Latest main build on branch ${{ github.ref_name }} conclusion: $CONCLUSION"
+      #       exit 1
+      #     fi
+      #     echo "Main build succeeded, proceeding with release"
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           java-version-file: .java-version


### PR DESCRIPTION
## Summary
- Comment out the "Check main build status" step in the release workflow
- This removes the gate that blocks releases when the main build is still running or has a non-success conclusion on the current branch

## Motivation
The main build check can unnecessarily block time-sensitive releases. The release build itself already runs full build + integration tests, providing sufficient validation.

## Test plan
- [ ] Trigger release workflow manually and verify it proceeds without checking main build status