### PR TITLE
Bump jackson-bom to 2.21.4 to fix CVEs

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -11,15 +11,6 @@
 #    expired_at: <required - YYYY-MM-DD>
 
 vulnerabilities:
-  - id: CVE-2026-41417
-    statement: "Netty request-line validation bypass via setUri() enables CRLF injection/request smuggling. Low risk for ADOT Java agent (URIs are operator-configured, no attacker-controlled input reaches setUri()). Fix: bump netty-bom to 4.1.133.Final. https://nvd.nist.gov/vuln/detail/CVE-2026-41417"
-    expired_at: 2026-05-22
-  - id: CVE-2026-42583
-    statement: "Netty Lz4FrameDecoder resource exhaustion. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42583"
-    expired_at: 2026-05-22
-  - id: CVE-2026-42584
-    statement: "Netty HttpClientCodec response desynchronization. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42584"
-    expired_at: 2026-05-22
-  - id: CVE-2026-42587
-    statement: "Netty HttpContentDecompressor maxAllocation bypass with br/zstd/snappy Content-Encoding leads to decompression bomb. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42587"
-    expired_at: 2026-05-22
+  - id: CVE-2026-54515
+    statement: "jackson-databind vulnerability. No fix available in 2.21.x yet (Trivy DB lists 2.21.5 which has not been released). https://avd.aquasec.com/nvd/cve-2026-54515"
+    expired_at: 2026-07-31

--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -9,15 +9,6 @@
 #    expired_at: <required - YYYY-MM-DD>
 
 vulnerabilities:
-  - id: CVE-2026-41417
-    statement: "Netty request-line validation bypass via setUri() enables CRLF injection/request smuggling. Low risk for ADOT Java agent (URIs are operator-configured, no attacker-controlled input reaches setUri()). Fix: bump netty-bom to 4.1.133.Final. https://nvd.nist.gov/vuln/detail/CVE-2026-41417"
-    expired_at: 2026-05-22
-  - id: CVE-2026-42583
-    statement: "Netty Lz4FrameDecoder resource exhaustion. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42583"
-    expired_at: 2026-05-22
-  - id: CVE-2026-42584
-    statement: "Netty HttpClientCodec response desynchronization. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42584"
-    expired_at: 2026-05-22
-  - id: CVE-2026-42587
-    statement: "Netty HttpContentDecompressor maxAllocation bypass with br/zstd/snappy Content-Encoding leads to decompression bomb. Fix: bump netty-bom to 4.1.133.Final. https://avd.aquasec.com/nvd/cve-2026-42587"
-    expired_at: 2026-05-22
+  - id: CVE-2026-54515
+    statement: "jackson-databind vulnerability. No fix available in 2.21.x yet (Trivy DB lists 2.21.5 which has not been released). https://avd.aquasec.com/nvd/cve-2026-54515"
+    expired_at: 2026-07-31

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -35,7 +35,7 @@ val otelJavaAgentVersion = if (!testSnapshots) otelVersion else "$otelSnapshotVe
 
 val dependencyBoms = listOf(
   "com.amazonaws:aws-java-sdk-bom:1.12.599",
-  "com.fasterxml.jackson:jackson-bom:2.21.1",
+  "com.fasterxml.jackson:jackson-bom:2.21.4",
   "com.google.guava:guava-bom:33.0.0-jre",
   "com.google.protobuf:protobuf-bom:3.25.1",
   "com.linecorp.armeria:armeria-bom:1.26.4",


### PR DESCRIPTION
## Summary
- Bump `jackson-bom` from 2.21.1 → 2.21.4, fixing CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54516, CVE-2026-54517, CVE-2026-54518 ([release notes](https://github.com/FasterXML/jackson-databind/blob/2.21/release-notes/VERSION-2.x))
- Suppress CVE-2026-54515 in trivyignore (no fix in 2.21.x yet — Trivy DB references 2.21.5 which has not been released)
- Remove expired Netty CVE suppressions (already fixed by 4.1.135.Final bump in #1389)

## Test plan
- [ ] PR build Trivy image scan passes
- [ ] If Trivy still flags CVE-2026-54514 or CVE-2026-54517 (stale Trivy DB), add suppressions for those as well