### PR TITLE
Bump Netty to 4.1.135.Final to fix CVE-2026-45416 and CVE-2026-44249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   application without a restart or redeploy. Opt-in and disabled by default via
   `OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED`. See `docs/dynamic-instrumentation.md`.
   ([#1384](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1384))
+- Bump Netty to 4.1.135.Final to fix CVE-2026-45416 and CVE-2026-44249
 
 ## v2.28.1 - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   `OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED`. See `docs/dynamic-instrumentation.md`.
   ([#1384](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1384))
 - Bump Netty to 4.1.135.Final to fix CVE-2026-45416 and CVE-2026-44249
+  ([#1389](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1389))
 
 ## v2.28.1 - 2026-05-26
 

--- a/appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts
+++ b/appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 dependencies {
-  implementation("io.netty:netty-all:4.1.94.Final")
+  implementation("io.netty:netty-all:4.1.135.Final")
   implementation("com.sparkjava:spark-core")
   implementation("org.slf4j:slf4j-simple")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/appsignals-tests/images/http-servers/netty-server/build.gradle.kts
+++ b/appsignals-tests/images/http-servers/netty-server/build.gradle.kts
@@ -27,7 +27,7 @@ java {
 }
 
 dependencies {
-  implementation("io.netty:netty-all:4.1.94.Final")
+  implementation("io.netty:netty-all:4.1.135.Final")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.slf4j:slf4j-simple:1.7.30")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -40,8 +40,7 @@ val dependencyBoms = listOf(
   "com.google.protobuf:protobuf-bom:3.25.1",
   "com.linecorp.armeria:armeria-bom:1.26.4",
   "io.grpc:grpc-bom:1.59.1",
-  // netty-bom pins to fix CVE-2026-41417
-  "io.netty:netty-bom:4.1.133.Final",
+  "io.netty:netty-bom:4.1.135.Final",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",
   "org.junit:junit-bom:5.10.1",


### PR DESCRIPTION
## Summary
- Bumps `io.netty:netty-bom` to `4.1.135.Final` in `dependencyManagement/build.gradle.kts` to fix CVE-2026-45416 and CVE-2026-44249.
- Updates the two test image hardcoded versions (`netty-server`, `netty-http-client`) from `4.1.94.Final` to `4.1.135.Final` so the test fleet stays aligned with the BOM.
- Adds a CHANGELOG entry under Unreleased.