### PR TITLE
cherry-pick main to release/2.28.x

### DIFF
--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/DynamicInstrumentationManager.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/DynamicInstrumentationManager.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.resources.Resource;
 import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -210,6 +211,10 @@ public final class DynamicInstrumentationManager {
     int registered = 0;
     int skipped = 0;
 
+    // Configs accepted into the registry — diagnosed for binding errors after the transformer is
+    // rebuilt, so a non-bindable target reports ERROR instead of a misleading READY.
+    List<InstrumentationConfiguration> registeredConfigs = new ArrayList<>();
+
     // Register all configurations in registry
     for (InstrumentationConfiguration config : configurations) {
       // Reject constructors and static initializers — ByteBuddy Advice cannot instrument them
@@ -276,6 +281,7 @@ public final class DynamicInstrumentationManager {
           config.getExpiresAt() != null ? config.getExpiresAt().toEpochMilli() : 0L);
 
       registered++;
+      registeredConfigs.add(config);
 
       logger.log(
           Level.FINE,
@@ -292,8 +298,25 @@ public final class DynamicInstrumentationManager {
     try {
       engine.rebuildAndApplyTransformer();
 
-      // Report READY status immediately after applying configurations
+      // Diagnose non-bindable targets BEFORE reporting READY, so a config whose method does not
+      // exist on the (loaded) target class, or whose class is not modifiable, is reported as ERROR
+      // rather than a misleading READY. Inheritance-aware and conservative: a not-yet-loaded class
+      // is left untouched (it may bind when it loads). Must precede reportNow() because the status
+      // reporter suppresses READY for any locationHash already reported as ERROR.
       if (statusReporter != null) {
+        for (InstrumentationConfiguration config : registeredConfigs) {
+          ErrorCause cause = engine.diagnoseBindingError(config);
+          if (cause != null) {
+            logger.log(
+                Level.WARNING,
+                "AWS DI: Target {0}.{1} cannot bind ({2}); reporting ERROR",
+                new Object[] {config.getFullyQualifiedClassName(), config.getMethodName(), cause});
+            statusReporter.reportError(
+                config.getInstrumentationType().name(), config.getLocationHash(), cause);
+          }
+        }
+
+        // Report READY status immediately after applying configurations
         statusReporter.reportNow();
       }
     } catch (Exception e) {
@@ -331,8 +354,15 @@ public final class DynamicInstrumentationManager {
     // Remove from registry
     int removed = 0;
     for (String methodKey : methodKeys) {
-      if (InstrumentationRegistry.remove(methodKey) != null) {
+      InstrumentationConfiguration removedConfig = InstrumentationRegistry.remove(methodKey);
+      if (removedConfig != null) {
         DIDataStore.removeConfig(methodKey);
+        // Clear the status reporter's one-time-report bookkeeping for this location hash, so a
+        // later re-applied config with the same hash (e.g. a now-bindable target) is not kept
+        // permanently suppressed by a prior ERROR.
+        if (statusReporter != null) {
+          statusReporter.forget(removedConfig.getLocationHash());
+        }
         removed++;
       }
     }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/StatusReporter.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/StatusReporter.java
@@ -58,6 +58,11 @@ public class StatusReporter {
   // Track reported configurations to avoid duplicate reports for one-time statuses
   private final Set<String> reportedConfigs = ConcurrentHashMap.newKeySet();
 
+  // LocationHashes already reported as ERROR. A config that failed to bind (e.g. its method does
+  // not exist on the target class, or the class is not modifiable) must NOT subsequently be
+  // reported as READY — otherwise the control plane shows a healthy breakpoint that can never fire.
+  private final Set<String> erroredLocationHashes = ConcurrentHashMap.newKeySet();
+
   // Background thread for periodic reporting
   private final ScheduledExecutorService scheduler =
       Executors.newSingleThreadScheduledExecutor(
@@ -128,6 +133,8 @@ public class StatusReporter {
    */
   public void reportError(String instrumentationType, String locationHash, ErrorCause cause) {
     String errorKey = getConfigKey(locationHash, ConfigurationStatus.ERROR);
+    // Mark this config as errored so a later periodic/initial sweep won't promote it to READY.
+    erroredLocationHashes.add(locationHash);
     if (reportedConfigs.add(errorKey)) {
       // First time reporting this error
       logger.log(
@@ -139,6 +146,24 @@ public class StatusReporter {
               instrumentationType, locationHash, ConfigurationStatus.ERROR, cause, Instant.now());
       sendReport(List.of(entry));
     }
+  }
+
+  /**
+   * Forget all one-time-report bookkeeping for a location hash. Called when its configuration is
+   * removed, so that a later re-applied configuration with the same location hash (e.g. a target
+   * that has since become bindable) can report READY again instead of staying permanently
+   * suppressed by a prior ERROR.
+   *
+   * @param locationHash Location hash of the removed configuration
+   */
+  public void forget(String locationHash) {
+    if (locationHash == null) {
+      return;
+    }
+    erroredLocationHashes.remove(locationHash);
+    reportedConfigs.remove(getConfigKey(locationHash, ConfigurationStatus.READY));
+    reportedConfigs.remove(getConfigKey(locationHash, ConfigurationStatus.ERROR));
+    reportedConfigs.remove(getConfigKey(locationHash, ConfigurationStatus.DISABLED));
   }
 
   /** Background loop for periodic status reporting. */
@@ -224,8 +249,10 @@ public class StatusReporter {
         logger.fine("Reporting ACTIVE status for: " + locationHash);
       }
 
-      // READY: Report once (initial reports only, hitCount==0, and NOT disabled)
-      if (hitCount == 0 && isInitialReport) {
+      // READY: Report once (initial reports only, hitCount==0, NOT disabled, and NOT already
+      // errored). Suppressing READY for an errored config keeps a non-bindable target (ghost
+      // method, unmodifiable class) from appearing healthy in the control plane.
+      if (hitCount == 0 && isInitialReport && !erroredLocationHashes.contains(locationHash)) {
         String readyKey = getConfigKey(locationHash, ConfigurationStatus.READY);
         if (reportedConfigs.add(readyKey)) {
           entries.add(

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/ByteBuddyInstrumentationEngine.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/ByteBuddyInstrumentationEngine.java
@@ -36,6 +36,7 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.utility.JavaModule;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.instrumentation.advice.MethodCaptureAdvice;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.CaptureConfiguration;
+import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.ErrorCause;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.InstrumentationConfiguration;
 
 /**
@@ -172,7 +173,13 @@ public class ByteBuddyInstrumentationEngine {
     }
     lineTransformers.clear();
 
-    // Get all classes with line-level instrumentations
+    // Get all classes with line-level instrumentations.
+    // NOTE: line-level transformers are keyed by the config's fully-qualified name
+    // (codeUnit.className). A nested class addressed by its SIMPLE name (className="Inner") is
+    // handled at the function level via matchesRuntimeClass, but the LINE-level path here still
+    // keys on the dotted FQN and so does not yet bind a line breakpoint on a nested class given
+    // only its simple name. Function-level breakpoints on such classes work; line-level on
+    // nested-simple-name targets remains a known gap (tracked separately).
     java.util.Map<String, List<InstrumentationConfiguration>> classToLineConfigs =
         new java.util.HashMap<>();
 
@@ -356,6 +363,27 @@ public class ByteBuddyInstrumentationEngine {
       }
     }
 
+    // A config may name a NESTED class by its simple name (e.g. ClassName="Inner"), whose dotted
+    // FQN "com.pkg.Inner" never equals the runtime binary name "com.pkg.Outer$Inner", so the
+    // exact-name lookup above misses it and the class is never retransformed -> the breakpoint
+    // silently never fires. Additionally scan loaded classes for binary names ('$') that a
+    // registered config matches as a nested simple-name target.
+    List<InstrumentationConfiguration> configs = InstrumentationRegistry.getAllConfigurations();
+    if (!configs.isEmpty()) {
+      for (Class<?> clazz : instrumentation.getAllLoadedClasses()) {
+        String binaryName = clazz.getName();
+        if (binaryName.indexOf('$') < 0) {
+          continue; // not a nested class; exact-name pass already handled it
+        }
+        for (InstrumentationConfiguration cfg : configs) {
+          if (cfg.matchesRuntimeClass(binaryName)) {
+            loadedClasses.add(clazz);
+            break;
+          }
+        }
+      }
+    }
+
     return loadedClasses;
   }
 
@@ -426,6 +454,109 @@ public class ByteBuddyInstrumentationEngine {
       }
     }
     return null;
+  }
+
+  /**
+   * Diagnoses whether a config's target method can possibly bind on its (loaded) target class, so a
+   * non-bindable target can be reported as ERROR instead of being silently reported READY (a
+   * breakpoint that can never fire). Inheritance-aware: a method inherited from a superclass or
+   * interface counts as present (it binds on the declaring type), so legitimate inherited-method
+   * targets are NOT flagged.
+   *
+   * <p>Conservative by design — only returns a cause when we can prove the target is non-bindable:
+   *
+   * <ul>
+   *   <li>{@link ErrorCause#RUNTIME_ERROR} — the class is loaded but the JVM cannot retransform it
+   *       (e.g. a bootstrap/JDK class). Reused rather than a new cause to keep the control-plane
+   *       status contract stable.
+   *   <li>{@link ErrorCause#METHOD_NOT_FOUND} — the class is loaded and modifiable, but no method
+   *       of that name exists anywhere in its type hierarchy (a "ghost" method).
+   *   <li>{@code null} — bindable, or the class is not yet loaded (cannot conclude; it may load and
+   *       bind later, so we must not false-error it).
+   * </ul>
+   *
+   * @param config The configuration to diagnose
+   * @return The error cause if the target is provably non-bindable, otherwise {@code null}
+   */
+  public ErrorCause diagnoseBindingError(InstrumentationConfiguration config) {
+    Class<?> target = findTargetClass(config);
+    if (target == null) {
+      return null; // Class not loaded yet — can't conclude; will (re)transform if/when it loads.
+    }
+    if (!instrumentation.isModifiableClass(target)) {
+      return ErrorCause.RUNTIME_ERROR;
+    }
+    if (!methodExistsInHierarchy(target, config.getMethodName())) {
+      return ErrorCause.METHOD_NOT_FOUND;
+    }
+    return null;
+  }
+
+  /**
+   * Finds the loaded class a config targets, honoring nested-class-by-simple-name matching (the
+   * runtime binary name carries '$', the config supplies only the simple name).
+   */
+  private Class<?> findTargetClass(InstrumentationConfiguration config) {
+    Class<?> exact = findLoadedClass(config.getFullyQualifiedClassName());
+    if (exact != null) {
+      return exact;
+    }
+    for (Class<?> clazz : instrumentation.getAllLoadedClasses()) {
+      String binaryName = clazz.getName();
+      if (binaryName.indexOf('$') >= 0 && config.matchesRuntimeClass(binaryName)) {
+        return clazz;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Whether a CONCRETE (non-abstract, non-native) method of the given name is declared on the class
+   * or any of its superclasses or (transitively) implemented interfaces. Walks declared methods
+   * (not just public) so private and package-private targets are recognized too.
+   *
+   * <p>Concreteness matters: ByteBuddy {@code Advice} cannot weave into abstract or native methods
+   * (no bytecode body), so a name that resolves only to abstract/native declarations (e.g. the
+   * target is an interface, or an abstract method never overridden by a concrete type) is NOT
+   * bindable and should be treated as non-existent for diagnosis purposes. If introspection is
+   * inconclusive (reflection throws) we return {@code true} to stay conservative and avoid a false
+   * ERROR.
+   */
+  private static boolean methodExistsInHierarchy(Class<?> clazz, String methodName) {
+    Set<Class<?>> visited = new HashSet<>();
+    java.util.ArrayDeque<Class<?>> queue = new java.util.ArrayDeque<>();
+    queue.add(clazz);
+    while (!queue.isEmpty()) {
+      Class<?> current = queue.poll();
+      if (current == null || !visited.add(current)) {
+        continue;
+      }
+      try {
+        for (java.lang.reflect.Method m : current.getDeclaredMethods()) {
+          if (m.getName().equals(methodName)) {
+            int mods = m.getModifiers();
+            if (!java.lang.reflect.Modifier.isAbstract(mods)
+                && !java.lang.reflect.Modifier.isNative(mods)) {
+              return true; // a concrete declaration exists -> bindable
+            }
+            // abstract/native match: not bindable on its own; keep scanning for a concrete one.
+          }
+        }
+      } catch (Throwable t) {
+        // getDeclaredMethods can throw (e.g. NoClassDefFoundError resolving a parameter type).
+        // Inconclusive for this type — stay conservative: treat the target as bindable so we
+        // don't emit a false ERROR for a target we simply couldn't introspect.
+        logger.log(Level.FINE, "Could not introspect methods of " + current.getName(), t);
+        return true;
+      }
+      if (current.getSuperclass() != null) {
+        queue.add(current.getSuperclass());
+      }
+      for (Class<?> iface : current.getInterfaces()) {
+        queue.add(iface);
+      }
+    }
+    return false;
   }
 
   /**
@@ -575,6 +706,120 @@ public class ByteBuddyInstrumentationEngine {
           "No parameter names available for {0}; advice will fall back to argN",
           methodKey);
     }
+
+    // Additionally register per-OVERLOAD parameter names keyed by full signature, so an
+    // overloaded method captures each overload's own argument names at runtime instead of the
+    // first-declared overload's (the per-methodKey map above can only hold one overload's names).
+    registerParameterNamesPerOverload(
+        typeDescription, classLoader, className, methodName, methodKey);
+  }
+
+  /**
+   * For each overload of {@code methodName}, register its parameter names under the signature key
+   * "&lt;methodKey&gt;(&lt;Advice.Origin arg list&gt;)" so {@code MethodCaptureAdvice} can resolve
+   * the EXECUTING overload's names from {@code @Advice.Origin} at runtime. Best-effort: any failure
+   * leaves the single-list fallback in place.
+   */
+  private void registerParameterNamesPerOverload(
+      net.bytebuddy.description.type.TypeDescription suppliedType,
+      ClassLoader classLoader,
+      String className,
+      String methodName,
+      String methodKey) {
+    try {
+      // Prefer the byte-based type (deterministic MethodParameters), fall back to supplied type.
+      net.bytebuddy.description.type.TypeDescription typeDescription = null;
+      try {
+        ClassFileLocator locator =
+            classLoader != null
+                ? ClassFileLocator.ForClassLoader.of(classLoader)
+                : ClassFileLocator.ForClassLoader.ofBootLoader();
+        net.bytebuddy.pool.TypePool pool =
+            new net.bytebuddy.pool.TypePool.Default(
+                net.bytebuddy.pool.TypePool.CacheProvider.NoOp.INSTANCE,
+                locator,
+                net.bytebuddy.pool.TypePool.Default.ReaderMode.EXTENDED);
+        net.bytebuddy.pool.TypePool.Resolution resolution = pool.describe(className);
+        if (resolution.isResolved()) {
+          typeDescription = resolution.resolve();
+        }
+      } catch (Throwable ignored) {
+        // fall through to supplied type
+      }
+      if (typeDescription == null) {
+        typeDescription = suppliedType;
+      }
+      if (typeDescription == null) {
+        return;
+      }
+
+      for (net.bytebuddy.description.method.MethodDescription method :
+          typeDescription.getDeclaredMethods().filter(named(methodName))) {
+        net.bytebuddy.description.method.ParameterList<?> params = method.getParameters();
+        if (params.isEmpty()) {
+          continue;
+        }
+        String[] names = new String[params.size()];
+        boolean anyNamed = false;
+        for (int i = 0; i < params.size(); i++) {
+          if (params.get(i).isNamed()) {
+            names[i] = params.get(i).getName();
+            anyNamed = true;
+          } else {
+            names[i] = "";
+          }
+        }
+        if (!anyNamed) {
+          continue;
+        }
+        // The signature key uses MethodDescription.toString(), which is exactly the string
+        // ByteBuddy renders for @Advice.Origin (default) for this overload at runtime.
+        String signatureKey = methodKey + signatureSuffix(method);
+        software.amazon.opentelemetry.javaagent.bootstrap.di.DIDataStore
+            .registerParameterNamesForSignature(signatureKey, names);
+        logger.log(
+            Level.FINE,
+            "Resolved per-overload parameter names for {0}: {1}",
+            new Object[] {signatureKey, java.util.Arrays.toString(names)});
+      }
+    } catch (Throwable t) {
+      logger.log(
+          Level.FINE,
+          "Could not register per-overload parameter names for {0}.{1}: {2}",
+          new Object[] {className, methodName, t.toString()});
+    }
+  }
+
+  /**
+   * Builds the "(paramType1,paramType2)" suffix matching the argument list ByteBuddy's
+   * {@code @Advice.Origin} renders for this method (comma separated, no spaces), so the
+   * registration-time key matches the runtime key derived from the Origin string.
+   *
+   * <p>Uses {@code getActualName()} (the source-style rendering, e.g. {@code java.lang.String[]},
+   * {@code int[]}) rather than {@code getName()} (the JVM descriptor-style {@code
+   * [Ljava.lang.String;}, {@code [I}). {@code @Advice.Origin}'s default value is {@code
+   * MethodDescription.toString()}, which renders parameter types via the source-style name — so for
+   * ARRAY parameters the two disagree and the per-overload key would never match, silently falling
+   * back to the wrong overload's parameter names.
+   *
+   * <p>This matches {@code @Advice.Origin} for ordinary (including array) parameter types. For a
+   * method with a type-variable parameter (e.g. {@code <T> void foo(T t)}), {@code asErasure()}
+   * here yields the erased upper bound (e.g. {@code java.lang.Object}) while {@code
+   * MethodDescription.toString()} on the generic declaration renders the type variable name ({@code
+   * T}); the keys then differ and the per-signature lookup simply misses, falling back to the
+   * shared method-level names (no mis-capture, just no per-overload disambiguation for that rare
+   * case).
+   */
+  static String signatureSuffix(net.bytebuddy.description.method.MethodDescription method) {
+    StringBuilder sb = new StringBuilder("(");
+    net.bytebuddy.description.method.ParameterList<?> params = method.getParameters();
+    for (int i = 0; i < params.size(); i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(params.get(i).getType().asErasure().getActualName());
+    }
+    return sb.append(')').toString();
   }
 
   /**

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationGrouper.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationGrouper.java
@@ -118,7 +118,9 @@ public final class InstrumentationGrouper {
 
     for (InstrumentationConfiguration config : configs) {
       try {
-        if (config != null && config.getFullyQualifiedClassName().equals(className)) {
+        // Match exact FQN or a nested class addressed by simple name (binary `className` here is
+        // the runtime name, e.g. com.pkg.Outer$Inner). matchesRuntimeClass handles both.
+        if (config != null && config.matchesRuntimeClass(className)) {
           String functionKey = config.getFullyQualifiedClassName() + "." + config.getMethodName();
 
           FunctionInstrumentationSet funcSet = grouped.get(functionKey);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistry.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/InstrumentationRegistry.java
@@ -129,7 +129,22 @@ public final class InstrumentationRegistry {
    * @return The configuration, or null if not found
    */
   public static InstrumentationConfiguration get(String methodKey) {
-    return configurations.get(methodKey);
+    InstrumentationConfiguration exact = configurations.get(methodKey);
+    if (exact != null) {
+      return exact;
+    }
+    // Fall back to a runtime-key match so a capture from a nested class addressed by its SIMPLE
+    // name (runtime key carries the binary name Outer$Inner, configs are keyed by the simple FQN)
+    // still resolves to its configuration instead of being silently dropped. Only the
+    // nested-class case (key contains '$') incurs this scan; exact lookups are unaffected.
+    if (methodKey != null && methodKey.indexOf('$') >= 0) {
+      for (InstrumentationConfiguration config : configurations.values()) {
+        if (config.matchesRuntimeInstrumentationKey(methodKey)) {
+          return config;
+        }
+      }
+    }
+    return null;
   }
 
   /**
@@ -169,8 +184,11 @@ public final class InstrumentationRegistry {
    * @return List of configurations for the class (empty if none)
    */
   public static List<InstrumentationConfiguration> getConfigsForClass(String className) {
+    // Matches exact fully-qualified name, and also a nested class addressed by its simple name
+    // when {@code className} is the runtime binary name (e.g. com.pkg.Outer$Inner). The exact-FQN
+    // path is unchanged; the nested-name path only activates for names containing '$'.
     return configurations.values().stream()
-        .filter(config -> config.getFullyQualifiedClassName().equals(className))
+        .filter(config -> config.matchesRuntimeClass(className))
         .collect(Collectors.toList());
   }
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/advice/MethodCaptureAdvice.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/advice/MethodCaptureAdvice.java
@@ -63,7 +63,14 @@ public class MethodCaptureAdvice {
       Map<String, Object> arguments = null;
       if (captureArgsFilter != null && args != null && args.length > 0) {
         arguments = new HashMap<>();
-        String[] paramNames = DIDataStore.getParameterNames(methodKey);
+        // Prefer parameter names for the SPECIFIC executing overload (keyed by the full
+        // signature from @Advice.Origin); fall back to the per-methodKey names for
+        // non-overloaded methods or when per-overload resolution was unavailable. Without this,
+        // every overload would be labeled with the first-declared overload's parameter names.
+        String[] paramNames = DIDataStore.getParameterNamesForSignature(signatureKey(method));
+        if (paramNames == null) {
+          paramNames = DIDataStore.getParameterNames(methodKey);
+        }
         for (int i = 0; i < args.length; i++) {
           String name =
               (paramNames != null
@@ -198,5 +205,23 @@ public class MethodCaptureAdvice {
 
     // Extract "com.example.Class.method"
     return origin.substring(lastSpace + 1, openParen);
+  }
+
+  /**
+   * Builds the per-overload signature key "&lt;methodKey&gt;(&lt;param types&gt;)" from an
+   * {@code @Advice.Origin} string, matching the key the engine registered for this overload. This
+   * disambiguates overloaded methods so each captures its OWN parameter names. Returns the bare
+   * methodKey if the origin has no parameter list (then per-signature lookup simply misses and the
+   * caller falls back to the shared names).
+   */
+  public static String signatureKey(String origin) {
+    int openParen = origin.indexOf('(');
+    if (openParen < 0) {
+      return extractMethodKey(origin);
+    }
+    // "com.example.Class.method" + "(param,types)" — the substring from '(' to the matching ')'.
+    int closeParen = origin.indexOf(')', openParen);
+    String argList = closeParen > openParen ? origin.substring(openParen, closeParen + 1) : "()";
+    return extractMethodKey(origin) + argList;
   }
 }

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfiguration.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfiguration.java
@@ -411,6 +411,46 @@ public final class InstrumentationConfiguration {
     return codeUnit + "." + className;
   }
 
+  /**
+   * Whether this configuration targets the given runtime class. {@code runtimeBinaryName} is the
+   * JVM binary name as seen during transformation (e.g. {@code com.pkg.Outer$Inner} for a nested
+   * class). Matches when it equals this config's fully-qualified name exactly, OR when this config
+   * names a NESTED class by its simple name: a user can only supply {@code className="Inner"} (the
+   * control plane has no separate enclosing-class field), which yields the FQN {@code
+   * com.pkg.Inner} and never matches the binary {@code com.pkg.Outer$Inner}. To still bind such
+   * targets, the binary name is normalized ({@code $} -&gt; {@code .}) and matched as
+   * "&lt;codeUnit&gt;.…&lt;className&gt;" within the same package (codeUnit). The exact-FQN case is
+   * always preferred and unchanged.
+   */
+  public boolean matchesRuntimeClass(String runtimeBinaryName) {
+    if (runtimeBinaryName == null) {
+      return false;
+    }
+    if (getFullyQualifiedClassName().equals(runtimeBinaryName)) {
+      return true; // top-level class, or a config already supplying the binary name
+    }
+    // Nested-class-by-simple-name. The user can only supply the simple ClassName, so "Inner"
+    // must bind to the binary "com.pkg.Outer$Inner". Match requires BOTH:
+    //   (a) the runtime class's package equals this config's codeUnit EXACTLY (not merely a
+    //       prefix — otherwise "com.pkg"/"Dog" would wrongly match "com.pkg.sub.Outer$Dog"); and
+    //   (b) the runtime simple name (final '$'/'.' segment) equals this config's className.
+    int dollar = runtimeBinaryName.indexOf('$');
+    if (dollar < 0) {
+      return false; // not a nested class; exact match above already decided it
+    }
+    // The enclosing top-level class is everything before the first '$'; its package is the
+    // substring before that class's last '.'.
+    String topLevel = runtimeBinaryName.substring(0, dollar);
+    int lastDotOfTopLevel = topLevel.lastIndexOf('.');
+    String runtimePackage = lastDotOfTopLevel < 0 ? "" : topLevel.substring(0, lastDotOfTopLevel);
+    if (!runtimePackage.equals(codeUnit)) {
+      return false;
+    }
+    // Simple name is the segment after the last '$' (nested classes are '$'-separated).
+    String simpleName = runtimeBinaryName.substring(runtimeBinaryName.lastIndexOf('$') + 1);
+    return simpleName.equals(className);
+  }
+
   /** Get unique key for the method: codeUnit.className.methodName */
   public String getMethodKey() {
     return codeUnit + "." + className + "." + methodName;
@@ -419,6 +459,61 @@ public final class InstrumentationConfiguration {
   /** Get unique key for this instrumentation point: methodKey:lineNumber */
   public String getInstrumentationKey() {
     return getMethodKey() + ":" + lineNumber;
+  }
+
+  /**
+   * Whether this configuration corresponds to the given RUNTIME method key, of the form
+   * "&lt;runtimeBinaryClass&gt;.&lt;method&gt;" as produced by the advice from
+   * {@code @Advice.Origin} (optionally with a ":&lt;line&gt;" suffix). Equals {@link
+   * #getMethodKey()} for top-level classes; for a nested class addressed by its simple name the
+   * runtime key carries the binary class name (Outer$Inner), reconciled via {@link
+   * #matchesRuntimeClass}. Used so a captured snapshot from a nested-simple-name target resolves
+   * back to its configuration (otherwise the collector finds no config and silently drops the
+   * snapshot).
+   */
+  public boolean matchesRuntimeInstrumentationKey(String runtimeKey) {
+    if (runtimeKey == null) {
+      return false;
+    }
+    if (getMethodKey().equals(runtimeKey) || getInstrumentationKey().equals(runtimeKey)) {
+      return true;
+    }
+    String key = runtimeKey;
+    int colon = key.lastIndexOf(':');
+    if (colon >= 0) {
+      // Optional ":<line>" suffix — if present it must match this config's line number.
+      String line = key.substring(colon + 1);
+      if (isInteger(line)) {
+        if (!line.equals(String.valueOf(lineNumber))) {
+          return false;
+        }
+        key = key.substring(0, colon);
+      }
+    }
+    int lastDot = key.lastIndexOf('.'); // split "<binaryClass>.<method>"
+    if (lastDot < 0) {
+      return false;
+    }
+    String runtimeBinaryClass = key.substring(0, lastDot);
+    String method = key.substring(lastDot + 1);
+    return method.equals(methodName) && matchesRuntimeClass(runtimeBinaryClass);
+  }
+
+  /** Whether {@code s} is a (optionally negative) base-10 integer. Avoids a per-call regex. */
+  private static boolean isInteger(String s) {
+    if (s.isEmpty()) {
+      return false;
+    }
+    int start = (s.charAt(0) == '-') ? 1 : 0;
+    if (start == s.length()) {
+      return false; // just "-"
+    }
+    for (int i = start; i < s.length(); i++) {
+      if (!Character.isDigit(s.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public boolean isValid() {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/StatusReporterTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/client/StatusReporterTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.opentelemetry.javaagent.bootstrap.di.DIDataStore;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.instrumentation.InstrumentationRegistry;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.ConfigurationStatus;
+import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.ErrorCause;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.InstrumentationConfiguration;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.StatusEntry;
 
@@ -228,6 +229,56 @@ class StatusReporterTest {
     assertThat(statuses).contains(ConfigurationStatus.DISABLED);
     assertThat(sink.countOf(LOCATION_HASH, ConfigurationStatus.READY)).isEqualTo(1);
     assertThat(sink.countOf(LOCATION_HASH, ConfigurationStatus.DISABLED)).isEqualTo(1);
+  }
+
+  @Test
+  void readyIsSuppressedAfterErrorForSameConfig() {
+    // A non-bindable target (e.g. a ghost method) is reported as ERROR before the initial READY
+    // sweep. READY must then be suppressed for that locationHash, so the control plane never shows
+    // a healthy breakpoint that can never fire.
+    reporter.reportError("BREAKPOINT", LOCATION_HASH, ErrorCause.METHOD_NOT_FOUND);
+
+    reporter.pullAndReportStatuses(true); // initial sweep would otherwise emit READY
+
+    assertThat(sink.statusesFor(LOCATION_HASH)).containsExactly(ConfigurationStatus.ERROR);
+    assertThat(sink.countOf(LOCATION_HASH, ConfigurationStatus.READY)).isZero();
+  }
+
+  @Test
+  void errorIsReportedExactlyOnce() {
+    reporter.reportError("BREAKPOINT", LOCATION_HASH, ErrorCause.METHOD_NOT_FOUND);
+    reporter.reportError("BREAKPOINT", LOCATION_HASH, ErrorCause.METHOD_NOT_FOUND);
+
+    assertThat(sink.countOf(LOCATION_HASH, ConfigurationStatus.ERROR)).isEqualTo(1);
+  }
+
+  @Test
+  void bindableConfigStillReportsReady() {
+    // No error reported -> the normal READY path is unaffected by the suppression logic.
+    reporter.pullAndReportStatuses(true);
+
+    assertThat(sink.statusesFor(LOCATION_HASH)).containsExactly(ConfigurationStatus.READY);
+  }
+
+  @Test
+  void forgetAllowsReadyToFireAgainAfterReApply() {
+    // A config reported ERROR, then removed (forget), then re-applied with the same location hash
+    // (now bindable) must be able to report READY again — not stay permanently suppressed.
+    reporter.reportError("BREAKPOINT", LOCATION_HASH, ErrorCause.METHOD_NOT_FOUND);
+    reporter.pullAndReportStatuses(true);
+    assertThat(sink.statusesFor(LOCATION_HASH)).containsExactly(ConfigurationStatus.ERROR);
+
+    reporter.forget(LOCATION_HASH); // config removed
+    sink.clear();
+
+    // Re-applied and now bindable: the initial sweep should emit READY.
+    reporter.pullAndReportStatuses(true);
+    assertThat(sink.statusesFor(LOCATION_HASH)).containsExactly(ConfigurationStatus.READY);
+  }
+
+  @Test
+  void forgetIsNullSafe() {
+    reporter.forget(null); // must not throw
   }
 
   /** Build a method-level (lineNumber 0) BREAKPOINT config with the given maxHits. */

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/DiagnoseBindingErrorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/DiagnoseBindingErrorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.instrumentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.instrument.Instrumentation;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.ErrorCause;
+import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model.InstrumentationConfiguration;
+
+/**
+ * Tests for {@link ByteBuddyInstrumentationEngine#diagnoseBindingError}, which lets a non-bindable
+ * target (ghost method / unmodifiable class) be reported as ERROR instead of a misleading READY.
+ * The diagnosis is inheritance-aware: a method inherited from a superclass or interface is a
+ * legitimate target and must NOT be flagged.
+ */
+class DiagnoseBindingErrorTest {
+
+  // ---- Fixture type hierarchy (uses binary FQNs of these nested classes) ----
+  interface Speaker {
+    String speak();
+  }
+
+  static class Base {
+    String inheritedFromBase() {
+      return "base";
+    }
+  }
+
+  static class Derived extends Base implements Speaker {
+    @Override
+    public String speak() {
+      return "hi";
+    }
+
+    String ownMethod() {
+      return "own";
+    }
+  }
+
+  abstract static class AbstractHolder {
+    abstract String onlyAbstract();
+
+    String concrete() {
+      return "c";
+    }
+  }
+
+  private static final String PKG = DiagnoseBindingErrorTest.class.getName();
+
+  private static InstrumentationConfiguration config(String fqClassName, String methodName) {
+    // codeUnit + "." + className must equal the runtime binary name for the exact-match path.
+    int lastDot = fqClassName.lastIndexOf('.');
+    String codeUnit = fqClassName.substring(0, lastDot);
+    String className = fqClassName.substring(lastDot + 1);
+
+    Map<String, Object> location = new HashMap<>();
+    location.put("Language", "Java");
+    location.put("CodeUnit", codeUnit);
+    location.put("ClassName", className);
+    location.put("MethodName", methodName);
+    location.put("LineNumber", 0);
+
+    Map<String, Object> locationWrapper = new HashMap<>();
+    locationWrapper.put("CodeLocation", location);
+
+    Map<String, Object> codeCapture = new HashMap<>();
+    codeCapture.put("CaptureReturn", true);
+
+    Map<String, Object> captureWrapper = new HashMap<>();
+    captureWrapper.put("CodeCapture", codeCapture);
+
+    Map<String, Object> apiConfig = new HashMap<>();
+    apiConfig.put("Location", locationWrapper);
+    apiConfig.put("LocationHash", "h" + methodName);
+    apiConfig.put("InstrumentationType", "BREAKPOINT");
+    apiConfig.put("CaptureConfiguration", captureWrapper);
+
+    return InstrumentationConfiguration.fromApiConfig(apiConfig);
+  }
+
+  private static ByteBuddyInstrumentationEngine engineWithLoaded(
+      Class<?>[] loaded, boolean modifiable) {
+    Instrumentation instr = mock(Instrumentation.class);
+    when(instr.getAllLoadedClasses()).thenReturn(loaded);
+    lenient()
+        .when(instr.isModifiableClass(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(modifiable);
+    return new ByteBuddyInstrumentationEngine(instr);
+  }
+
+  @Test
+  void ownMethodOnLoadedModifiableClassIsBindable() {
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {Derived.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "ownMethod"))).isNull();
+  }
+
+  @Test
+  void methodInheritedFromSuperclassIsBindable() {
+    // The legitimate inherited-method case — must NOT be flagged as METHOD_NOT_FOUND.
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {Derived.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "inheritedFromBase"))).isNull();
+  }
+
+  @Test
+  void methodInheritedFromInterfaceIsBindable() {
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {Derived.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "speak"))).isNull();
+  }
+
+  @Test
+  void ghostMethodOnLoadedClassReportsMethodNotFound() {
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {Derived.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "noSuchMethod")))
+        .isEqualTo(ErrorCause.METHOD_NOT_FOUND);
+  }
+
+  @Test
+  void unmodifiableClassReportsRuntimeError() {
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {Derived.class}, false);
+    // Even for a real method, an unmodifiable class can't bind.
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "ownMethod")))
+        .isEqualTo(ErrorCause.RUNTIME_ERROR);
+  }
+
+  @Test
+  void abstractOnlyMethodReportsMethodNotFound() {
+    // A method that resolves only to an abstract declaration can't be woven -> not bindable.
+    ByteBuddyInstrumentationEngine engine =
+        engineWithLoaded(new Class<?>[] {AbstractHolder.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$AbstractHolder", "onlyAbstract")))
+        .isEqualTo(ErrorCause.METHOD_NOT_FOUND);
+  }
+
+  @Test
+  void concreteMethodOnAbstractClassIsBindable() {
+    ByteBuddyInstrumentationEngine engine =
+        engineWithLoaded(new Class<?>[] {AbstractHolder.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$AbstractHolder", "concrete"))).isNull();
+  }
+
+  @Test
+  void classNotLoadedIsInconclusive() {
+    // Target class not among loaded classes -> null (it may load and bind later).
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {Base.class}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "ownMethod"))).isNull();
+  }
+
+  @Test
+  void emptyLoadedSetIsInconclusive() {
+    ByteBuddyInstrumentationEngine engine = engineWithLoaded(new Class<?>[] {}, true);
+    assertThat(engine.diagnoseBindingError(config(PKG + "$Derived", "ownMethod"))).isNull();
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/OverloadParameterNamesTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/instrumentation/OverloadParameterNamesTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.instrumentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.pool.TypePool;
+import org.junit.jupiter.api.Test;
+import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.instrumentation.advice.MethodCaptureAdvice;
+
+/**
+ * Verifies the overloaded-method parameter-name fix: the per-overload signature key built at
+ * registration time (engine side) must exactly equal the key derived at runtime from
+ * {@code @Advice.Origin} (advice side), so each overload captures its OWN parameter names instead
+ * of the first-declared overload's.
+ */
+class OverloadParameterNamesTest {
+
+  // Overloaded target: distinct parameter names per overload.
+  @SuppressWarnings("unused")
+  static class Overloaded {
+    public String process(int count) {
+      return "int:" + count;
+    }
+
+    public String process(String label) {
+      return "str:" + label;
+    }
+
+    public String process(int count, String label) {
+      return count + label;
+    }
+
+    // Array-parameter overload: guards the signature-suffix array rendering. ByteBuddy's
+    // getName() yields the descriptor form "[Ljava.lang.String;" / "[I" while @Advice.Origin
+    // (MethodDescription.toString()) yields the source form "java.lang.String[]" / "int[]" —
+    // the suffix must use the source form so the keys match.
+    public String process(String[] tags, int[] counts) {
+      return tags.length + ":" + counts.length;
+    }
+  }
+
+  private static TypeDescription describe() {
+    // EXTENDED reader mode parses the MethodParameters attribute (compiled with -parameters).
+    TypePool pool =
+        new TypePool.Default(
+            TypePool.CacheProvider.NoOp.INSTANCE,
+            net.bytebuddy.dynamic.ClassFileLocator.ForClassLoader.of(
+                OverloadParameterNamesTest.class.getClassLoader()),
+            TypePool.Default.ReaderMode.EXTENDED);
+    return pool.describe(Overloaded.class.getName()).resolve();
+  }
+
+  @Test
+  void registrationSignatureKeyMatchesRuntimeOriginKey() {
+    String methodKey = Overloaded.class.getName() + ".process";
+    TypeDescription type = describe();
+
+    int checked = 0;
+    for (MethodDescription method :
+        type.getDeclaredMethods().filter(net.bytebuddy.matcher.ElementMatchers.named("process"))) {
+      // Engine side: methodKey + signatureSuffix(method).
+      String registrationKey = methodKey + ByteBuddyInstrumentationEngine.signatureSuffix(method);
+      // Advice side: derived from @Advice.Origin, which renders MethodDescription.toString().
+      String runtimeKey = MethodCaptureAdvice.signatureKey(method.toString());
+      assertThat(runtimeKey)
+          .as("registration key must match runtime @Advice.Origin key for overload %s", method)
+          .isEqualTo(registrationKey);
+      checked++;
+    }
+    assertThat(checked).isEqualTo(4); // all four overloads
+  }
+
+  @Test
+  void overloadsProduceDistinctSignatureKeys() {
+    String methodKey = Overloaded.class.getName() + ".process";
+    TypeDescription type = describe();
+
+    java.util.Set<String> keys = new java.util.HashSet<>();
+    for (MethodDescription method :
+        type.getDeclaredMethods().filter(net.bytebuddy.matcher.ElementMatchers.named("process"))) {
+      keys.add(methodKey + ByteBuddyInstrumentationEngine.signatureSuffix(method));
+    }
+    // Four overloads -> four distinct keys (the whole point: they no longer collapse to one).
+    assertThat(keys).hasSize(4);
+  }
+
+  @Test
+  void signatureKeyExtractsArgListFromOrigin() {
+    // Sanity on the runtime parser against a representative Origin string.
+    String origin = "public java.lang.String com.example.Overloaded.process(java.lang.String)";
+    assertThat(MethodCaptureAdvice.signatureKey(origin))
+        .isEqualTo("com.example.Overloaded.process(java.lang.String)");
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/MatchesRuntimeClassTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/MatchesRuntimeClassTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link InstrumentationConfiguration#matchesRuntimeClass}, which lets a breakpoint on a
+ * nested class addressed by its SIMPLE name bind to the runtime binary name (Outer$Inner). Without
+ * it, such a target silently never fires.
+ */
+class MatchesRuntimeClassTest {
+
+  private static InstrumentationConfiguration config(String codeUnit, String className) {
+    Map<String, Object> codeLocation = new HashMap<>();
+    codeLocation.put("Language", "java");
+    codeLocation.put("CodeUnit", codeUnit);
+    codeLocation.put("ClassName", className);
+    codeLocation.put("MethodName", "speak");
+    Map<String, Object> location = new HashMap<>();
+    location.put("CodeLocation", codeLocation);
+    Map<String, Object> item = new HashMap<>();
+    item.put("InstrumentationType", "BREAKPOINT");
+    item.put("Location", location);
+    item.put("LocationHash", "h");
+    Map<String, Object> capture = new HashMap<>();
+    Map<String, Object> codeCapture = new HashMap<>();
+    codeCapture.put("CaptureReturn", true);
+    capture.put("CodeCapture", codeCapture);
+    item.put("CaptureConfiguration", capture);
+    return InstrumentationConfiguration.fromApiConfig(item);
+  }
+
+  @Test
+  void exactFqnMatches() {
+    InstrumentationConfiguration c = config("com.pkg", "TopLevel");
+    assertThat(c.matchesRuntimeClass("com.pkg.TopLevel")).isTrue();
+  }
+
+  @Test
+  void nestedClassBySimpleNameMatchesBinaryName() {
+    // User can only supply ClassName="Dog"; runtime sees the binary name with '$'.
+    InstrumentationConfiguration c = config("com.pkg.dispatch", "Dog");
+    assertThat(c.matchesRuntimeClass("com.pkg.dispatch.InheritanceTests$Dog")).isTrue();
+  }
+
+  @Test
+  void deeplyNestedSimpleNameMatches() {
+    InstrumentationConfiguration c = config("com.pkg", "Inner");
+    assertThat(c.matchesRuntimeClass("com.pkg.Outer$Mid$Inner")).isTrue();
+  }
+
+  @Test
+  void wrongPackageDoesNotMatch() {
+    InstrumentationConfiguration c = config("com.pkg", "Dog");
+    assertThat(c.matchesRuntimeClass("com.other.Outer$Dog")).isFalse();
+  }
+
+  @Test
+  void differentSimpleNameDoesNotMatch() {
+    InstrumentationConfiguration c = config("com.pkg", "Cat");
+    assertThat(c.matchesRuntimeClass("com.pkg.Outer$Dog")).isFalse();
+  }
+
+  @Test
+  void deeperSubpackageDoesNotMatch() {
+    // codeUnit is an exact package, not a prefix: "com.pkg"/"Dog" must NOT match a nested Dog in a
+    // DEEPER package, or a breakpoint could bind to an unintended class.
+    InstrumentationConfiguration c = config("com.pkg", "Dog");
+    assertThat(c.matchesRuntimeClass("com.pkg.sub.Outer$Dog")).isFalse();
+  }
+
+  @Test
+  void nonNestedDifferentNameDoesNotMatch() {
+    // No '$' in the runtime name and not an exact FQN -> no match (avoids loose suffix matching).
+    InstrumentationConfiguration c = config("com.pkg", "Dog");
+    assertThat(c.matchesRuntimeClass("com.pkg.Cat")).isFalse();
+  }
+
+  @Test
+  void nullRuntimeNameIsFalse() {
+    assertThat(config("com.pkg", "Dog").matchesRuntimeClass(null)).isFalse();
+  }
+
+  // ---- matchesRuntimeInstrumentationKey: capture-key reconciliation ----
+
+  @Test
+  void runtimeMethodKeyWithBinaryClassMatches() {
+    // The collector looks up by the advice's methodKey (no ":line" for method-level), which
+    // carries the binary class name for a nested target. It must resolve to the simple-name config.
+    InstrumentationConfiguration c = config("com.pkg.dispatch", "Dog");
+    assertThat(c.matchesRuntimeInstrumentationKey("com.pkg.dispatch.InheritanceTests$Dog.speak"))
+        .isTrue();
+  }
+
+  @Test
+  void runtimeKeyWithLineSuffixMatchesWhenLineMatches() {
+    // config() builds a method-level config (no LineNumber) -> lineNumber 0; ":0" suffix matches.
+    InstrumentationConfiguration c = config("com.pkg", "Inner");
+    assertThat(c.matchesRuntimeInstrumentationKey("com.pkg.Outer$Inner.speak:0")).isTrue();
+  }
+
+  @Test
+  void runtimeKeyWrongMethodDoesNotMatch() {
+    InstrumentationConfiguration c = config("com.pkg", "Dog");
+    assertThat(c.matchesRuntimeInstrumentationKey("com.pkg.Outer$Dog.bark")).isFalse();
+  }
+
+  @Test
+  void runtimeKeyExactMethodKeyMatches() {
+    InstrumentationConfiguration c = config("com.pkg", "TopLevel");
+    assertThat(c.matchesRuntimeInstrumentationKey("com.pkg.TopLevel.speak")).isTrue();
+  }
+
+  @Test
+  void runtimeKeyNullIsFalse() {
+    assertThat(config("com.pkg", "Dog").matchesRuntimeInstrumentationKey(null)).isFalse();
+  }
+}

--- a/di-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/javaagent/bootstrap/di/DIDataStore.java
+++ b/di-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/javaagent/bootstrap/di/DIDataStore.java
@@ -59,6 +59,12 @@ public final class DIDataStore {
       new ConcurrentHashMap<>();
   private static final ConcurrentHashMap<String, String[]> parameterNames =
       new ConcurrentHashMap<>();
+  // Per-overload parameter names, keyed by the full signature key
+  // "<methodKey>(<comma-separated-param-types>)" so an overloaded method captures each
+  // overload's own argument names (the per-methodKey map above only holds one overload's
+  // names, which would mislabel every other overload's arguments).
+  private static final ConcurrentHashMap<String, String[]> parameterNamesBySignature =
+      new ConcurrentHashMap<>();
   private static final ConcurrentHashMap<String, HitState> hitStates = new ConcurrentHashMap<>();
 
   private DIDataStore() {}
@@ -292,12 +298,30 @@ public final class DIDataStore {
     parameterNames.put(key, names);
   }
 
+  /**
+   * Register parameter names for a specific overload, keyed by its full signature
+   * "&lt;methodKey&gt;(&lt;comma-separated-param-types&gt;)". The param-type string must match the
+   * argument list produced by ByteBuddy's {@code @Advice.Origin} (fully-qualified types, comma
+   * separated, no spaces) so the runtime lookup resolves the executing overload's own names.
+   */
+  public static void registerParameterNamesForSignature(String signatureKey, String[] names) {
+    parameterNamesBySignature.put(signatureKey, names);
+  }
+
+  /** Look up parameter names for a specific overload signature; null if none registered. */
+  public static String[] getParameterNamesForSignature(String signatureKey) {
+    return parameterNamesBySignature.get(signatureKey);
+  }
+
   public static void removeConfig(String key) {
     limits.remove(key);
     captureArguments.remove(key);
     captureLocals.remove(key);
     captureReturnFlags.remove(key);
     parameterNames.remove(key);
+    // Drop any per-signature entries for this methodKey ("<methodKey>(...)").
+    String prefix = key + "(";
+    parameterNamesBySignature.keySet().removeIf(k -> k.startsWith(prefix));
     hitStates.remove(key);
   }
 

--- a/di-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/javaagent/bootstrap/di/DIDataStoreTest.java
+++ b/di-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/javaagent/bootstrap/di/DIDataStoreTest.java
@@ -178,6 +178,28 @@ class DIDataStoreTest {
     assertThat(DIDataStore.snapshotAll(true)).isEmpty();
   }
 
+  @Test
+  void removeConfigDropsPerSignatureParameterNames() {
+    // Per-overload names are keyed by "<methodKey>(<types>)"; removing the methodKey must drop all
+    // of its per-signature entries (and not touch an unrelated method's entries).
+    String methodKey = "com.pkg.Svc.process";
+    String otherKey = "com.pkg.Svc.handle";
+    DIDataStore.registerParameterNamesForSignature(methodKey + "(int)", new String[] {"count"});
+    DIDataStore.registerParameterNamesForSignature(
+        methodKey + "(java.lang.String)", new String[] {"label"});
+    DIDataStore.registerParameterNamesForSignature(otherKey + "(int)", new String[] {"id"});
+
+    DIDataStore.removeConfig(methodKey);
+
+    assertThat(DIDataStore.getParameterNamesForSignature(methodKey + "(int)")).isNull();
+    assertThat(DIDataStore.getParameterNamesForSignature(methodKey + "(java.lang.String)"))
+        .isNull();
+    // Unrelated method's per-signature entry is untouched.
+    assertThat(DIDataStore.getParameterNamesForSignature(otherKey + "(int)")).containsExactly("id");
+
+    DIDataStore.removeConfig(otherKey); // cleanup
+  }
+
   // ─── Method entry/exit argument pairing (recursion) ──────────────────────────
 
   /**


### PR DESCRIPTION
Cherry-picked from main:
- #1399

(release/v2.28.x was already caught up with main via the #1397 backport; #1399 is the only commit that landed afterward.)