### PR TITLE
refactor(debugger): remove unused instrumentation_name field from DI

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistry.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistry.java
@@ -285,7 +285,6 @@ public final class InstrumentationRegistry {
               CaptureConfiguration.class,
               String.class,
               InstrumentationType.class,
-              String.class,
               java.time.Instant.class,
               int.class,
               List.class,
@@ -304,7 +303,6 @@ public final class InstrumentationRegistry {
               captureConfig,
               locationHash, // Use actual locationHash parameter
               InstrumentationType.valueOf(instrumentationType),
-              "", // instrumentationName
               null, // expiresAt
               maxHits,
               new ArrayList<>(), // attributeFilters

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfiguration.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfiguration.java
@@ -53,7 +53,6 @@ public final class InstrumentationConfiguration {
   private final CaptureConfiguration captureConfig;
   private final String locationHash;
   private final InstrumentationType instrumentationType;
-  private final String instrumentationName;
   private final Instant expiresAt;
   private final int maxHits;
   private final List<Map<String, String>> attributeFilters;
@@ -70,7 +69,6 @@ public final class InstrumentationConfiguration {
       CaptureConfiguration captureConfig,
       String locationHash,
       InstrumentationType instrumentationType,
-      String instrumentationName,
       Instant expiresAt,
       int maxHits,
       List<Map<String, String>> attributeFilters,
@@ -85,7 +83,6 @@ public final class InstrumentationConfiguration {
     this.captureConfig = captureConfig;
     this.locationHash = locationHash;
     this.instrumentationType = instrumentationType;
-    this.instrumentationName = instrumentationName;
     this.expiresAt = expiresAt;
     this.maxHits = maxHits;
     this.attributeFilters = Collections.unmodifiableList(new ArrayList<>(attributeFilters));
@@ -181,12 +178,6 @@ public final class InstrumentationConfiguration {
         }
       }
 
-      // Parse instrumentation name (optional for PROBE)
-      String instrName = (String) apiConfig.get("InstrumentationName");
-      if (instrName == null) {
-        instrName = ""; // Default to empty string
-      }
-
       // Parse line number (optional - 0 if missing means method-level)
       int lineNum = safeInt(location.get("LineNumber"), 0);
       if (type == InstrumentationType.PROBE && lineNum > 0) {
@@ -280,7 +271,6 @@ public final class InstrumentationConfiguration {
           captureConfig,
           locationHash,
           type,
-          instrName,
           expiresAt,
           maxHits,
           filters,
@@ -483,10 +473,6 @@ public final class InstrumentationConfiguration {
 
   public InstrumentationType getInstrumentationType() {
     return instrumentationType;
-  }
-
-  public String getInstrumentationName() {
-    return instrumentationName;
   }
 
   public Instant getExpiresAt() {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/DynamicInstrumentationManagerTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/DynamicInstrumentationManagerTest.java
@@ -164,7 +164,6 @@ class DynamicInstrumentationManagerTest {
     apiConfig.put("Location", locationWrapper);
     apiConfig.put("LocationHash", "test-hash");
     apiConfig.put("InstrumentationType", "PROBE");
-    apiConfig.put("InstrumentationName", "test-probe");
     java.util.Map<String, Object> captureWrapper = new java.util.HashMap<>();
     captureWrapper.put("CodeCapture", java.util.Map.of());
     apiConfig.put("CaptureConfiguration", captureWrapper);
@@ -293,7 +292,6 @@ class DynamicInstrumentationManagerTest {
     apiConfig.put("Location", locationWrapperInit);
     apiConfig.put("LocationHash", "hash-init");
     apiConfig.put("InstrumentationType", "BREAKPOINT");
-    apiConfig.put("InstrumentationName", "test-init");
     java.util.Map<String, Object> captureWrapperInit = new java.util.HashMap<>();
     captureWrapperInit.put("CodeCapture", java.util.Map.of());
     apiConfig.put("CaptureConfiguration", captureWrapperInit);
@@ -342,7 +340,6 @@ class DynamicInstrumentationManagerTest {
     apiConfig.put("Location", locationWrapperClinit);
     apiConfig.put("LocationHash", "hash-clinit");
     apiConfig.put("InstrumentationType", "BREAKPOINT");
-    apiConfig.put("InstrumentationName", "test-clinit");
     java.util.Map<String, Object> captureWrapperClinit = new java.util.HashMap<>();
     captureWrapperClinit.put("CodeCapture", java.util.Map.of());
     apiConfig.put("CaptureConfiguration", captureWrapperClinit);
@@ -391,7 +388,6 @@ class DynamicInstrumentationManagerTest {
     initConfig.put("Location", initLocationWrapper);
     initConfig.put("LocationHash", "hash-init");
     initConfig.put("InstrumentationType", "BREAKPOINT");
-    initConfig.put("InstrumentationName", "test-init");
     java.util.Map<String, Object> initCaptureWrapper = new java.util.HashMap<>();
     initCaptureWrapper.put("CodeCapture", java.util.Map.of());
     initConfig.put("CaptureConfiguration", initCaptureWrapper);
@@ -408,7 +404,6 @@ class DynamicInstrumentationManagerTest {
     normalConfig.put("Location", normalLocationWrapper);
     normalConfig.put("LocationHash", "hash-normal");
     normalConfig.put("InstrumentationType", "BREAKPOINT");
-    normalConfig.put("InstrumentationName", "test-normal");
     java.util.Map<String, Object> normalCaptureWrapper = new java.util.HashMap<>();
     normalCaptureWrapper.put("CodeCapture", java.util.Map.of());
     normalConfig.put("CaptureConfiguration", normalCaptureWrapper);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPollerDeduplicationTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPollerDeduplicationTest.java
@@ -379,7 +379,6 @@ class ConfigurationPollerDeduplicationTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     if (createdAt != null) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPollerDeduplicationTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/ConfigurationPollerDeduplicationTest.java
@@ -377,10 +377,6 @@ class ConfigurationPollerDeduplicationTest {
     apiConfig.put("LocationHash", locationHash);
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     if (createdAt != null) {
       apiConfig.put("CreatedAt", createdAt.toString());
     }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/FunctionInstrumentationSetTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/FunctionInstrumentationSetTest.java
@@ -346,7 +346,6 @@ class FunctionInstrumentationSetTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
@@ -374,7 +373,6 @@ class FunctionInstrumentationSetTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
@@ -418,7 +416,6 @@ class FunctionInstrumentationSetTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     return InstrumentationConfiguration.fromApiConfig(apiConfig);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/FunctionInstrumentationSetTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/FunctionInstrumentationSetTest.java
@@ -344,10 +344,6 @@ class FunctionInstrumentationSetTest {
     apiConfig.put("LocationHash", "test-hash");
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
   }
 
@@ -371,10 +367,6 @@ class FunctionInstrumentationSetTest {
     apiConfig.put("LocationHash", "test-hash");
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
   }
 
@@ -414,10 +406,6 @@ class FunctionInstrumentationSetTest {
     apiConfig.put("LocationHash", "test-hash");
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationGrouperTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationGrouperTest.java
@@ -211,7 +211,6 @@ class InstrumentationGrouperTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     return InstrumentationConfiguration.fromApiConfig(apiConfig);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationGrouperTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationGrouperTest.java
@@ -209,10 +209,6 @@ class InstrumentationGrouperTest {
     apiConfig.put("LocationHash", "test-hash");
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
   }
 }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistryTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistryTest.java
@@ -391,10 +391,6 @@ class InstrumentationRegistryTest {
     apiConfig.put("LocationHash", "test-hash");
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
   }
 
@@ -425,10 +421,6 @@ class InstrumentationRegistryTest {
     apiConfig.put("LocationHash", locationHash);
     apiConfig.put("InstrumentationType", type);
     apiConfig.put("CaptureConfiguration", captureWrapper);
-
-    if ("PROBE".equals(type)) {
-    }
-
     if (createdAt != null) {
       apiConfig.put("CreatedAt", createdAt.toString());
     }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistryTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistryTest.java
@@ -393,7 +393,6 @@ class InstrumentationRegistryTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     return InstrumentationConfiguration.fromApiConfig(apiConfig);
@@ -428,7 +427,6 @@ class InstrumentationRegistryTest {
     apiConfig.put("CaptureConfiguration", captureWrapper);
 
     if ("PROBE".equals(type)) {
-      apiConfig.put("InstrumentationName", "test-probe");
     }
 
     if (createdAt != null) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfigurationTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfigurationTest.java
@@ -62,13 +62,11 @@ class InstrumentationConfigurationTest {
   void testFromApiConfig_validProbe() {
     Map<String, Object> apiConfig =
         createValidApiConfig("PROBE", "com.example", "OrderService", "processOrder", 0);
-    apiConfig.put("InstrumentationName", "order-processing-probe");
 
     InstrumentationConfiguration config = InstrumentationConfiguration.fromApiConfig(apiConfig);
 
     assertThat(config).isNotNull();
     assertThat(config.getInstrumentationType()).isEqualTo(InstrumentationType.PROBE);
-    assertThat(config.getInstrumentationName()).isEqualTo("order-processing-probe");
     assertThat(config.isPermanent()).isTrue();
     assertThat(config.isTemporary()).isFalse();
   }
@@ -77,27 +75,12 @@ class InstrumentationConfigurationTest {
   void testFromApiConfig_probeWithLineNumberForcedToZero() {
     Map<String, Object> apiConfig =
         createValidApiConfig("PROBE", "com.example", "OrderService", "processOrder", 42);
-    apiConfig.put("InstrumentationName", "test-probe");
 
     InstrumentationConfiguration config = InstrumentationConfiguration.fromApiConfig(apiConfig);
 
     assertThat(config).isNotNull();
     assertThat(config.getLineNumber()).isEqualTo(0);
     assertThat(config.isMethodLevel()).isTrue();
-  }
-
-  @Test
-  void testFromApiConfig_probeMissingInstrumentationName() {
-    Map<String, Object> apiConfig =
-        createValidApiConfig("PROBE", "com.example", "OrderService", "processOrder", 0);
-    // No InstrumentationName set
-
-    InstrumentationConfiguration config = InstrumentationConfiguration.fromApiConfig(apiConfig);
-
-    // InstrumentationName is now optional - should return valid config with empty name
-    assertThat(config).isNotNull();
-    assertThat(config.getInstrumentationType()).isEqualTo(InstrumentationType.PROBE);
-    assertThat(config.getInstrumentationName()).isEmpty();
   }
 
   @Test
@@ -214,7 +197,6 @@ class InstrumentationConfigurationTest {
   void testFromApiConfig_probeIgnoresExpiresAt() {
     Map<String, Object> apiConfig =
         createValidApiConfig("PROBE", "com.example", "OrderService", "processOrder", 0);
-    apiConfig.put("InstrumentationName", "test-probe");
     apiConfig.put("ExpiresAt", "2026-01-23T10:36:51Z");
 
     InstrumentationConfiguration config = InstrumentationConfiguration.fromApiConfig(apiConfig);
@@ -344,7 +326,6 @@ class InstrumentationConfigurationTest {
   void testFromApiConfig_probeIgnoresMaxHits() {
     Map<String, Object> apiConfig =
         createValidApiConfig("PROBE", "com.example", "OrderService", "processOrder", 0);
-    apiConfig.put("InstrumentationName", "test-probe");
 
     Map<String, Object> captureConfig = new HashMap<>();
     Map<String, Object> captureLimits = new HashMap<>();

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/output/DISnapshotOtlpEmitterTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/output/DISnapshotOtlpEmitterTest.java
@@ -306,7 +306,6 @@ class DISnapshotOtlpEmitterTest {
 
     apiConfig.put("LocationHash", "hash123");
     apiConfig.put("InstrumentationType", instrumentationType);
-    apiConfig.put("InstrumentationName", "test-config");
 
     Map<String, Object> captureWrapper = new HashMap<>();
     captureWrapper.put("CodeCapture", Map.of());


### PR DESCRIPTION
## Summary

- Drop `instrumentation_name` from `BreakpointConfiguration` and its parsing in `from_api_config` — the field was parsed from the API response but never read by any consumer.
- Remove the `InstrumentationName` test fixture entry and the now-empty `test_probe_missing_instrumentation_name_defaults_to_empty` test; update the surrounding docstring/class docstring to drop the name reference.