### PR TITLE
fix: exclude DI's bundled ASM so instrumentation works on Java 25

### DIFF
--- a/otelagent/build.gradle.kts
+++ b/otelagent/build.gradle.kts
@@ -42,6 +42,16 @@ val javaagentLibs by configurations.creating {
   exclude("io.opentelemetry", "opentelemetry-sdk-common")
   exclude("io.opentelemetry.semconv", "opentelemetry-semconv")
   exclude("io.opentelemetry", "opentelemetry-api-incubator")
+
+  // Dynamic Instrumentation (in :awsagentprovider) declares org.ow2.asm:asm for its line-level
+  // instrumentation transformer. We must NOT bundle that copy: it lands at inst/org/objectweb/asm
+  // and collides with the ASM the upstream OpenTelemetry javaagent already ships there. The pulled
+  // version (9.7) only understands class-file versions up to Java 24 (v68), so on Java 25 (v69) its
+  // ClassReader throws "Unsupported class file major version 69" for EVERY class ByteBuddy tries to
+  // match — silently disabling ALL instrumentation (no spans/metrics). Excluding it makes DI's
+  // plain `org.objectweb.asm.*` references resolve to the agent's own (newer, v69-capable) ASM,
+  // which lives in the same inst/org/objectweb/asm namespace.
+  exclude("org.ow2.asm")
 }
 
 val shadowClasspath by configurations.creating {


### PR DESCRIPTION
## Description

The Application Signals **E2E Java 25** jobs fail every validator (EMF logs, metrics, traces) because the agent produces **no telemetry at all** on Java 25. Java 11/17/21/24 are unaffected.

### Root cause

The Dynamic Instrumentation feature (#1384) added `org.ow2.asm:asm:9.7` / `asm-tree:9.7` to `:awsagentprovider` for its line-level instrumentation transformer. `:awsagentprovider` relocates ASM in its **own** shadowJar, but `:otelagent` consumes it via the `javaagentLibs` configuration (the plain jar + transitive deps), so the **un-relocated** `org.objectweb.asm` 9.7 classes get bundled into the agent jar at `inst/org/objectweb/asm` — the same namespace where the upstream OpenTelemetry javaagent already ships its own (newer) ASM. The agent jar ends up with **two copies of every ASM class** (two `inst/org/objectweb/asm/ClassReader.classdata` entries: 45818 bytes for the agent's ASM, 45545 bytes for the bundled 9.7).

ASM 9.7 only understands class-file versions up to Java 24 (v68). On Java 25 (v69) its `ClassReader` throws `IllegalArgumentException: Unsupported class file major version 69` for every class ByteBuddy tries to match, which **silently disables ALL instrumentation** — no spans, no App Signals metrics. Java 24 and below are within 9.7's range, which is why only Java 25 regressed.

### Fix

Exclude `org.ow2.asm` from the `otelagent` `javaagentLibs` configuration. DI's plain `org.objectweb.asm.*` references then resolve to the agent's own v69-capable ASM (same `inst/org/objectweb/asm` namespace), and the duplicate is gone. This also keeps DI's ASM in lockstep with the upstream agent's ASM as new JDKs land.

## Testing

Locally built the agent (`:otelagent:shadowJar`) and ran a small app (JDK `HttpServer` + an outbound `HttpURLConnection` call, which forces ByteBuddy/ASM class transformation) under the agent with the logging exporters, App Signals enabled, and DI enabled.

**Jar packaging:**
- Pre-fix jar: **two** `inst/org/objectweb/asm/ClassReader.classdata` entries (45818 + 45545 bytes).
- Fixed jar: **one** entry (45818), no duplicate `inst/org/objectweb/asm/*` paths.

**Negative control (pre-fix agent, Java 25):** 3340 × `IllegalArgumentException: Unsupported class file major version 69` from `org.objectweb.asm.ClassReader.<init>` → **0 spans, 0 HTTP metrics** emitted (app itself ran fine — telemetry silently dropped).

**Fixed agent (app compiled for Java 11, run across the JDK matrix):**

| JDK | SERVER+CLIENT spans | HTTP duration metrics | v69 errors | DI init |
|---|---|---|---|---|
| 25 | ✅ 2 | ✅ 2 | 0 | ✅ initialized |
| 21 | ✅ 2 | ✅ 2 | 0 | ✅ initialized |
| 17 | ✅ 2 | ✅ 2 | 0 | ✅ initialized |
| 11 | ✅ 2 | ✅ 2 | 0 | ✅ initialized |

Logs path also confirmed on Java 25 (`otlp.exporter.seen{type="log"}` exported; ServiceEvents OTLP logs endpoint wired). Dynamic Instrumentation logged `AWS DI: Manager initialized successfully` and shut down cleanly on every JDK.

CI / Application Signals E2E across the Java matrix will provide the final cross-environment confirmation.
