### PR TITLE
fix(serviceevents): replace Java 9+ APIs so the agent starts on Java 8

### DIFF
--- a/instrumentation/serviceevents/build.gradle.kts
+++ b/instrumentation/serviceevents/build.gradle.kts
@@ -20,6 +20,14 @@ plugins {
 
 base.archivesBaseName = "aws-instrumentation-serviceevents"
 
+// ServiceEvents runs on Java 8+. The root build only sets source/targetCompatibility = 8, which
+// controls the emitted bytecode version but NOT the API surface — Java 9+ JDK API references (e.g.
+// ProcessHandle) compile fine and then throw NoClassDefFoundError at runtime on Java 8, aborting the
+// whole agent. Pinning the release flag makes the compiler reject Java 9+ JDK APIs at build time.
+tasks.named<JavaCompile>("compileJava") {
+  options.release.set(8)
+}
+
 dependencies {
   // Bootstrap bridge for cross-classloader communication (compile-only since it's loaded via bootstrap)
   compileOnly(project(":serviceevents-bootstrap-bridge"))

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/ServiceEventsInstrumentation.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/ServiceEventsInstrumentation.java
@@ -341,7 +341,8 @@ public class ServiceEventsInstrumentation {
                   config.getDeploymentUrl(),
                   config.getGitCommitSha(),
                   config.getGitRepoUrl(),
-                  ProcessHandle.current().pid());
+                  software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils
+                      .ProcessUtils.currentPid());
 
       // Apply incident-snapshot rate-limit startup defaults from env. Applied for any mode
       // that emits IncidentSnapshots (bytecode + lite). The rate-limit window is fixed at 1 minute.

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/DeploymentEventCollector.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/DeploymentEventCollector.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.exporter.ServiceEventsOtlpEmitter;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.models.DeploymentEvent;
+import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils.ProcessUtils;
 
 /**
  * Collector for deployment event telemetry.
@@ -89,7 +90,7 @@ public class DeploymentEventCollector extends BaseCollector {
     this.deploymentUrl = deploymentUrl != null ? deploymentUrl : "";
     this.gitCommitSha = gitCommitSha != null ? gitCommitSha : "";
     this.gitRepoUrl = gitRepoUrl != null ? gitRepoUrl : "";
-    this.pid = ProcessHandle.current().pid();
+    this.pid = ProcessUtils.currentPid();
     this.sdkVersion = loadSdkVersion();
     this.objectMapper = new ObjectMapper();
   }
@@ -130,9 +131,9 @@ public class DeploymentEventCollector extends BaseCollector {
   }
 
   private void exportToConsole(DeploymentEvent event) {
-    System.out.println("\n" + "=".repeat(80));
+    System.out.println("\n" + ProcessUtils.repeat("=", 80));
     System.out.println("SERVICE_EVENTS DEPLOYMENT EVENT TELEMETRY");
-    System.out.println("=".repeat(80));
+    System.out.println(ProcessUtils.repeat("=", 80));
 
     try {
       String json = objectMapper.writeValueAsString(event.toMap());
@@ -141,7 +142,7 @@ public class DeploymentEventCollector extends BaseCollector {
       logger.log(Level.WARNING, "Failed to serialize deployment event", e);
     }
 
-    System.out.println("\n" + "=".repeat(80) + "\n");
+    System.out.println("\n" + ProcessUtils.repeat("=", 80) + "\n");
   }
 
   private static String loadSdkVersion() {

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/EndpointCollector.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/EndpointCollector.java
@@ -34,6 +34,7 @@ import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.mod
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.models.EndpointMetricEvent.ErrorDetail;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.models.ExceptionMetricEvent;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils.EndpointIdGenerator;
+import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils.ProcessUtils;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils.SehHistogram;
 import software.amazon.opentelemetry.serviceevents.EndpointAggregation;
 import software.amazon.opentelemetry.serviceevents.EndpointErrorData;
@@ -101,7 +102,7 @@ public class EndpointCollector extends BaseCollector {
     this.deploymentUrl = deploymentUrl != null ? deploymentUrl : "";
     this.gitCommitSha = gitCommitSha != null ? gitCommitSha : "";
     this.gitRepoUrl = gitRepoUrl != null ? gitRepoUrl : "";
-    this.pid = ProcessHandle.current().pid();
+    this.pid = ProcessUtils.currentPid();
     this.objectMapper = new ObjectMapper();
     this.suppressEndpointSummary = suppressEndpointSummary;
   }
@@ -299,9 +300,9 @@ public class EndpointCollector extends BaseCollector {
   }
 
   private void exportToConsole(List<EndpointMetricEvent> events) {
-    System.out.println("\n" + "=".repeat(80));
+    System.out.println("\n" + ProcessUtils.repeat("=", 80));
     System.out.println("SERVICE_EVENTS ENDPOINT TELEMETRY");
-    System.out.println("=".repeat(80));
+    System.out.println(ProcessUtils.repeat("=", 80));
 
     for (EndpointMetricEvent event : events) {
       try {
@@ -312,13 +313,13 @@ public class EndpointCollector extends BaseCollector {
       }
     }
 
-    System.out.println("\n" + "=".repeat(80) + "\n");
+    System.out.println("\n" + ProcessUtils.repeat("=", 80) + "\n");
   }
 
   private void exportExceptionMetricsToConsole(List<ExceptionMetricEvent> events) {
-    System.out.println("\n" + "=".repeat(80));
+    System.out.println("\n" + ProcessUtils.repeat("=", 80));
     System.out.println("SERVICE_EVENTS EXCEPTION EMF METRICS");
-    System.out.println("=".repeat(80));
+    System.out.println(ProcessUtils.repeat("=", 80));
 
     for (ExceptionMetricEvent event : events) {
       try {
@@ -329,7 +330,7 @@ public class EndpointCollector extends BaseCollector {
       }
     }
 
-    System.out.println("\n" + "=".repeat(80) + "\n");
+    System.out.println("\n" + ProcessUtils.repeat("=", 80) + "\n");
   }
 
   /** Error info container. */

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/FunctionCallCollector.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/collectors/FunctionCallCollector.java
@@ -29,6 +29,7 @@ import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.exp
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.models.CloudWatchMetadata;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.models.DurationMetrics;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.models.FunctionCallMetrics;
+import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils.ProcessUtils;
 import software.amazon.opentelemetry.serviceevents.AggregationData;
 import software.amazon.opentelemetry.serviceevents.ServiceEventsDataStore;
 
@@ -87,7 +88,7 @@ public class FunctionCallCollector extends BaseCollector {
     this.deploymentUrl = deploymentUrl != null ? deploymentUrl : "";
     this.gitCommitSha = gitCommitSha != null ? gitCommitSha : "";
     this.gitRepoUrl = gitRepoUrl != null ? gitRepoUrl : "";
-    this.pid = ProcessHandle.current().pid();
+    this.pid = ProcessUtils.currentPid();
     this.objectMapper = new ObjectMapper();
   }
 
@@ -203,9 +204,9 @@ public class FunctionCallCollector extends BaseCollector {
   }
 
   private void exportToConsole(List<FunctionCallMetrics> events) {
-    System.out.println("\n" + "=".repeat(80));
+    System.out.println("\n" + ProcessUtils.repeat("=", 80));
     System.out.println("SERVICE_EVENTS FUNCTION CALL TELEMETRY (EMF FORMAT)");
-    System.out.println("=".repeat(80));
+    System.out.println(ProcessUtils.repeat("=", 80));
 
     for (FunctionCallMetrics event : events) {
       try {
@@ -216,6 +217,6 @@ public class FunctionCallCollector extends BaseCollector {
       }
     }
 
-    System.out.println("\n" + "=".repeat(80) + "\n");
+    System.out.println("\n" + ProcessUtils.repeat("=", 80) + "\n");
   }
 }

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/ProcessUtils.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/ProcessUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils;
+
+import java.lang.management.ManagementFactory;
+
+/** Process-level helpers that must work on every supported runtime, including Java 8. */
+public final class ProcessUtils {
+
+  private ProcessUtils() {}
+
+  /**
+   * Return the current process id without using {@code ProcessHandle} (a Java 9+ API).
+   * ServiceEvents runs on Java 8+, and {@code ProcessHandle.current().pid()} throws {@link
+   * NoClassDefFoundError} on Java 8 — which, thrown from agent init, aborts the entire
+   * OpenTelemetry javaagent. The runtime MXBean name is formatted as {@code "<pid>@<host>"} on the
+   * HotSpot/Corretto JVMs we target, so we parse the pid out of it. Returns {@code -1} if the pid
+   * cannot be determined; callers still emit their records (pid is informational only).
+   */
+  public static long currentPid() {
+    try {
+      String name = ManagementFactory.getRuntimeMXBean().getName();
+      if (name != null) {
+        int at = name.indexOf('@');
+        if (at > 0) {
+          return Long.parseLong(name.substring(0, at));
+        }
+      }
+    } catch (RuntimeException e) {
+      // Fall through to the sentinel — pid is best-effort metadata.
+    }
+    return -1L;
+  }
+
+  /**
+   * Repeat {@code s} {@code count} times. Replacement for {@code String.repeat(int)}, which is a
+   * Java 11+ API — calling it on Java 8 throws {@link NoSuchMethodError}. Used for console banner
+   * separators in the debug export paths.
+   */
+  public static String repeat(String s, int count) {
+    if (count <= 0 || s.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder(s.length() * count);
+    for (int i = 0; i < count; i++) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+}

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/ProcessUtilsTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/ProcessUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ProcessUtilsTest {
+
+  @Test
+  void currentPidReturnsPositivePidForThisJvm() {
+    // The running JVM always has a pid; the ManagementFactory-based resolution must succeed
+    // (and must NOT use ProcessHandle, a Java 9+ API that breaks the agent on Java 8).
+    long pid = ProcessUtils.currentPid();
+    assertTrue(pid > 0, "expected a positive pid, got " + pid);
+  }
+
+  @Test
+  void repeatBuildsTheExpectedString() {
+    assertEquals("===", ProcessUtils.repeat("=", 3));
+    assertEquals("abab", ProcessUtils.repeat("ab", 2));
+  }
+
+  @Test
+  void repeatHandlesZeroNegativeAndEmpty() {
+    assertEquals("", ProcessUtils.repeat("=", 0));
+    assertEquals("", ProcessUtils.repeat("=", -5));
+    assertEquals("", ProcessUtils.repeat("", 10));
+  }
+}

--- a/serviceevents-bootstrap-bridge/build.gradle.kts
+++ b/serviceevents-bootstrap-bridge/build.gradle.kts
@@ -24,6 +24,14 @@ java {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+// This bridge is loaded by the bootstrap classloader and must run on Java 8+. source/target
+// compatibility only controls the bytecode version, not the API surface — pin the release flag so a
+// Java 9+ JDK API reference (e.g. ProcessHandle, String.repeat) fails the build instead of throwing
+// NoClassDefFoundError/NoSuchMethodError at runtime on Java 8.
+tasks.named<JavaCompile>("compileJava") {
+  options.release.set(8)
+}
+
 // This module should have NO dependencies - it goes into bootstrap classloader
 dependencies {
   // No dependencies allowed!


### PR DESCRIPTION
## Problem

The Application Signals E2E **Java 8** jobs (`default-v8-amd64`, `eks-v8-amd64`) fail every validator (EMF logs, metrics, traces) because the **entire OpenTelemetry javaagent fails to start** on Java 8:

```
OpenTelemetry Javaagent failed to start
java.util.ServiceConfigurationError: ... ServiceEventsInstrumentationModule could not be instantiated
Caused by: java.lang.NoClassDefFoundError: java/lang/ProcessHandle
    at ...serviceevents.collectors.DeploymentEventCollector.<init>(DeploymentEventCollector.java:92)
    at ...serviceevents.ServiceEventsInstrumentation.initialize(...)
    at ...serviceevents.ServiceEventsInstrumentationModule.<clinit>(...)
```

ServiceEvents calls **`ProcessHandle.current().pid()`** (a **Java 9+** API) in its collector constructors, which run at agent init. On Java 8 this throws `NoClassDefFoundError` — an `Error`, not an `Exception` — so it escapes the `catch (Exception)` guards and propagates as a fatal `ServiceConfigurationError` during SPI instantiation. The agent never attaches, so no telemetry is produced and all validators see empty results.

A second latent break: **`String.repeat(int)`** (a **Java 11+** API) is used on the production console-export path; it would throw `NoSuchMethodError` on Java 8 as well.

### Why it compiled but failed at runtime

The build sets `source/targetCompatibility = 8`, which only controls the emitted **bytecode version**, not the **API surface**. Java 9+ JDK API references compile cleanly and then fail at runtime on a real Java 8 JVM. Only the `--release` flag cross-checks against the target JDK API.

## Fix

- Add `ProcessUtils` with Java 8-safe `currentPid()` (parses the `ManagementFactory` runtime name `"<pid>@<host>"`) and `repeat(String, int)`, and repoint all call sites.
- Pin **`options.release = 8`** on the `serviceevents` and `serviceevents-bootstrap-bridge` compile tasks so any future Java 9+ JDK API reference **fails the build** instead of shipping. This guard is what surfaced the `String.repeat` usages.

## Verification

- Rebuilt the agent and ran it with `OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true` on **Corretto 8, 11, 17, 21, 25**:
  - Before: Java 8 → "OpenTelemetry Javaagent failed to start" (reproduced the exact stack trace).
  - After: Java 8 starts cleanly and ServiceEvents **fully initializes** (DeploymentEventCollector, FunctionCallCollector, EndpointMetricCollector, FunctionMetricsBridge all start); 11/17/21/25 unaffected.
- `:serviceevents-bootstrap-bridge:build` and `:instrumentation:serviceevents:build` pass (unit tests + spotless). Added `ProcessUtilsTest`.

## Scope

This fixes the **Java 8** failures only. The Java 25 E2E failure is a separate, still-open issue (the agent already starts cleanly on Java 25) and is not addressed here.