### PR TITLE
serviceevents: remove adaptive sampling, default to always, cap call_path

### DIFF
--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/ServiceEventsInstrumentation.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/ServiceEventsInstrumentation.java
@@ -175,22 +175,21 @@ public class ServiceEventsInstrumentation {
       // is no function call data to collect)
       FunctionCallCollector functionCallCollector = null;
       if (config.isBytecodeEnabled()) {
-        // Apply adaptive-sampling startup defaults from env BEFORE the collector
-        // begins ticking — ensures the very first flush already reflects the
-        // configured tier thresholds and hot-endpoint cycle length.
+        // Apply sampling startup defaults from env BEFORE the collector begins
+        // ticking — ensures the very first flush already reflects the configured
+        // mode and (for "auto") the tier thresholds.
         software.amazon.opentelemetry.serviceevents.ServiceEventsDataStore.setSamplingMode(
             config.getSamplingMode());
         software.amazon.opentelemetry.serviceevents.ServiceEventsDataStore.setSamplingThresholds(
             config.getSampleTier1Threshold(),
             config.getSampleTier2Threshold(),
             config.getSampleTier2Rate(),
-            config.getSampleTier3Rate(),
-            config.getHotEndpointCycles());
+            config.getSampleTier3Rate());
         // Read back the effective mode after setSamplingMode's internal
-        // validation. If the operator-supplied value was rejected (e.g.
-        // OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE=fast), the effective mode falls
-        // back to the prior default ("adaptive"); surfacing the mismatch
-        // here helps operators debug misconfiguration.
+        // validation. If the operator-supplied value was rejected (e.g. the
+        // removed "adaptive", or OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE=fast),
+        // the effective mode falls back to the default ("always"); surfacing the
+        // mismatch here helps operators debug misconfiguration.
         String requestedMode = config.getSamplingMode();
         String effectiveMode =
             software.amazon.opentelemetry.serviceevents.ServiceEventsDataStore.getSamplingMode();
@@ -200,7 +199,7 @@ public class ServiceEventsInstrumentation {
                 : effectiveMode + " (config requested '" + requestedMode + "', invalid)";
         logger()
             .info(
-                "Adaptive sampling: mode="
+                "ServiceEvents sampling: mode="
                     + modeReport
                     + ", tier1="
                     + config.getSampleTier1Threshold()
@@ -209,9 +208,7 @@ public class ServiceEventsInstrumentation {
                     + ", tier2Rate="
                     + config.getSampleTier2Rate()
                     + ", tier3Rate="
-                    + config.getSampleTier3Rate()
-                    + ", hotCycles="
-                    + config.getHotEndpointCycles());
+                    + config.getSampleTier3Rate());
 
         // Wire the OTel histogram bridge for direct in-line metric recording at
         // __exit__. Gated on `otlpEmitter != null && !output_file` (network OTLP

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/FunctionCallCollector.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/FunctionCallCollector.java
@@ -97,13 +97,6 @@ public class FunctionCallCollector extends BaseCollector {
     Map<String, Map<String, AggregationData>> aggregations =
         ServiceEventsDataStore.getAndSwapAggregations();
 
-    // Adaptive-sampling lifecycle: decrement every hot-operation countdown by
-    // one. Operations recently incident-marked stay 100%-sampled for
-    // hotEndpointCycles flushes; this is the only place countdowns advance.
-    // Run unconditionally — cheap (CHM iteration over typically empty map),
-    // and a no-op when sampling mode != "adaptive" or no incidents have fired.
-    ServiceEventsDataStore.tickHotOperations();
-
     if (aggregations == null || aggregations.isEmpty()) {
       // Either no function call captured, or methodExit is recording into the
       // OTel histogram bridge directly (in which case the

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/LiteIncidentDrainer.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/LiteIncidentDrainer.java
@@ -214,7 +214,8 @@ public final class LiteIncidentDrainer extends BaseCollector implements Metadata
           exceptionMessage,
           stackTrace,
           traceId,
-          spanId);
+          spanId,
+          /* isPartial= */ false); // lite mode carries no call_path, so timing is never partial
     }
   }
 }

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfig.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfig.java
@@ -79,15 +79,14 @@ public class ServiceEventsConfig {
   private final int incidentSnapshotMaxPerMinute;
   private final int incidentSnapshotMaxSameError;
 
-  // Adaptive sampling for aws.service_events.function_call records (gates MethodAdvice hot path).
-  // Default mode is "adaptive": tiered sampling + 100% sampling on hot endpoints
-  // (those that recently incident-fired). Mirrors Python/JS sampling shape.
+  // Sampling for aws.service_events.function_call records (gates MethodAdvice hot path).
+  // Default mode is "always" (every call sampled); "auto" applies tiered sampling as a
+  // high-volume cost cap; "never" disables the duration metric. Mirrors Python/JS sampling shape.
   private final String samplingMode;
   private final int sampleTier1Threshold;
   private final int sampleTier2Threshold;
   private final int sampleTier2Rate;
   private final int sampleTier3Rate;
-  private final int hotEndpointCycles;
 
   // OTLP Export
   private final String logsEndpoint;
@@ -129,7 +128,6 @@ public class ServiceEventsConfig {
     this.sampleTier2Threshold = builder.sampleTier2Threshold;
     this.sampleTier2Rate = builder.sampleTier2Rate;
     this.sampleTier3Rate = builder.sampleTier3Rate;
-    this.hotEndpointCycles = builder.hotEndpointCycles;
     this.logsEndpoint = builder.logsEndpoint;
     this.metricsEndpoint = builder.metricsEndpoint;
     this.logGroup = builder.logGroup;
@@ -219,8 +217,8 @@ public class ServiceEventsConfig {
             .deploymentUrl(getStringEnv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_URL", ""))
             .gitCommitSha(getStringEnv("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA", ""))
             .gitRepoUrl(getStringEnv("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", ""))
-            // serviceCodeNamespace, deploymentEventFlushInterval, and hotEndpointCycles are
-            // internal with no override — Builder defaults stand.
+            // serviceCodeNamespace and deploymentEventFlushInterval are internal with no
+            // override — Builder defaults stand.
             .functionCallFlushInterval(hookInt(hook, "FUNCTION_CALL_FLUSH_INTERVAL", 30000))
             .endpointFlushInterval(hookInt(hook, "ENDPOINT_FLUSH_INTERVAL", 30000))
             .bytecodeEnabled(
@@ -246,7 +244,7 @@ public class ServiceEventsConfig {
                 getIntEnv("OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_PER_MINUTE", 100))
             .incidentSnapshotMaxSameError(
                 getIntEnv("OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_SAME_ERROR", 1))
-            .samplingMode(getStringEnv("OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE", "adaptive"))
+            .samplingMode(getStringEnv("OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE", "always"))
             .sampleTier1Threshold(hookInt(hook, "SAMPLE_TIER1_THRESHOLD", 100))
             .sampleTier2Threshold(hookInt(hook, "SAMPLE_TIER2_THRESHOLD", 1000))
             .sampleTier2Rate(hookInt(hook, "SAMPLE_TIER2_RATE", 10))
@@ -623,8 +621,8 @@ public class ServiceEventsConfig {
   }
 
   /**
-   * Adaptive-sampling mode for {@code aws.service_events.function_call} records: {@code "auto"},
-   * {@code "adaptive"} (default), {@code "always"}, or {@code "never"}. Only gates MethodAdvice;
+   * Sampling mode for {@code aws.service_events.function_call} records: {@code "always"} (default),
+   * {@code "auto"} (tiered cost cap), or {@code "never"}. Only gates MethodAdvice;
    * endpoint/incident signals are unaffected.
    */
   public String getSamplingMode() {
@@ -645,10 +643,6 @@ public class ServiceEventsConfig {
 
   public int getSampleTier3Rate() {
     return sampleTier3Rate;
-  }
-
-  public int getHotEndpointCycles() {
-    return hotEndpointCycles;
   }
 
   public String getLogsEndpoint() {
@@ -702,12 +696,11 @@ public class ServiceEventsConfig {
     private List<String> endpointExcludePatterns = new ArrayList<>();
     private int incidentSnapshotMaxPerMinute = 100;
     private int incidentSnapshotMaxSameError = 1;
-    private String samplingMode = "adaptive";
+    private String samplingMode = "always";
     private int sampleTier1Threshold = 100;
     private int sampleTier2Threshold = 1000;
     private int sampleTier2Rate = 10;
     private int sampleTier3Rate = 100;
-    private int hotEndpointCycles = 100;
     private String logsEndpoint = "http://localhost:4316/v1/logs";
     private String metricsEndpoint = "http://localhost:4316/v1/metrics";
     private String logGroup = "/serviceevents/telemetry";
@@ -844,11 +837,6 @@ public class ServiceEventsConfig {
     public Builder sampleTier3Rate(int sampleTier3Rate) {
       // Clamp to >= 1 — see sampleTier2Rate.
       this.sampleTier3Rate = Math.max(1, sampleTier3Rate);
-      return this;
-    }
-
-    public Builder hotEndpointCycles(int hotEndpointCycles) {
-      this.hotEndpointCycles = hotEndpointCycles;
       return this;
     }
 

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/IncidentSnapshotEmitter.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/IncidentSnapshotEmitter.java
@@ -69,7 +69,20 @@ public class IncidentSnapshotEmitter implements IncidentSnapshotEmitterBridge {
       String spanId,
       List<CallPathEntry> callPath) {
     try {
-      List<Map<String, Object>> serializedCallPath = serializeCallPath(callPath);
+      // is_partial: at least one frame lacks timing (unsampled frame or truncation sentinel,
+      // both durationNs == 0). Matches the Python/JS `any(duration_ns == 0)` rule; an empty
+      // call path is not partial. Used both to drive the strip below and the OTLP attribute.
+      boolean isPartial = false;
+      if (callPath != null) {
+        for (CallPathEntry entry : callPath) {
+          if (entry.durationNs == 0) {
+            isPartial = true;
+            break;
+          }
+        }
+      }
+
+      List<Map<String, Object>> serializedCallPath = serializeCallPath(callPath, isPartial);
 
       IncidentSnapshotRecordBuilder.Inputs inputs =
           new IncidentSnapshotRecordBuilder.Inputs(
@@ -90,24 +103,6 @@ public class IncidentSnapshotEmitter implements IncidentSnapshotEmitterBridge {
       long timestamp = System.currentTimeMillis();
       Map<String, Object> record = recordBuilder.build(inputs, serializedCallPath, timestamp);
 
-      // Adaptive sampling boost: mark this operation "hot" so subsequent
-      // function-call records inside it are 100%-sampled for the next
-      // hotEndpointCycles flush rounds. No-op when sampling mode != "adaptive".
-      //
-      // Placed AFTER recordBuilder.build() succeeds but BEFORE the emit:
-      //   - build/serializeCallPath failure → caught below, no hot-mark
-      //     (avoids "phantom incident" boost when no record was actually
-      //     produced).
-      //   - null otlpEmitter (file-export mode, test harness) → still
-      //     fires (the incident was successfully recorded locally).
-      //   - emit throws (network blip, serialization error in transport)
-      //     → still fires (rate-limit/dedup slot was consumed upstream;
-      //     in-process feedback loop should activate).
-      // Fired post-rate-limit/post-dedup so suppressed incidents don't mark
-      // hot — matches Python/JS placement.
-      software.amazon.opentelemetry.serviceevents.ServiceEventsDataStore.markOperationHot(
-          operation);
-
       if (otlpEmitter != null) {
         IncidentMetadata meta =
             new IncidentMetadata(
@@ -126,7 +121,8 @@ public class IncidentSnapshotEmitter implements IncidentSnapshotEmitterBridge {
                 exceptionMessage,
                 stackTrace,
                 traceId,
-                spanId);
+                spanId,
+                isPartial);
         otlpEmitter.emitIncidentSnapshot(record, meta);
       }
     } catch (Throwable t) {
@@ -134,7 +130,8 @@ public class IncidentSnapshotEmitter implements IncidentSnapshotEmitterBridge {
     }
   }
 
-  private static List<Map<String, Object>> serializeCallPath(List<CallPathEntry> callPath) {
+  private static List<Map<String, Object>> serializeCallPath(
+      List<CallPathEntry> callPath, boolean isPartial) {
     if (callPath == null || callPath.isEmpty()) {
       return new ArrayList<>();
     }
@@ -145,7 +142,12 @@ public class IncidentSnapshotEmitter implements IncidentSnapshotEmitterBridge {
       // ArrayDeque#push, which rejects null children.
       m.put("function_name", entry.functionId != null ? entry.functionId : "");
       m.put("caller_function_name", entry.caller != null ? entry.caller : "");
-      m.put("duration_ns", entry.durationNs);
+      // On a partial snapshot, omit the misleading zero durations (unsampled frames + the
+      // truncation sentinel) so only the genuine per-frame timings that WERE captured survive;
+      // a fully-timed snapshot keeps every duration. Mirrors the Python/JS to_dict strip.
+      if (!isPartial || entry.durationNs != 0) {
+        m.put("duration_ns", entry.durationNs);
+      }
       m.put("error", entry.error);
       m.put("is_async", entry.isAsync);
       out.add(m);

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/ServiceEventsOtlpEmitter.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/ServiceEventsOtlpEmitter.java
@@ -312,7 +312,7 @@ public class ServiceEventsOtlpEmitter {
     attrs.put("aws.service_events.trigger_type", incident.triggerType);
     attrs.put("aws.service_events.operation", incident.operation);
     attrs.put("aws.service_events.duration_ms", incident.durationMs);
-    attrs.put("aws.service_events.is_partial", true);
+    attrs.put("aws.service_events.is_partial", incident.isPartial);
     attrs.put("http.request.method", incident.method);
     attrs.put("url.route", incident.route);
     attrs.put("http.response.status_code", (long) incident.statusCode);

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/models/IncidentMetadata.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/models/IncidentMetadata.java
@@ -34,6 +34,14 @@ public class IncidentMetadata {
   public final String traceId;
   public final String spanId;
 
+  /**
+   * True when at least one captured call_path frame lacks timing (durationNs == 0) — i.e. an
+   * unsampled frame or the truncation sentinel. Computed from the call path (matches the Python/JS
+   * distros' {@code any(duration_ns == 0)} rule) rather than hardcoded, so a fully-timed snapshot
+   * (the {@code always}-mode default) correctly reports {@code false}.
+   */
+  public final boolean isPartial;
+
   public IncidentMetadata(
       String threadName,
       long startNs,
@@ -50,7 +58,8 @@ public class IncidentMetadata {
       String exceptionMessage,
       String stackTrace,
       String traceId,
-      String spanId) {
+      String spanId,
+      boolean isPartial) {
     this.threadName = threadName;
     this.startNs = startNs;
     this.endNs = endNs;
@@ -67,5 +76,6 @@ public class IncidentMetadata {
     this.stackTrace = stackTrace;
     this.traceId = traceId;
     this.spanId = spanId;
+    this.isPartial = isPartial;
   }
 }

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfigTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfigTest.java
@@ -39,7 +39,6 @@ class ServiceEventsConfigTest {
     "otel.aws.service_events.sample.tier2.threshold",
     "otel.aws.service_events.sample.tier2.rate",
     "otel.aws.service_events.sample.tier3.rate",
-    "otel.aws.service_events.hot.endpoint.cycles",
     "otel.aws.service_events.function.call.flush.interval",
     "otel.aws.service_events.endpoint.flush.interval",
     "otel.aws.service_events.deployment.event.flush.interval",
@@ -417,12 +416,12 @@ class ServiceEventsConfigTest {
     assertEquals(100, cfg.getIncidentSnapshotMaxPerMinute());
   }
 
-  // ───── Adaptive sampling for function-call records ─────
+  // ───── Sampling mode for function-call records ─────
 
   @Test
-  void samplingMode_defaultIsAdaptive() {
+  void samplingMode_defaultIsAlways() {
     ServiceEventsConfig cfg = ServiceEventsConfig.fromEnv();
-    assertEquals("adaptive", cfg.getSamplingMode());
+    assertEquals("always", cfg.getSamplingMode());
   }
 
   @Test
@@ -438,24 +437,21 @@ class ServiceEventsConfigTest {
     assertEquals(1000, cfg.getSampleTier2Threshold());
     assertEquals(10, cfg.getSampleTier2Rate());
     assertEquals(100, cfg.getSampleTier3Rate());
-    assertEquals(100, cfg.getHotEndpointCycles());
   }
 
   @Test
   void samplingThresholds_envIsIgnored() {
-    // Sampling tiers + hot-endpoint cycles are internal now — the former sysprops/env vars have
-    // no effect. (Tier thresholds/rates are reachable via the test-config hook; see below.)
+    // Sampling tiers are internal now — the former sysprops/env vars have no effect.
+    // (Tier thresholds/rates are reachable via the test-config hook; see below.)
     System.setProperty("otel.aws.service_events.sample.tier1.threshold", "50");
     System.setProperty("otel.aws.service_events.sample.tier2.threshold", "500");
     System.setProperty("otel.aws.service_events.sample.tier2.rate", "5");
     System.setProperty("otel.aws.service_events.sample.tier3.rate", "50");
-    System.setProperty("otel.aws.service_events.hot.endpoint.cycles", "20");
     ServiceEventsConfig cfg = ServiceEventsConfig.fromEnv();
     assertEquals(100, cfg.getSampleTier1Threshold());
     assertEquals(1000, cfg.getSampleTier2Threshold());
     assertEquals(10, cfg.getSampleTier2Rate());
     assertEquals(100, cfg.getSampleTier3Rate());
-    assertEquals(100, cfg.getHotEndpointCycles());
   }
 
   // ───── Flush intervals + log group/stream are internal (no env override) ─────

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/IncidentSnapshotEmitterTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/IncidentSnapshotEmitterTest.java
@@ -91,11 +91,74 @@ class IncidentSnapshotEmitterTest {
     assertEquals(false, first.get("error"));
     assertEquals(false, first.get("is_async"));
     assertEquals(true, emittedPath.get(1).get("error"));
+    // Fully-timed call path (no zero durations) => not partial, every duration_ns survives.
+    assertEquals(500L, emittedPath.get(1).get("duration_ns"));
 
     IncidentMetadata meta = capturedMeta.get();
     assertNotNull(meta);
     assertEquals("snap_abc", meta.snapshotId);
     assertEquals("GET /api/x", meta.operation);
+    assertFalse(meta.isPartial, "fully-timed snapshot must report is_partial=false");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void emitIncident_partialCallPathStripsZeroDurations() {
+    // A snapshot mixing a sampled frame (real duration) with an unsampled frame / truncation
+    // sentinel (durationNs == 0) is partial: is_partial must be true, the zero duration_ns must
+    // be omitted (it reads as misleading "instantaneous"), and the real timing must survive.
+    // Mirrors the Python/JS to_dict strip — this is the cross-SDK wire-parity guarantee.
+    AtomicReference<Map<String, Object>> captured = new AtomicReference<>();
+    AtomicReference<IncidentMetadata> capturedMeta = new AtomicReference<>();
+    ServiceEventsOtlpEmitter otlp =
+        new ServiceEventsOtlpEmitter(null, null, null, "deploy-1", "abc123", "", "") {
+          @Override
+          public void emitIncidentSnapshot(Map<String, Object> record, IncidentMetadata incident) {
+            captured.set(record);
+            capturedMeta.set(incident);
+          }
+        };
+    IncidentSnapshotEmitter emitter = new IncidentSnapshotEmitter(newBuilder(), otlp);
+
+    List<CallPathEntry> callPath =
+        Arrays.asList(
+            new CallPathEntry("com.example.Svc.handle", null, 1000L, false, false),
+            // Unsampled frame: durationNs == 0.
+            new CallPathEntry("com.example.Svc.mid", "com.example.Svc.handle", 0L, false, false),
+            new CallPathEntry("com.example.Svc.fail", "com.example.Svc.mid", 700L, true, false));
+
+    emitter.emitIncident(
+        "snap_partial",
+        "exception",
+        "critical",
+        "thread-1",
+        1_000_000L,
+        2_000_000L,
+        "/api/x",
+        "GET",
+        "GET /api/x",
+        500,
+        1.23,
+        "RuntimeException",
+        "boom",
+        "stack",
+        "0123456789abcdef0123456789abcdef",
+        "0123456789abcdef",
+        callPath);
+
+    IncidentMetadata meta = capturedMeta.get();
+    assertNotNull(meta);
+    assertTrue(
+        meta.isPartial, "a call path with a zero-duration frame must report is_partial=true");
+
+    List<Map<String, Object>> exInfo =
+        (List<Map<String, Object>>) captured.get().get("exception_info");
+    List<Map<String, Object>> path = (List<Map<String, Object>>) exInfo.get(0).get("call_path");
+    assertEquals(3, path.size());
+    // Real timings survive; the zero-duration frame omits duration_ns entirely.
+    assertEquals(1000L, path.get(0).get("duration_ns"));
+    assertFalse(path.get(1).containsKey("duration_ns"), "zero duration_ns must be stripped");
+    assertEquals(700L, path.get(2).get("duration_ns"));
   }
 
   @Test

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/ServiceEventsOtlpEmitterTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/exporter/ServiceEventsOtlpEmitterTest.java
@@ -228,7 +228,8 @@ class ServiceEventsOtlpEmitterTest {
             "null reference", // exceptionMessage
             "at com.example.Foo.bar(Foo.java:42)", // stackTrace
             "0af7651916cd43dd8448eb211c80319c", // traceId
-            "b7ad6b7169203331"); // spanId
+            "b7ad6b7169203331", // spanId
+            true); // isPartial
 
     emitter.emitIncidentSnapshot(record, incident);
 
@@ -247,6 +248,8 @@ class ServiceEventsOtlpEmitterTest {
     assertEquals("exception", attrs.get(AttributeKey.stringKey("aws.service_events.trigger_type")));
     assertEquals(
         "GET /api/data", attrs.get(AttributeKey.stringKey("aws.service_events.operation")));
+    // is_partial now reflects the IncidentMetadata flag (passed true above) rather than a
+    // hardcoded constant — a fully-timed snapshot would report false.
     assertEquals(true, attrs.get(AttributeKey.booleanKey("aws.service_events.is_partial")));
     assertEquals("GET", attrs.get(AttributeKey.stringKey("http.request.method")));
     assertEquals("/api/data", attrs.get(AttributeKey.stringKey("url.route")));
@@ -285,7 +288,8 @@ class ServiceEventsOtlpEmitterTest {
             null,
             null,
             null,
-            null);
+            null,
+            false); // isPartial
 
     emitter.emitIncidentSnapshot(record, incident);
 

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/InvestigationData.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/InvestigationData.java
@@ -20,6 +20,23 @@ import java.util.List;
 
 /** Investigation data for incident call path tracking. */
 public class InvestigationData {
+  /**
+   * Hard cap on real call-path frames retained per request. The hoisted methodExit records a frame
+   * for every instrumented call (not just sampled ones), so under {@code auto}/{@code never}
+   * sampling a high-call-volume request would otherwise grow this list without bound and could push
+   * a serialized IncidentSnapshot past the 1 MB CloudWatch OTLP Logs limit. At ~150-250 B/frame,
+   * 1024 frames is ~256 KB — well under the limit with room for the stack trace and other fields,
+   * yet far above any legitimate request's frame count. Python/JS apply the same cap.
+   */
+  static final int MAX_CALL_PATH_ENTRIES = 1024;
+
+  /**
+   * Marker appended once when the cap is exceeded. {@code durationNs == 0} trips {@code is_partial}
+   * (computed from the call path as {@code any(durationNs == 0)} in the IncidentSnapshot emitter,
+   * matching Python/JS), and the zero duration is stripped from the serialized frame.
+   */
+  static final String CALL_PATH_TRUNCATION_SENTINEL = "<call_path_truncated>";
+
   private final List<CallPathEntry> callPath = new ArrayList<CallPathEntry>();
   private ExceptionData exception;
 
@@ -31,6 +48,16 @@ public class InvestigationData {
 
   public void addEntry(
       String functionId, String caller, long durationNs, boolean error, boolean isAsync) {
+    int size = callPath.size();
+    if (size > MAX_CALL_PATH_ENTRIES) {
+      // Already at [MAX real frames + sentinel] — drop everything after.
+      return;
+    }
+    if (size == MAX_CALL_PATH_ENTRIES) {
+      // This frame overflows the cap: keep the first MAX, then a single truncation sentinel.
+      callPath.add(new CallPathEntry(CALL_PATH_TRUNCATION_SENTINEL, null, 0L, false, false));
+      return;
+    }
     callPath.add(new CallPathEntry(functionId, caller, durationNs, error, isAsync));
   }
 

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/MethodAggregationStore.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/MethodAggregationStore.java
@@ -35,77 +35,37 @@ final class MethodAggregationStore {
 
   // All four tier knobs and the mode are volatile so the agent-classloader init
   // (ServiceEventsInstrumentation) can set them at startup without needing to reach
-  // into the bootstrap bridge's private state. Python/JS expose the same four
-  // knobs and the same four modes; see the cross-SDK §3.6 sampling table.
+  // into the bootstrap bridge's private state. Python/JS expose the same four knobs and the same
+  // three modes: the SAMPLING_MODE enum is documented in SERVICE_EVENTS_ENV_VARS_RELEASE.md §6
+  // (Sampling); the hardcoded auto-mode tier cutoffs/rates in SERVICE_EVENTS_INTERNAL_KNOBS.md
+  // §1.3.
 
-  /** Mode: "auto" (tiered), "adaptive" (auto + hot-endpoint boost), "always", or "never". */
-  static volatile String samplingMode = "adaptive";
+  /** Mode: "auto" (tiered), "always", or "never". */
+  static volatile String samplingMode = "always";
 
   static volatile long sampleTier1Threshold = 100;
   static volatile long sampleTier2Threshold = 1000;
   static volatile int sampleTier2Rate = 10;
   static volatile int sampleTier3Rate = 100;
 
-  /** Countdown-based hot operation tracking for adaptive mode. */
-  static volatile int hotEndpointCycles = 100;
-
-  private static final ConcurrentHashMap<String, Integer> hotOperations =
-      new ConcurrentHashMap<String, Integer>();
-
   static void setSamplingMode(String mode) {
     if (mode == null) {
       return;
     }
     String normalized = mode.toLowerCase(java.util.Locale.ROOT);
-    if (!normalized.equals("auto")
-        && !normalized.equals("adaptive")
-        && !normalized.equals("always")
-        && !normalized.equals("never")) {
-      // Invalid mode — leave current setting unchanged.
+    if (!normalized.equals("auto") && !normalized.equals("always") && !normalized.equals("never")) {
+      // Invalid mode (including the removed "adaptive") — leave current setting unchanged.
       return;
     }
     samplingMode = normalized;
   }
 
   static void setSamplingThresholds(
-      long tier1Threshold, long tier2Threshold, int tier2Rate, int tier3Rate, int hotCycles) {
+      long tier1Threshold, long tier2Threshold, int tier2Rate, int tier3Rate) {
     if (tier1Threshold > 0) sampleTier1Threshold = tier1Threshold;
     if (tier2Threshold > 0) sampleTier2Threshold = tier2Threshold;
     if (tier2Rate > 0) sampleTier2Rate = tier2Rate;
     if (tier3Rate > 0) sampleTier3Rate = tier3Rate;
-    if (hotCycles > 0) hotEndpointCycles = hotCycles;
-  }
-
-  /**
-   * Mark an operation "hot" so adaptive-mode function calls within it are 100% sampled for the next
-   * {@link #hotEndpointCycles} flush cycles. Called after an incident is raised against the
-   * operation (incident → operation needs fuller diagnostic data next time).
-   */
-  static void markOperationHot(String operation) {
-    if (operation == null || operation.isEmpty()) {
-      return;
-    }
-    hotOperations.put(operation, hotEndpointCycles);
-  }
-
-  /**
-   * Decrement every hot-operation countdown by one. Called once per function-call collector flush.
-   * Operations at zero are removed.
-   *
-   * <p>Race-safe under concurrent {@code markOperationHot} calls: each entry is updated atomically
-   * via {@link ConcurrentHashMap#computeIfPresent} so a fresh countdown {@code put} from an
-   * incident-emitter thread is never silently overwritten or removed by this iteration. Returning
-   * {@code null} from the remapping function asks ConcurrentHashMap to remove the entry.
-   * Package-private for tests.
-   */
-  static void tickHotOperations() {
-    for (String op : hotOperations.keySet()) {
-      hotOperations.computeIfPresent(op, (k, v) -> v <= 1 ? null : v - 1);
-    }
-  }
-
-  private static boolean isOperationHot(String operation) {
-    return operation != null && hotOperations.containsKey(operation);
   }
 
   // =========================================================================
@@ -176,12 +136,9 @@ final class MethodAggregationStore {
    * #samplingMode} via volatile field (cheap; no synchronization).
    *
    * <ul>
-   *   <li>{@code always} — every call sampled.
+   *   <li>{@code always} (default) — every call sampled.
    *   <li>{@code never} — no calls sampled.
-   *   <li>{@code adaptive} — same as {@code auto} unless the current operation is "hot" (an
-   *       incident fired against it recently), in which case every call is sampled. Reads the
-   *       thread-local {@code currentOperation}; only one CHM lookup when hot.
-   *   <li>{@code auto} (default) — three-tier: all calls up to {@link #sampleTier1Threshold}, then
+   *   <li>{@code auto} — three-tier: all calls up to {@link #sampleTier1Threshold}, then
    *       1-in-{@link #sampleTier2Rate} up to {@link #sampleTier2Threshold}, then 1-in-{@link
    *       #sampleTier3Rate} thereafter.
    * </ul>
@@ -194,20 +151,17 @@ final class MethodAggregationStore {
     if ("never".equals(mode)) {
       return false;
     }
-    if ("adaptive".equals(mode) && !hotOperations.isEmpty()) {
-      String op = ServiceEventsDataStore.getCurrentOperation();
-      if (isOperationHot(op)) {
-        return true;
-      }
-    }
-    // auto + adaptive (non-hot) fall through to tiered sampling.
+    // auto — tiered sampling. Rates are "1-in-N"; a non-positive N is degenerate (it can only
+    // arrive via the internal test-config hook, which doesn't validate) and would otherwise throw
+    // ArithmeticException on the `%`. Treat N <= 0 as "sample none in this tier" so a misconfigured
+    // rate degrades gracefully instead of crashing this hot path. Mirrors Python/JS.
     if (totalCalls <= sampleTier1Threshold) {
       return true;
     }
     if (totalCalls <= sampleTier2Threshold) {
-      return (totalCalls % sampleTier2Rate == 0);
+      return sampleTier2Rate > 0 && (totalCalls % sampleTier2Rate == 0);
     }
-    return (totalCalls % sampleTier3Rate == 0);
+    return sampleTier3Rate > 0 && (totalCalls % sampleTier3Rate == 0);
   }
 
   /**
@@ -237,12 +191,10 @@ final class MethodAggregationStore {
   /** Reset all aggregation state. Used for testing. */
   static void resetState() {
     aggregations.set(new ConcurrentHashMap<String, ConcurrentHashMap<String, AggregationData>>());
-    hotOperations.clear();
-    samplingMode = "adaptive";
+    samplingMode = "always";
     sampleTier1Threshold = 100;
     sampleTier2Threshold = 1000;
     sampleTier2Rate = 10;
     sampleTier3Rate = 100;
-    hotEndpointCycles = 100;
   }
 }

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStore.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStore.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -128,13 +129,12 @@ public final class ServiceEventsDataStore {
   }
 
   // =========================================================================
-  // Adaptive Sampling (delegated to MethodAggregationStore)
+  // Function-Call Sampling (delegated to MethodAggregationStore)
   // =========================================================================
 
   /**
-   * Set the sampling mode for function-call records. Accepted values: {@code "auto"} (default,
-   * tiered), {@code "adaptive"} (tiered + hot-endpoint boost), {@code "always"}, {@code "never"}.
-   * Invalid values are silently ignored.
+   * Set the sampling mode for function-call records. Accepted values: {@code "always"} (default),
+   * {@code "auto"} (tiered cost cap), {@code "never"}. Invalid values are silently ignored.
    */
   public static void setSamplingMode(String mode) {
     MethodAggregationStore.setSamplingMode(mode);
@@ -149,30 +149,13 @@ public final class ServiceEventsDataStore {
   }
 
   /**
-   * Set the tiered-sampling thresholds and hot-endpoint cycle length. Non-positive values for any
+   * Set the tiered-sampling thresholds (used by {@code auto} mode). Non-positive values for any
    * parameter are silently ignored (current setting retained).
    */
   public static void setSamplingThresholds(
-      long tier1Threshold, long tier2Threshold, int tier2Rate, int tier3Rate, int hotCycles) {
+      long tier1Threshold, long tier2Threshold, int tier2Rate, int tier3Rate) {
     MethodAggregationStore.setSamplingThresholds(
-        tier1Threshold, tier2Threshold, tier2Rate, tier3Rate, hotCycles);
-  }
-
-  /**
-   * Mark an operation "hot" for adaptive-mode sampling. Subsequent function calls within this
-   * operation are 100% sampled for the next {@code HOT_ENDPOINT_CYCLES} flush cycles. Called after
-   * an incident is recorded against the operation.
-   */
-  public static void markOperationHot(String operation) {
-    MethodAggregationStore.markOperationHot(operation);
-  }
-
-  /**
-   * Decrement every hot-operation countdown by one. Called once per function-call collector flush
-   * cycle. Operations at zero are removed.
-   */
-  public static void tickHotOperations() {
-    MethodAggregationStore.tickHotOperations();
+        tier1Threshold, tier2Threshold, tier2Rate, tier3Rate);
   }
 
   // =========================================================================
@@ -202,6 +185,17 @@ public final class ServiceEventsDataStore {
   /** Thread-local investigation data for incident snapshots. */
   private static final ThreadLocal<InvestigationData> investigationData =
       new ThreadLocal<InvestigationData>();
+
+  /**
+   * Count of threads with an active investigation. The hoisted {@link #methodExit} records a
+   * call_path entry for EVERY instrumented call (not just sampled ones), which would otherwise pay
+   * a {@link ThreadLocal#get()} on the hottest path even when no incident investigation is in
+   * flight (the common case). This process-wide counter lets the hot path skip that lookup when no
+   * thread is investigating — mirroring the JS distro's {@code _investigationActiveCount} gate.
+   * Incremented only when {@link #beginInvestigation()} actually creates new data (so nested
+   * servlet dispatch doesn't double-count) and decremented on the matching clear/get.
+   */
+  private static final AtomicInteger investigationActiveCount = new AtomicInteger(0);
 
   /** Endpoint aggregation: endpointKey -> EndpointAggregation. */
   private static final AtomicReference<ConcurrentHashMap<String, EndpointAggregation>>
@@ -440,13 +434,28 @@ public final class ServiceEventsDataStore {
       stack.remove(stack.size() - 1);
     }
 
-    // Metrics/investigation are recorded for sampled calls only (unchanged behavior). The push/pop
-    // above already ran for every call, so skipping the rest here no longer corrupts the graph.
+    // durationNs is only meaningful for sampled calls (methodEnter records startTime only when
+    // sampled); unsampled calls carry 0. Computed up front so the investigation call_path entry
+    // below can record it regardless of sampling.
+    long durationNs = sampled ? System.nanoTime() - ctx[0] : 0L;
+
+    // Record the call_path entry for EVERY call, not just sampled ones — mirrors Python/JS, where
+    // the investigation call graph must survive in "never"/unsampled modes so incident snapshots
+    // still capture who-called-whom (durationNs is 0 for unsampled frames). Only the duration
+    // METRIC below is sampling-gated. The active-count check gates the ThreadLocal lookup so the
+    // common case (no investigation in flight) skips it on this hot path — same gate as JS.
+    if (investigationActiveCount.get() > 0) {
+      InvestigationData investigation = investigationData.get();
+      if (investigation != null) {
+        boolean error = exceptionType != null;
+        investigation.addEntry(functionId, caller, durationNs, error, false);
+      }
+    }
+
+    // The service.function.duration metric is recorded for sampled calls only (unchanged behavior).
     if (!sampled) {
       return;
     }
-
-    long durationNs = System.nanoTime() - ctx[0];
 
     String operation = currentOperation.get();
     if (operation == null) {
@@ -462,13 +471,6 @@ public final class ServiceEventsDataStore {
       // SEH pre-aggregation fallback, used only when the bridge failed to wire.
       MethodAggregationStore.recordMethodInvocation(
           operation, functionId, durationNs, caller, exceptionType);
-    }
-
-    // Record to investigation data (sampled calls only — unchanged).
-    InvestigationData investigation = investigationData.get();
-    if (investigation != null) {
-      boolean error = exceptionType != null;
-      investigation.addEntry(functionId, caller, durationNs, error, false);
     }
   }
 
@@ -721,9 +723,10 @@ public final class ServiceEventsDataStore {
    */
   public static boolean beginInvestigation() {
     if (investigationData.get() != null) {
-      return false; // nested servlet dispatch — outer request's call path wins
+      return false; // nested servlet dispatch — outer request's call path wins (no double-count)
     }
     investigationData.set(new InvestigationData());
+    investigationActiveCount.incrementAndGet();
     return true;
   }
 
@@ -758,12 +761,29 @@ public final class ServiceEventsDataStore {
   public static InvestigationData getAndClearInvestigationData() {
     InvestigationData investigation = investigationData.get();
     investigationData.remove();
+    if (investigation != null) {
+      decrementInvestigationCount();
+    }
     return investigation;
   }
 
   /** Clear investigation data without returning it. */
   public static void clearInvestigation() {
+    if (investigationData.get() != null) {
+      decrementInvestigationCount();
+    }
     investigationData.remove();
+  }
+
+  /**
+   * Decrement {@link #investigationActiveCount}, clamping at zero. Clamping keeps the counter from
+   * going negative if a clear is ever unbalanced (e.g. a clear with no prior begin on this thread).
+   * A spuriously-high count only costs an extra ThreadLocal lookup on the hot path (it degrades to
+   * the pre-guard behavior); a negative count would wrongly disable call_path capture, so we guard
+   * against that direction.
+   */
+  private static void decrementInvestigationCount() {
+    investigationActiveCount.updateAndGet(n -> n > 0 ? n - 1 : 0);
   }
 
   // =========================================================================
@@ -816,6 +836,7 @@ public final class ServiceEventsDataStore {
     currentOperation.remove();
     callStack.remove();
     investigationData.remove();
+    investigationActiveCount.set(0);
     IncidentRateLimiter.resetState();
   }
 }

--- a/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/InvestigationDataTest.java
+++ b/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/InvestigationDataTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.serviceevents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the call_path cap in {@link InvestigationData}. Mirrors Python/JS keep-first truncation.
+ */
+class InvestigationDataTest {
+
+  @Test
+  void addEntry_capsCallPathAndAppendsSingleTruncationSentinelOnOverflow() {
+    InvestigationData inv = new InvestigationData();
+    int max = InvestigationData.MAX_CALL_PATH_ENTRIES;
+
+    // Record well past the cap; every real frame has a non-zero duration.
+    for (int i = 0; i < max + 50; i++) {
+      String caller = i == 0 ? null : "func-" + (i - 1);
+      inv.addEntry("func-" + i, caller, 1000L);
+    }
+
+    List<CallPathEntry> path = inv.getCallPath();
+    // Keep-first: MAX real frames + exactly one sentinel, regardless of how far past the cap we
+    // went.
+    assertEquals(max + 1, path.size());
+
+    // A below-cap frame is a normal entry.
+    assertEquals("func-0", path.get(0).functionId);
+    assertEquals("func-" + (max - 1), path.get(max - 1).functionId);
+    assertEquals(1000L, path.get(max - 1).durationNs);
+
+    // The overflow frame is the sentinel with durationNs=0, which trips is_partial in the emitter.
+    CallPathEntry sentinel = path.get(max);
+    assertEquals(InvestigationData.CALL_PATH_TRUNCATION_SENTINEL, sentinel.functionId);
+    assertNull(sentinel.caller);
+    assertEquals(0L, sentinel.durationNs);
+  }
+
+  @Test
+  void addEntry_belowCapKeepsEveryFrame() {
+    InvestigationData inv = new InvestigationData();
+
+    inv.addEntry("a", null, 10L);
+    inv.addEntry("b", "a", 20L);
+    inv.addEntry("c", "b", 30L);
+
+    List<CallPathEntry> path = inv.getCallPath();
+    assertEquals(3, path.size());
+    assertEquals("a", path.get(0).functionId);
+    assertEquals("c", path.get(2).functionId);
+    assertEquals(30L, path.get(2).durationNs);
+  }
+}

--- a/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/MethodAggregationStoreSamplingTest.java
+++ b/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/MethodAggregationStoreSamplingTest.java
@@ -17,23 +17,28 @@ package software.amazon.opentelemetry.serviceevents;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests adaptive sampling: mode dispatch, tier thresholds, hot-operation lifecycle. Mirrors
- * Python/JS sampling semantics (see python_monitor_impl.py and serviceevents-monitor.ts).
+ * Tests ServiceEvents sampling: mode dispatch (always/auto/never), tier thresholds, and the
+ * never-mode call_path capture. Mirrors Python/JS sampling semantics (see python_monitor_impl.py
+ * and serviceevents-monitor.ts).
  */
 class MethodAggregationStoreSamplingTest {
 
   @BeforeEach
   @AfterEach
   void resetState() {
-    MethodAggregationStore.resetState();
-    ServiceEventsDataStore.setCurrentOperation(null);
+    // Full reset: clears sampling config, counters, call stack, and investigation data so the
+    // never-mode call_path tests below start from a clean thread-local state.
+    ServiceEventsDataStore.resetState();
   }
 
   // ───── Mode dispatch ─────────────────────────────────────────────────
@@ -56,11 +61,14 @@ class MethodAggregationStoreSamplingTest {
 
   @Test
   void mode_invalidValue_silentlyIgnored() {
-    // Default is "adaptive"; invalid mode shouldn't change it.
+    // Default is "always"; invalid modes leave it unchanged. The removed "adaptive" mode is now
+    // just another invalid value — this doubles as the hard-removal regression check.
     ServiceEventsDataStore.setSamplingMode("BOGUS");
-    assertEquals("adaptive", MethodAggregationStore.samplingMode);
+    assertEquals("always", MethodAggregationStore.samplingMode);
+    ServiceEventsDataStore.setSamplingMode("adaptive");
+    assertEquals("always", MethodAggregationStore.samplingMode);
     ServiceEventsDataStore.setSamplingMode(null);
-    assertEquals("adaptive", MethodAggregationStore.samplingMode);
+    assertEquals("always", MethodAggregationStore.samplingMode);
   }
 
   @Test
@@ -69,7 +77,7 @@ class MethodAggregationStoreSamplingTest {
     assertTrue(MethodAggregationStore.shouldSample(99_999));
   }
 
-  // ───── Tiered sampling (auto + adaptive when not hot) ────────────────
+  // ───── Tiered sampling (auto mode) ───────────────────────────────────
 
   @Test
   void auto_tier1_belowThresholdAlwaysSampled() {
@@ -103,92 +111,134 @@ class MethodAggregationStoreSamplingTest {
   @Test
   void thresholds_setterUpdatesTiers() {
     ServiceEventsDataStore.setSamplingMode("auto");
-    ServiceEventsDataStore.setSamplingThresholds(5, 20, 4, 50, 7);
+    ServiceEventsDataStore.setSamplingThresholds(5, 20, 4, 50);
     assertTrue(MethodAggregationStore.shouldSample(5)); // tier1
     assertFalse(MethodAggregationStore.shouldSample(6)); // tier2 first call
     assertTrue(MethodAggregationStore.shouldSample(8)); // tier2: 8 % 4 == 0
-    assertEquals(7, MethodAggregationStore.hotEndpointCycles);
   }
 
   @Test
   void thresholds_nonPositiveIgnored() {
     int origTier1 = (int) MethodAggregationStore.sampleTier1Threshold;
-    ServiceEventsDataStore.setSamplingThresholds(0, -1, 0, 0, -5);
+    ServiceEventsDataStore.setSamplingThresholds(0, -1, 0, 0);
     assertEquals(origTier1, (int) MethodAggregationStore.sampleTier1Threshold);
   }
 
-  // ───── Adaptive mode + hot-operation lifecycle ───────────────────────
-
   @Test
-  void adaptive_hotOperation_samplesEvenInTier3() {
-    ServiceEventsDataStore.setSamplingMode("adaptive");
-    ServiceEventsDataStore.markOperationHot("GET /api/checkout");
-    ServiceEventsDataStore.setCurrentOperation("GET /api/checkout");
+  void auto_zeroRate_samplesNoneInThatTierWithoutCrashing() {
+    // The public setter rejects non-positive rates, but the internal test-config hook (and direct
+    // field writes) don't validate, so shouldSample must not divide by zero. A zero rate degrades
+    // to "sample none in this tier" — mirrors Python/JS, which guard the modulo the same way.
+    ServiceEventsDataStore.setSamplingMode("auto");
+    MethodAggregationStore.sampleTier2Rate = 0;
+    MethodAggregationStore.sampleTier3Rate = 0;
 
-    // Tier3 territory — would normally only sample 1 in 100.
-    assertTrue(MethodAggregationStore.shouldSample(1101));
-    assertTrue(MethodAggregationStore.shouldSample(50_000));
+    // tier1 still samples everything up to its threshold (unaffected by the rates).
+    assertTrue(MethodAggregationStore.shouldSample(1));
+    // tier2 (100 < n <= 1000) and tier3 (n > 1000): zero rate → no crash, sample none.
+    assertFalse(MethodAggregationStore.shouldSample(500));
+    assertFalse(MethodAggregationStore.shouldSample(5000));
   }
 
-  @Test
-  void adaptive_coldOperation_fallsBackToTieredSampling() {
-    ServiceEventsDataStore.setSamplingMode("adaptive");
-    ServiceEventsDataStore.setCurrentOperation("GET /api/cold");
-    // No markOperationHot — should follow tier rules.
-    assertTrue(MethodAggregationStore.shouldSample(50)); // tier1
-    assertFalse(MethodAggregationStore.shouldSample(111)); // tier2 not on rate
-  }
+  // ───── never-mode call_path capture (Python/JS parity) ───────────────
 
   @Test
-  void hotOperation_tickDecrements() {
-    ServiceEventsDataStore.setSamplingMode("adaptive");
-    // Set thresholds BEFORE marking hot — markOperationHot snapshots the
-    // current hotEndpointCycles into the operation's countdown.
-    ServiceEventsDataStore.setSamplingThresholds(100, 1000, 10, 100, 3); // 3 cycles
-    ServiceEventsDataStore.markOperationHot("GET /api/op");
+  void never_recordsCallPathWithZeroDuration() {
+    ServiceEventsDataStore.setSamplingMode("never");
+    ServiceEventsDataStore.beginInvestigation();
     ServiceEventsDataStore.setCurrentOperation("GET /api/op");
 
-    // Pick a callCount in tier3 that's NOT a tier3-rate hit (1101 % 100 != 0)
-    // so a "true" result can only come from the hot-operation boost.
-    long off = 1101;
+    // A single instrumented call under "never": no duration metric is recorded, but the call_path
+    // entry must still be captured (durationNs == 0) so incident snapshots retain who-called-whom.
+    Object ctx = ServiceEventsDataStore.methodEnter("com.example.Svc.handle");
+    ServiceEventsDataStore.methodExit("com.example.Svc.handle", ctx, null);
 
-    // Cycle 0: hot.
-    assertTrue(MethodAggregationStore.shouldSample(off));
-    ServiceEventsDataStore.tickHotOperations();
-    // Cycle 1: still hot (countdown was 3, now 2).
-    assertTrue(MethodAggregationStore.shouldSample(off));
-    ServiceEventsDataStore.tickHotOperations();
-    // Cycle 2: still hot (countdown 1).
-    assertTrue(MethodAggregationStore.shouldSample(off));
-    ServiceEventsDataStore.tickHotOperations();
-    // Cycle 3: cold (countdown reached 0, removed) — falls back to tier rules,
-    // and 1101 is not on the tier3 rate.
-    assertFalse(MethodAggregationStore.shouldSample(off));
+    InvestigationData inv = ServiceEventsDataStore.peekInvestigationData();
+    assertNotNull(inv);
+    List<CallPathEntry> path = inv.getCallPath();
+    assertEquals(1, path.size());
+    CallPathEntry entry = path.get(0);
+    assertEquals("com.example.Svc.handle", entry.functionId);
+    assertNull(entry.caller);
+    assertEquals(0L, entry.durationNs);
+    assertFalse(entry.error);
+
+    // The duration metric path is sampling-gated, so the aggregation map stays empty under "never".
+    assertNull(MethodAggregationStore.getAndSwapAggregations());
   }
 
   @Test
-  void hotOperation_remarkResetsCountdown() {
-    ServiceEventsDataStore.setSamplingMode("adaptive");
-    // Set thresholds BEFORE marking hot.
-    ServiceEventsDataStore.setSamplingThresholds(100, 1000, 10, 100, 2);
-    ServiceEventsDataStore.markOperationHot("GET /api/op");
+  void never_nestedCallsPreserveCallerAttribution() {
+    ServiceEventsDataStore.setSamplingMode("never");
+    ServiceEventsDataStore.beginInvestigation();
     ServiceEventsDataStore.setCurrentOperation("GET /api/op");
 
-    long off = 5001; // tier3, not on rate (5001 % 100 != 0)
-    ServiceEventsDataStore.tickHotOperations(); // 1 left
-    ServiceEventsDataStore.markOperationHot("GET /api/op"); // back to 2
-    ServiceEventsDataStore.tickHotOperations(); // 1
-    assertTrue(MethodAggregationStore.shouldSample(off));
+    // A -> B, both unsampled. The call stack is still maintained for every frame, so B resolves its
+    // caller to A even though neither call produced a duration metric.
+    Object ctxA = ServiceEventsDataStore.methodEnter("A");
+    Object ctxB = ServiceEventsDataStore.methodEnter("B");
+    ServiceEventsDataStore.methodExit("B", ctxB, null);
+    ServiceEventsDataStore.methodExit("A", ctxA, null);
+
+    List<CallPathEntry> path = ServiceEventsDataStore.peekInvestigationData().getCallPath();
+    assertEquals(2, path.size());
+    // B exits first (caller A), then A (no caller).
+    assertEquals("B", path.get(0).functionId);
+    assertEquals("A", path.get(0).caller);
+    assertEquals(0L, path.get(0).durationNs);
+    assertEquals("A", path.get(1).functionId);
+    assertNull(path.get(1).caller);
   }
 
   @Test
-  void markOperationHot_nullOrEmpty_isNoop() {
-    ServiceEventsDataStore.markOperationHot(null);
-    ServiceEventsDataStore.markOperationHot("");
-    ServiceEventsDataStore.setSamplingMode("adaptive");
+  void never_errorEntryFlaggedInCallPath() {
+    ServiceEventsDataStore.setSamplingMode("never");
+    ServiceEventsDataStore.beginInvestigation();
     ServiceEventsDataStore.setCurrentOperation("GET /api/op");
-    // Pick a tier3 callCount that's NOT on the rate so a hot-boost could be
-    // distinguished from a regular tier3 hit (1501 % 100 != 0).
-    assertFalse(MethodAggregationStore.shouldSample(1501));
+
+    // An exception on an unsampled call still flags the call_path entry as an error.
+    Object ctx = ServiceEventsDataStore.methodEnter("com.example.Svc.boom");
+    ServiceEventsDataStore.methodExit("com.example.Svc.boom", ctx, "java.lang.RuntimeException");
+
+    List<CallPathEntry> path = ServiceEventsDataStore.peekInvestigationData().getCallPath();
+    assertEquals(1, path.size());
+    assertTrue(path.get(0).error);
+    assertEquals(0L, path.get(0).durationNs);
+  }
+
+  // ───── active-count gate on the methodExit call_path lookup (JS parity) ──
+
+  @Test
+  void noInvestigation_methodExitDoesNotCaptureCallPath() {
+    // With no beginInvestigation(), the active-count gate keeps methodExit from recording anything.
+    // (beginInvestigation also short-circuits on a null ThreadLocal, but the gate is what lets the
+    // hot path skip the ThreadLocal lookup entirely — this asserts the no-capture behavior.)
+    ServiceEventsDataStore.setSamplingMode("always");
+    ServiceEventsDataStore.setCurrentOperation("GET /api/op");
+
+    Object ctx = ServiceEventsDataStore.methodEnter("com.example.Svc.handle");
+    ServiceEventsDataStore.methodExit("com.example.Svc.handle", ctx, null);
+
+    assertNull(ServiceEventsDataStore.peekInvestigationData());
+  }
+
+  @Test
+  void investigationClearedMidFlight_subsequentCallsDoNotCapture() {
+    // After the investigation is cleared, the active-count returns to zero, so a stray instrumented
+    // call exiting on the same thread (e.g. cleanup code) records nothing — no resurrected data.
+    ServiceEventsDataStore.setSamplingMode("always");
+    ServiceEventsDataStore.beginInvestigation();
+    ServiceEventsDataStore.setCurrentOperation("GET /api/op");
+
+    Object ctx1 = ServiceEventsDataStore.methodEnter("com.example.Svc.handle");
+    ServiceEventsDataStore.methodExit("com.example.Svc.handle", ctx1, null);
+    assertEquals(1, ServiceEventsDataStore.peekInvestigationData().getCallPath().size());
+
+    ServiceEventsDataStore.clearInvestigation();
+
+    // A late call after clear must not re-create or append to investigation data.
+    Object ctx2 = ServiceEventsDataStore.methodEnter("com.example.Svc.cleanup");
+    ServiceEventsDataStore.methodExit("com.example.Svc.cleanup", ctx2, null);
+    assertNull(ServiceEventsDataStore.peekInvestigationData());
   }
 }


### PR DESCRIPTION
## Description

Hard-removes the **adaptive** ServiceEvents sampling mode and its hot-endpoint
tracking, flips the default sampling mode to **always** (100%), bounds
per-request `call_path` growth, and brings the `is_partial` wire signal into
parity with the Python/JS distros.

### Sampling
- Modes are now **always / auto / never**; `adaptive` is rejected (mode unchanged on invalid input).
- `auto` tier rates guard against a non-positive 1-in-N rate (treated as "sample none in this tier") so a misconfigured rate degrades gracefully instead of throwing on the hot path.

### call_path cap
- `InvestigationData` caps the call path at `MAX_CALL_PATH_ENTRIES` (1024) and appends a single `<call_path_truncated>` sentinel (`durationNs=0`) on overflow, keeping the first 1024 frames. Bounds a serialized IncidentSnapshot well under the 1 MB CloudWatch OTLP Logs limit.

### Active-count guard
- A process-wide `investigationActiveCount` (`AtomicInteger`) gates the per-thread investigation-data lookup on `methodExit` so the common case (no investigation in flight) skips it. Create-only increment, decrement only when data was present, clamped at zero (drifts high → degrades to the old lookup; never low).
- `call_path` entries are now recorded for **every** call (not just sampled), so incident snapshots capture who-called-whom under `auto`/`never`; only the duration metric stays sampling-gated.

### is_partial parity
- `is_partial` is computed as `any(durationNs == 0)` over the call path (empty → `false`) instead of hardcoded `true`, and zero durations are stripped from serialized frames on a partial snapshot. A fully-timed `always`-mode snapshot now reports `is_partial=false` with all timings intact — matching the Python/JS distros and the OTLP signals spec.

## Testing
- `:serviceevents-bootstrap-bridge:test` + `:instrumentation:serviceevents:test` — **208 tests, 0 failures**.
- `spotlessApply` clean.
