### PR TITLE
serviceevents: use comma delimiter for LATENCY_THRESHOLDS (match Python/JS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   ([#1386](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1386))
 - Bump Netty to 4.1.135.Final to fix CVE-2026-45416 and CVE-2026-44249
   ([#1389](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1389))
+- ServiceEvents: parse `OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS` as a comma-separated list to
+  match the Python and JS SDKs (was pipe-separated). Routes containing a literal comma must now be
+  matched with a glob, e.g. `GET /search*:750`.
+  ([#1393](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1393))
 
 ## v2.28.1 - 2026-05-26
 

--- a/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/serviceevents/base/ServiceEventsContractTestBase.java
+++ b/appsignals-tests/contract-tests/src/test/java/software/amazon/opentelemetry/appsignals/test/serviceevents/base/ServiceEventsContractTestBase.java
@@ -164,8 +164,9 @@ public abstract class ServiceEventsContractTestBase {
     env.put("OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_DURATION_THRESHOLD_MS", "30000");
     // Per-endpoint override: trigger a latency incident when /slow-success exceeds 500ms.
     // The trailing "bad-entry:notanumber" malformed segment exercises the skip-and-log path.
+    // Entries are comma-separated (matching the Python and JS SDKs).
     env.put(
-        "OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS", "GET /slow-success:500|bad-entry:notanumber");
+        "OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS", "GET /slow-success:500,bad-entry:notanumber");
     env.put(
         "OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE",
         "software.amazon.opentelemetry.appsignals.tests.images.serviceevents");

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfig.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfig.java
@@ -65,7 +65,7 @@ public class ServiceEventsConfig {
   private final List<String> packagesExclude;
   private final List<String> packagesInclude;
 
-  // Per-endpoint latency thresholds (pipe-delimited entries, each "METHOD /route:threshold_ms")
+  // Per-endpoint latency thresholds (comma-separated entries, each "METHOD /route:threshold_ms")
   private final List<String> latencyThresholds;
 
   // Endpoint filter glob patterns. Format: "METHOD /route" (e.g. "GET /api/*",
@@ -235,7 +235,7 @@ public class ServiceEventsConfig {
                     getListEnv("OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE", new ArrayList<>()),
                     "OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE"))
             .latencyThresholds(
-                getPipeListEnv("OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS", new ArrayList<>()))
+                getListEnv("OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS", new ArrayList<>()))
             .endpointIncludePatterns(
                 getListEnv("OTEL_AWS_SERVICE_EVENTS_ENDPOINT_INCLUDE_PATTERNS", new ArrayList<>()))
             .endpointExcludePatterns(
@@ -483,10 +483,6 @@ public class ServiceEventsConfig {
     return normalized;
   }
 
-  private static List<String> getPipeListEnv(String name, List<String> defaultValue) {
-    return getDelimitedListEnv(name, "\\|", defaultValue);
-  }
-
   private static List<String> getDelimitedListEnv(
       String name, String delimiterRegex, List<String> defaultValue) {
     String value = getConfigValue(name);
@@ -592,9 +588,11 @@ public class ServiceEventsConfig {
               "software.amazon.opentelemetry.di."));
 
   /**
-   * Raw pipe-delimited entries parsed from {@code OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS}. Each
-   * entry is of the form {@code METHOD /route:threshold_ms} (glob on method and route allowed;
-   * threshold parsed from the text after the last {@code :}). Empty by default.
+   * Raw comma-separated entries parsed from {@code OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS}.
+   * Each entry is of the form {@code METHOD /route:threshold_ms} (glob on method and route allowed;
+   * threshold parsed from the text after the last {@code :}). Empty by default. Matches the comma
+   * delimiter used by the Python and JS SDKs; routes containing literal commas (e.g. query strings
+   * like {@code ?q=a,b,c}) must be expressed with a glob (e.g. {@code GET /search*}).
    */
   public List<String> getLatencyThresholds() {
     return latencyThresholds;

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/LatencyThresholdResolver.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/LatencyThresholdResolver.java
@@ -24,12 +24,14 @@ import java.util.regex.Pattern;
 import software.amazon.opentelemetry.serviceevents.LatencyThresholdBridge;
 
 /**
- * Resolves per-endpoint latency thresholds from a pipe-delimited list of glob patterns.
+ * Resolves per-endpoint latency thresholds from a comma-separated list of glob patterns.
  *
  * <p>Each entry has the form {@code METHOD /route:threshold_ms}. The threshold is parsed from the
  * text after the LAST {@code :}, so routes may contain colons. The pattern part supports glob
  * wildcards {@code *} (zero or more chars) and {@code ?} (single char) on both the method and the
- * route; all other regex metacharacters are escaped.
+ * route; all other regex metacharacters are escaped. Because the list separator is a comma, a route
+ * containing a literal comma (e.g. {@code ?q=a,b,c}) cannot be expressed verbatim — use a glob such
+ * as {@code GET /search*} instead. This matches the comma delimiter used by the Python and JS SDKs.
  *
  * <p>Lookup matches {@code METHOD} (uppercased) + " " + {@code route} against the compiled patterns
  * in insertion order — first match wins. No match returns {@link Double#NaN}, signaling the caller

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfigTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/config/ServiceEventsConfigTest.java
@@ -84,10 +84,10 @@ class ServiceEventsConfigTest {
   }
 
   @Test
-  void latencyThresholds_pipeDelimited_parsedAndTrimmed() {
+  void latencyThresholds_commaDelimited_parsedAndTrimmed() {
     System.setProperty(
         "otel.aws.service_events.latency.thresholds",
-        "  POST /api/checkout:500  |  GET /api/health:50  |  GET /api/reports:5000");
+        "  POST /api/checkout:500  ,  GET /api/health:50  ,  GET /api/reports:5000");
     ServiceEventsConfig cfg = ServiceEventsConfig.fromEnv();
     List<String> entries = cfg.getLatencyThresholds();
     assertEquals(3, entries.size());
@@ -97,21 +97,26 @@ class ServiceEventsConfigTest {
   }
 
   @Test
-  void latencyThresholds_emptySegmentsBetweenPipes_skipped() {
+  void latencyThresholds_emptySegmentsBetweenCommas_skipped() {
     System.setProperty(
-        "otel.aws.service_events.latency.thresholds", "||POST /api/checkout:500||GET /ok:100||");
+        "otel.aws.service_events.latency.thresholds", ",,POST /api/checkout:500,,GET /ok:100,,");
     ServiceEventsConfig cfg = ServiceEventsConfig.fromEnv();
     assertEquals(2, cfg.getLatencyThresholds().size());
   }
 
   @Test
-  void latencyThresholds_routeContainingComma_preservedByPipeDelimiter() {
+  void latencyThresholds_routeContainingComma_splitByCommaDelimiter() {
+    // Comma is the list separator (matching the Python and JS SDKs), so a route containing a
+    // literal comma is split across entries — it cannot be expressed verbatim. Use a glob
+    // (e.g. "GET /search*:750") to match such routes instead.
     System.setProperty(
-        "otel.aws.service_events.latency.thresholds", "GET /search?q=a,b,c:750|POST /orders:900");
+        "otel.aws.service_events.latency.thresholds", "GET /search?q=a,b,c:750,POST /orders:900");
     List<String> entries = ServiceEventsConfig.fromEnv().getLatencyThresholds();
-    assertEquals(2, entries.size());
-    assertEquals("GET /search?q=a,b,c:750", entries.get(0));
-    assertEquals("POST /orders:900", entries.get(1));
+    assertEquals(4, entries.size());
+    assertEquals("GET /search?q=a", entries.get(0));
+    assertEquals("b", entries.get(1));
+    assertEquals("c:750", entries.get(2));
+    assertEquals("POST /orders:900", entries.get(3));
   }
 
   @Test

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/LatencyThresholdResolverTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/LatencyThresholdResolverTest.java
@@ -67,8 +67,10 @@ class LatencyThresholdResolverTest {
 
   @Test
   void routeWithComma_parsesCorrectly() {
-    // Pipe is the outer delimiter in ServiceEventsConfig, so an entry with a comma reaches the
-    // resolver intact.
+    // The resolver receives already-split entries, so it parses a comma-bearing route fine on its
+    // own. Note that ServiceEventsConfig now splits the env var on commas, so such an entry can no
+    // longer be produced verbatim from configuration — a comma route must be matched with a glob
+    // (e.g. "GET /search*:750"). This test pins the resolver's own behavior in isolation.
     LatencyThresholdResolver r =
         new LatencyThresholdResolver(Collections.singletonList("GET /search?q=a,b,c:750"));
     assertEquals(750.0, r.resolveThresholdMs("GET", "/search?q=a,b,c"));


### PR DESCRIPTION
## Description

`OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS` was the only ServiceEvents list-typed env var on Java that split entries on a pipe (`|`) instead of a comma. The Python and JS SDKs both split this var on commas, and every other list-typed ServiceEvents var on Java (`PACKAGES_INCLUDE`/`EXCLUDE`, `ENDPOINT_INCLUDE`/`EXCLUDE_PATTERNS`) already uses a comma. This change makes the env surface identical across all three ADOT SDKs.

Each entry is still `METHOD /route:threshold_ms`, with the threshold parsed from the text after the **last** colon (so routes may still contain colons). Glob wildcards (`*`, `?`) on method and route are unchanged.

## Behavior change / tradeoff

A route containing a **literal comma** (e.g. a query string like `?q=a,b,c`) can no longer be expressed verbatim, because comma is now the entry separator. Match such routes with a glob instead, e.g. `GET /search*:750`. This matches the existing Python/JS behavior.

```
# before (Java, pipe):
OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS="GET /health:200|POST /checkout:8000"
# after (Java, comma — same as Python/JS):
OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS="GET /health:200,POST /checkout:8000"
```

## Changes

- `ServiceEventsConfig`: `getPipeListEnv` → `getListEnv` for this var; remove the now-unused `getPipeListEnv` helper; update the field comment and `getLatencyThresholds()` Javadoc.
- `LatencyThresholdResolver`: update class Javadoc (it described a pipe-delimited list). The resolver itself is unchanged — it still parses already-split entries.
- Tests: convert the three pipe-delimited `ServiceEventsConfigTest` cases to comma; the route-with-comma case now asserts the new split-into-4 behavior and documents the glob workaround.

## Testing

`./gradlew :instrumentation:serviceevents:test` — `ServiceEventsConfigTest` 49/49 and `LatencyThresholdResolverTest` 17/17 pass. `spotlessApply` clean.