### PR TITLE
Add .kotlin/ to .gitignore to fix nebula.release dirty-tree failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .gradle
 build/
 
+# Kotlin Gradle plugin build cache (created during builds, e.g. buildSrc/.kotlin/)
+.kotlin/
+
 .DS_Store
 
 .vscode


### PR DESCRIPTION
## Summary

The `release/v2.28.x` Release Build [run #27777741679](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/27777741679) failed in the `publish-sdk` job at the **Build and Publish release with Gradle** step with:

```
Caused by: org.gradle.api.GradleException: Final and candidate builds require all changes to be committed into Git.
?? buildSrc/.kotlin/
  at nebula.plugin.release.ReleasePlugin.checkStateForStage(ReleasePlugin.groovy:303)
```

The `nebula.release` plugin refuses to run a final/candidate release when the git working tree is dirty. During the build, the Kotlin Gradle plugin creates an untracked `buildSrc/.kotlin/` cache directory, which dirties the tree and trips the guard.

## Fix

Add `.kotlin/` to `.gitignore` so the Kotlin plugin's build cache directory is ignored everywhere (including `buildSrc/`), keeping the working tree clean for the release plugin.

## Testing

`.kotlin/` is a build-time cache directory only; ignoring it has no runtime/artifact impact.
