### PR TITLE
ci: wire Service Events EC2 test into main-build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -258,6 +258,14 @@ jobs:
       aws-region: us-east-1
       caller-workflow-name: 'main-build'
 
+  service-events-ec2:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-ec2-service-events-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
   # This validation is to ensure that all test workflows relevant to this repo are actually
   # being used in this repo, which is referring to all the other jobs in this file.
   #


### PR DESCRIPTION
## Summary
- Adds `service-events-ec2` job to the E2E test workflow, calling `java-ec2-service-events-test.yml@main` from the test-framework repo.
- Runs after `upload-main-build` to validate Service Events telemetry (DeploymentEvent, IncidentSnapshot, FunctionCall) on every main-build.

## Dependencies
- Requires [aws-application-signals-test-framework PR #651](https://github.com/aws-observability/aws-application-signals-test-framework/pull/651) to merge first (the SE workflow must exist on `main`).

## Test plan
- [ ] Merge test-framework PR #651
- [ ] Trigger main-build workflow and verify `service-events-ec2` job passes