### PR TITLE
fix: remove EOL aws sdk v1 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   match the Python and JS SDKs (was pipe-separated). Routes containing a literal comma must now be
   matched with a glob, e.g. `GET /search*:750`.
   ([#1393](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1393))
+- fix: remove EOL AWS SDK v1 dependency for ARN parsing
+  ([#1401](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1401))
 
 ## v2.28.1 - 2026-05-26
 

--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -51,8 +51,8 @@ dependencies {
   // ASM for line-level instrumentation (relocated/shaded at build time)
   implementation("org.ow2.asm:asm:9.7")
   implementation("org.ow2.asm:asm-tree:9.7")
-  // Import AWS SDK v1 core for ARN parsing utilities
-  implementation("com.amazonaws:aws-java-sdk-core:1.12.773")
+  // ARN parsing utilities (replaces EOL aws-java-sdk-core dependency)
+  implementation("software.amazon.awssdk:arns")
   // Export configuration
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
   // For Udp emitter

--- a/awsagentprovider/build.gradle.kts
+++ b/awsagentprovider/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
   // ASM for line-level instrumentation (relocated/shaded at build time)
   implementation("org.ow2.asm:asm:9.7")
   implementation("org.ow2.asm:asm-tree:9.7")
-  // ARN parsing utilities (replaces EOL aws-java-sdk-core dependency)
+  // ARN parsing utilities
   implementation("software.amazon.awssdk:arns")
   // Export configuration
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -110,7 +110,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.ExceptionEventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import software.amazon.awssdk.arns.Arn;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -125,6 +124,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import javax.annotation.Nullable;
+import software.amazon.awssdk.arns.Arn;
 
 /**
  * AwsMetricAttributeGenerator generates very specific metric attributes based on low-cardinality
@@ -707,7 +707,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getKinesisStreamNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
+      return Optional.of(getResourceName(resourceArn.resourceAsString()));
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Kinesis stream name from ARN: %s", stringArn));
@@ -718,7 +718,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getDynamodbTableNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
+      return Optional.of(getResourceName(resourceArn.resourceAsString()));
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse DynamoDB table name from ARN: %s", stringArn));
@@ -730,7 +730,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     try {
       if (stringArn.isPresent() && stringArn.get().startsWith("arn:aws:lambda:")) {
         Arn resourceArn = Arn.fromString(stringArn.get());
-        return Optional.of(resourceArn.resourceAsString().split(":")[1]);
+        return Optional.of(getResourceName(resourceArn.resourceAsString()));
       }
     } catch (IllegalArgumentException e) {
       logger.log(
@@ -743,7 +743,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSecretsManagerResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
+      return Optional.of(getResourceName(resourceArn.resourceAsString()));
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE,
@@ -755,7 +755,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSfnResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
+      return Optional.of(getResourceName(resourceArn.resourceAsString()));
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Sfn resource name from ARN: %s", stringArn));
@@ -772,6 +772,28 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
           Level.FINE, String.format("Could not parse Sfn resource name from ARN: %s", stringArn));
     }
     return Optional.empty();
+  }
+
+  /**
+   * Extracts the resource name from the resource portion of an ARN. ARN resources can use either
+   * ':' or '/' as a separator between resource type and resource name (e.g.,
+   * "stream/my-stream-name" or "stateMachine:my-state-machine"). This method splits on the first
+   * occurrence of either separator and returns the name portion.
+   */
+  private static String getResourceName(String resource) {
+    int colonIdx = resource.indexOf(':');
+    int slashIdx = resource.indexOf('/');
+    int separatorIdx;
+    if (colonIdx < 0 && slashIdx < 0) {
+      return resource;
+    } else if (colonIdx < 0) {
+      separatorIdx = slashIdx;
+    } else if (slashIdx < 0) {
+      separatorIdx = colonIdx;
+    } else {
+      separatorIdx = Math.min(colonIdx, slashIdx);
+    }
+    return resource.substring(separatorIdx + 1);
   }
 
   /**

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -102,7 +102,6 @@ import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessin
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresent;
 import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresentWithFallback;
 
-import com.amazonaws.arn.Arn;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -111,6 +110,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.ExceptionEventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import software.amazon.awssdk.arns.Arn;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -684,8 +684,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
           String stringArn = escapeDelimiters(span.getAttributes().get(attributeKey));
           try {
             Arn resourceArn = Arn.fromString(stringArn);
-            remoteResourceAccountId = Optional.of(resourceArn.getAccountId());
-            remoteResourceRegion = Optional.of(resourceArn.getRegion());
+            remoteResourceAccountId = resourceArn.accountId();
+            remoteResourceRegion = resourceArn.region();
           } catch (IllegalArgumentException e) {
             logger.log(
                 Level.FINE,
@@ -707,7 +707,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getKinesisStreamNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.getResource().toString().split(":")[1]);
+      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Kinesis stream name from ARN: %s", stringArn));
@@ -718,7 +718,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getDynamodbTableNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.getResource().toString().split(":")[1]);
+      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse DynamoDB table name from ARN: %s", stringArn));
@@ -730,7 +730,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     try {
       if (stringArn.isPresent() && stringArn.get().startsWith("arn:aws:lambda:")) {
         Arn resourceArn = Arn.fromString(stringArn.get());
-        return Optional.of(resourceArn.getResource().toString().split(":")[1]);
+        return Optional.of(resourceArn.resourceAsString().split(":")[1]);
       }
     } catch (IllegalArgumentException e) {
       logger.log(
@@ -743,7 +743,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSecretsManagerResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.getResource().toString().split(":")[1]);
+      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE,
@@ -755,7 +755,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSfnResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.getResource().toString().split(":")[1]);
+      return Optional.of(resourceArn.resourceAsString().split(":")[1]);
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Sfn resource name from ARN: %s", stringArn));
@@ -766,7 +766,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSnsResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.getResource().toString());
+      return Optional.of(resourceArn.resourceAsString());
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Sfn resource name from ARN: %s", stringArn));

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -707,7 +707,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getKinesisStreamNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(getResourceName(resourceArn.resourceAsString()));
+      return Optional.of(resourceArn.resource().resource());
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Kinesis stream name from ARN: %s", stringArn));
@@ -718,7 +718,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getDynamodbTableNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(getResourceName(resourceArn.resourceAsString()));
+      return Optional.of(resourceArn.resource().resource());
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse DynamoDB table name from ARN: %s", stringArn));
@@ -730,7 +730,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     try {
       if (stringArn.isPresent() && stringArn.get().startsWith("arn:aws:lambda:")) {
         Arn resourceArn = Arn.fromString(stringArn.get());
-        return Optional.of(getResourceName(resourceArn.resourceAsString()));
+        return Optional.of(resourceArn.resource().resource());
       }
     } catch (IllegalArgumentException e) {
       logger.log(
@@ -743,7 +743,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSecretsManagerResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(getResourceName(resourceArn.resourceAsString()));
+      return Optional.of(resourceArn.resource().resource());
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE,
@@ -755,7 +755,7 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSfnResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(getResourceName(resourceArn.resourceAsString()));
+      return Optional.of(resourceArn.resource().resource());
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Sfn resource name from ARN: %s", stringArn));
@@ -766,34 +766,12 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
   private static Optional<String> getSnsResourceNameFromArn(Optional<String> stringArn) {
     try {
       Arn resourceArn = Arn.fromString(stringArn.get());
-      return Optional.of(resourceArn.resourceAsString());
+      return Optional.of(resourceArn.resource().resource());
     } catch (IllegalArgumentException e) {
       logger.log(
           Level.FINE, String.format("Could not parse Sfn resource name from ARN: %s", stringArn));
     }
     return Optional.empty();
-  }
-
-  /**
-   * Extracts the resource name from the resource portion of an ARN. ARN resources can use either
-   * ':' or '/' as a separator between resource type and resource name (e.g.,
-   * "stream/my-stream-name" or "stateMachine:my-state-machine"). This method splits on the first
-   * occurrence of either separator and returns the name portion.
-   */
-  private static String getResourceName(String resource) {
-    int colonIdx = resource.indexOf(':');
-    int slashIdx = resource.indexOf('/');
-    int separatorIdx;
-    if (colonIdx < 0 && slashIdx < 0) {
-      return resource;
-    } else if (colonIdx < 0) {
-      separatorIdx = slashIdx;
-    } else if (slashIdx < 0) {
-      separatorIdx = colonIdx;
-    } else {
-      separatorIdx = Math.min(colonIdx, slashIdx);
-    }
-    return resource.substring(separatorIdx + 1);
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our AppSignals attribute generator uses an AWS SDK v1 dependency to parse resource name from ARNs. This package has been EOL since 2025-12-31. This PR replaces it with the AWS SDK V2 dependency and updates the impacted method calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
