### PR TITLE
fix(di): interrupt poller threads on stop and harden flaky concurrency test

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPoller.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPoller.java
@@ -92,8 +92,13 @@ public final class ConfigurationPoller {
     logger.fine("Initialized ConfigurationPoller");
   }
 
-  /** Start all polling threads. */
-  public void start() {
+  /**
+   * Start all polling threads.
+   *
+   * <p>Synchronized with {@link #stop()} so that a stop() racing a start() always observes fully
+   * initialized thread references and stop latch.
+   */
+  public synchronized void start() {
     // Atomic check-and-set so two concurrent start() calls cannot both create poller threads.
     if (!running.compareAndSet(false, true)) {
       logger.warning("Configuration poller already running");
@@ -123,8 +128,13 @@ public final class ConfigurationPoller {
     logger.fine("Configuration poller started");
   }
 
-  /** Stop all polling threads and wait for completion. */
-  public void stop() {
+  /**
+   * Stop all polling threads and wait for completion.
+   *
+   * <p>Synchronized with {@link #start()} so that a stop() racing a start() always observes fully
+   * initialized thread references and stop latch.
+   */
+  public synchronized void stop() {
     // Atomic check-and-set so a concurrent stop() runs the shutdown sequence only once.
     if (!running.compareAndSet(true, false)) {
       logger.warning("Configuration poller not running");
@@ -132,6 +142,15 @@ public final class ConfigurationPoller {
     }
 
     logger.fine("Stopping configuration poller...");
+
+    // Interrupt the poller threads so they wake from their poll-interval sleeps immediately
+    // instead of lingering until the next running-flag check (up to a full poll interval).
+    if (probeThread != null) {
+      probeThread.interrupt();
+    }
+    if (breakpointThread != null) {
+      breakpointThread.interrupt();
+    }
 
     try {
       if (!stopLatch.await(10, TimeUnit.SECONDS)) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPollerTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPollerTest.java
@@ -112,10 +112,16 @@ class ConfigurationPollerTest {
   void concurrentStartCreatesPollerThreadsOnlyOnce() throws Exception {
     ConfigurationPoller poller = new ConfigurationPoller(client);
 
+    // Wait out any poller threads leaked by other tests in this class. A leftover thread that
+    // dies between the baseline count below and the assertion would offset the +1 from this
+    // poller's new thread and make the delta read 0 (the CI flake this guards against).
+    awaitNoThreadsNamed("ProbePoller");
+    awaitNoThreadsNamed("BreakpointPoller");
+
     // Count the poller threads created by this poller's concurrent start storm via a before/after
-    // delta — robust to poller threads left over from other tests in this class. With an atomic
-    // check-and-set only one start() wins, so exactly two threads (ProbePoller + BreakpointPoller)
-    // are added; a non-atomic check-then-act could let multiple callers through and spawn extras.
+    // delta. With an atomic check-and-set only one start() wins, so exactly one thread of each
+    // name (ProbePoller + BreakpointPoller) is added; a non-atomic check-then-act could let
+    // multiple callers through and spawn extras.
     int beforeProbe = countThreadsNamed("ProbePoller");
     int beforeBreakpoint = countThreadsNamed("BreakpointPoller");
 
@@ -157,6 +163,17 @@ class ConfigurationPollerTest {
       }
     }
     return count;
+  }
+
+  /** Wait until no live thread with the exact given name remains, failing after a timeout. */
+  private static void awaitNoThreadsNamed(String name) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + 15_000;
+    while (countThreadsNamed(name) > 0) {
+      if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError("Timed out waiting for leftover " + name + " threads to exit");
+      }
+      Thread.sleep(50);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

The [main build](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/27241134973) failed intermittently after #1384 on:

```
ConfigurationPollerTest > concurrentStartCreatesPollerThreadsOnlyOnce() FAILED
    expected: 1
     but was: 0
```

### Root cause

`ConfigurationPoller.stop()` flipped the `running` flag but never interrupted the poller threads, leaving them asleep in their poll-interval backoff for up to ~15s after `stop()` returned. As a result:

- `stop()` always blocked the full 10s latch timeout (logging "Polling threads did not stop within timeout").
- Each test calling `stop()` leaked `ProbePoller`/`BreakpointPoller` threads that died asynchronously.
- In `concurrentStartCreatesPollerThreadsOnlyOnce`, a leaked thread from an earlier test dying between the baseline thread count and the assertion offset the delta to 0 — the exact CI failure. The test is timing-dependent, which is why a re-run passed.

### Changes

- `stop()` now interrupts both poller threads before awaiting the stop latch. The polling loops already catch `InterruptedException` and break cleanly, so threads exit immediately. This also makes shutdown deterministic in production instead of always eating the 10s timeout.
- `start()`/`stop()` are now `synchronized` so a `stop()` racing a `start()` always observes fully initialized thread references and stop latch (these are plain fields with no other happens-before edge).
- The concurrency test waits for leftover poller threads to exit before taking its baseline counts, closing the flake window entirely.

## Testing

- Full `:awsagentprovider` suite: 713 tests, 0 failures (same count as CI).
- `spotlessCheck` passes.
- `ConfigurationPollerTest` runtime drops from ~54s to <1s since `stop()` no longer blocks on the latch timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.