### PR TITLE
feat(serviceevents): resolve aws.local.environment for SE/DI in the SDK to align with CloudWatch agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(serviceevents): resolve `aws.local.environment` in the SDK (eks/k8s/ecs/ec2/generic) to align
+  ServiceEvents & Dynamic Instrumentation with the CloudWatch agent, with a custom EC2 ASG fetcher
+  ([#1417](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1417))
 - fix(serviceevents): gate incident trace correlation on the SAMPLED flag
 - fix: remove EOL AWS SDK v1 dependency for ARN parsing
   ([#1401](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1401))

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/DynamicInstrumentationManager.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/DynamicInstrumentationManager.java
@@ -43,6 +43,7 @@ import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.output.DISerializerImpl;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.output.DISnapshotCollector;
 import software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.output.DISnapshotOtlpEmitter;
+import software.amazon.opentelemetry.javaagent.providers.environment.EnvironmentResolver;
 import software.amazon.opentelemetry.javaagent.providers.exporter.otlp.aws.logs.OtlpAwsLogRecordExporterBuilder;
 
 /**
@@ -481,13 +482,13 @@ public final class DynamicInstrumentationManager {
   private DISnapshotOtlpEmitter createOtlpEmitter(DynamicInstrumentationConfig diConfig) {
     String logsEndpoint = diConfig.getLogsEndpoint();
 
-    // Resource supplier: defers reading ResourceHolder until first emit
+    // Resource supplier: defers reading ResourceHolder until first emit. aws.local.environment is
+    // stamped via the SDK-only resolver (same precedence as the CloudWatch agent) so DI snapshot
+    // telemetry correlates with Application Signals.
     Resource fallbackResource =
-        Resource.create(
-            Attributes.of(
-                AttributeKey.stringKey("service.name"), diConfig.getServiceName(),
-                AttributeKey.stringKey("deployment.environment"),
-                    diConfig.getDeploymentEnvironment()));
+        EnvironmentResolver.withLocalEnvironment(
+            Resource.create(
+                Attributes.of(AttributeKey.stringKey("service.name"), diConfig.getServiceName())));
 
     java.util.function.Supplier<Resource> resourceSupplier =
         () -> {
@@ -496,7 +497,7 @@ public final class DynamicInstrumentationManager {
             java.lang.reflect.Method getResource = holderClass.getMethod("getResource");
             Resource holderResource = (Resource) getResource.invoke(null);
             if (holderResource != null && !holderResource.equals(Resource.getDefault())) {
-              return holderResource;
+              return EnvironmentResolver.withLocalEnvironment(holderResource);
             }
           } catch (Throwable ignored) {
             // ResourceHolder not available or not yet populated — use fallback

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/config/DynamicInstrumentationConfig.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/config/DynamicInstrumentationConfig.java
@@ -15,11 +15,11 @@
 
 package software.amazon.opentelemetry.javaagent.providers.dynamicInstrumentation.config;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ServiceAttributes;
 import java.lang.instrument.Instrumentation;
 import java.util.logging.Logger;
+import software.amazon.opentelemetry.javaagent.providers.environment.EnvironmentResolver;
 
 /**
  * Configuration for the Dynamic Instrumentation feature. Holds all settings needed for
@@ -114,8 +114,19 @@ public final class DynamicInstrumentationConfig {
   }
 
   /**
-   * Extract deployment environment from resource with lazy-loading and caching. Only caches
-   * successful environment resolution to handle timing issues with Resource population.
+   * Compute {@code aws.local.environment} from the resource with lazy-loading and caching.
+   *
+   * <p>SDK-only environment resolution: rather than reading only an explicit {@code
+   * deployment.environment[.name]}, this computes the full {@code aws.local.environment} from the
+   * detected resource attributes using the same precedence as the CloudWatch agent (explicit &rarr;
+   * {@code eks/k8s:<cluster>/<namespace>} &rarr; {@code ecs:<cluster>} &rarr; {@code ec2:<asg>}
+   * &rarr; {@code ec2:default} &rarr; {@code generic:default}). This makes DI self-sufficient — the
+   * value used as the request's Environment lookup key matches Application Signals without relying
+   * on the agent proxy to inject it.
+   *
+   * <p>Only caches once the resource carries platform context, to handle timing issues with
+   * Resource population; until then returns {@code "UnknownEnvironment"} without caching, allowing
+   * automatic retry on the next call.
    */
   public String getDeploymentEnvironment() {
     // Return cached value if we successfully found it before
@@ -129,17 +140,21 @@ public final class DynamicInstrumentationConfig {
       return "UnknownEnvironment"; // Don't cache - Resource might appear later
     }
 
-    String env = resource.getAttribute(AttributeKey.stringKey("deployment.environment.name"));
-    if (env != null && !env.isEmpty()) {
-      // SUCCESS! Cache it so we never query again
+    String env = EnvironmentResolver.resolveLocalEnvironment(resource);
+
+    // Cache only once the resource has the platform context to resolve a concrete value.
+    // The fallback values ("ec2:default", "generic:default") are also what a still-populating
+    // resource momentarily yields (no cloud.platform / host / k8s attributes yet), so don't cache
+    // those cases — the Resource may still be filling in. A specific value is always safe to cache.
+    boolean isFallback = "ec2:default".equals(env) || "generic:default".equals(env);
+    if (!env.isEmpty() && (!isFallback || EnvironmentResolver.hasPlatformContext(resource))) {
       cachedDeploymentEnvironment = env;
       logger.fine("AWS DI: Deployment environment resolved and cached: " + env);
       return env;
     }
 
-    // Attribute not available yet - don't cache, try again next time
-    logger.fine(
-        "AWS DI: deployment.environment.name attribute not yet available, will retry on next call");
+    // Resource not populated yet - don't cache, try again next time
+    logger.fine("AWS DI: environment not yet resolvable from resource, will retry on next call");
     return "UnknownEnvironment";
   }
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/environment/Ec2AutoScalingGroupFetcher.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/environment/Ec2AutoScalingGroupFetcher.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.environment;
+
+import java.time.Duration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * Fetches the EC2 Auto Scaling group name from IMDS instance tags.
+ *
+ * <p>The stock OTel {@code Ec2Resource} only reads the instance-identity document — it does NOT
+ * fetch instance tags, so the Auto Scaling group is absent from the SDK Resource. The CloudWatch
+ * agent reads the ASG from IMDS instance tags ({@code
+ * /latest/meta-data/tags/instance/aws:autoscaling:groupName}) to resolve {@code ec2:<asg>}. This
+ * fetcher closes that gap so the SDK can compute the same {@code aws.local.environment} the agent
+ * would on EC2, without depending on the agent.
+ *
+ * <p>Instance metadata tags must be enabled on the instance ({@code InstanceMetadataTags=enabled});
+ * when they aren't (or IMDS is unreachable / not EC2), the fetcher returns an empty string and the
+ * {@link EnvironmentResolver} falls back to {@code ec2:default} — matching the agent.
+ *
+ * <p>The fetch is invoked lazily by the resolver only on the EC2 branch, so EKS/ECS/explicit-env
+ * workloads never pay the IMDS round-trip.
+ */
+public final class Ec2AutoScalingGroupFetcher {
+
+  private static final Logger logger = Logger.getLogger(Ec2AutoScalingGroupFetcher.class.getName());
+
+  private static final String DEFAULT_IMDS_ENDPOINT = "169.254.169.254";
+  private static final String TOKEN_PATH = "/latest/api/token";
+  private static final String ASG_TAG_PATH =
+      "/latest/meta-data/tags/instance/aws:autoscaling:groupName";
+  private static final Duration TIMEOUT = Duration.ofSeconds(1);
+  private static final RequestBody EMPTY_BODY = RequestBody.create(new byte[0]);
+
+  private final String endpoint;
+
+  public Ec2AutoScalingGroupFetcher() {
+    // Endpoint is overridable for tests via the same system property the OTel EC2 resource uses;
+    // defaults to the EC2 link-local IMDS address.
+    this(System.getProperty("otel.aws.imds.endpointOverride", DEFAULT_IMDS_ENDPOINT));
+  }
+
+  // Visible for testing.
+  Ec2AutoScalingGroupFetcher(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  /**
+   * Returns the Auto Scaling group name from IMDS instance tags, or an empty string when not on
+   * EC2, IMDS is unreachable, or instance metadata tags are not enabled. Never throws.
+   */
+  public String fetch() {
+    try {
+      OkHttpClient client =
+          new OkHttpClient.Builder()
+              .callTimeout(TIMEOUT)
+              .connectTimeout(TIMEOUT)
+              .readTimeout(TIMEOUT)
+              .build();
+
+      String urlBase = "http://" + endpoint;
+      String token = fetchToken(client, urlBase + TOKEN_PATH);
+      String asg = fetchTag(client, urlBase + ASG_TAG_PATH, token);
+      return asg == null ? "" : asg.trim();
+    } catch (RuntimeException e) {
+      // Not on EC2, IMDS unreachable, or instance tags not enabled — all expected, non-fatal.
+      logger.log(Level.FINE, "EC2 Auto Scaling group not available via IMDS", e);
+      return "";
+    }
+  }
+
+  private static String fetchToken(OkHttpClient client, String tokenUrl) {
+    Request request =
+        new Request.Builder()
+            .url(tokenUrl)
+            .method("PUT", EMPTY_BODY)
+            .addHeader("X-aws-ec2-metadata-token-ttl-seconds", "60")
+            .build();
+    return execute(client, request);
+  }
+
+  private static String fetchTag(OkHttpClient client, String tagUrl, String token) {
+    Request.Builder builder = new Request.Builder().url(tagUrl).get();
+    if (!token.isEmpty()) {
+      builder.addHeader("X-aws-ec2-metadata-token", token);
+    }
+    return execute(client, builder.build());
+  }
+
+  private static String execute(OkHttpClient client, Request request) {
+    try (Response response = client.newCall(request).execute()) {
+      if (response.code() != 200 || response.body() == null) {
+        return "";
+      }
+      return response.body().string();
+    } catch (Exception e) {
+      logger.log(Level.FINE, "IMDS request failed: " + request.url(), e);
+      return "";
+    }
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/environment/EnvironmentResolver.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/environment/EnvironmentResolver.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.environment;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Resolves {@code aws.local.environment} from OTel Resource attributes, mirroring the CloudWatch
+ * agent's awsapplicationsignals resolver precedence so the SDK can compute the same environment
+ * value the agent would, with no dependency on the agent process:
+ *
+ * <ol>
+ *   <li>Explicit {@code deployment.environment[.name]} &rarr; use as-is
+ *   <li>EKS / K8s &rarr; {@code "eks:<cluster>/<namespace>"} or {@code "k8s:<cluster>/<namespace>"}
+ *   <li>ECS &rarr; {@code "ecs:<cluster>"} (cluster name from {@code aws.ecs.cluster.arn})
+ *   <li>EC2 (host is actually EC2) &rarr; {@code "ec2:<asg>"} when an Auto Scaling group is known,
+ *       else {@code "ec2:default"}
+ *   <li>Otherwise (non-AWS / undetected host) &rarr; {@code "generic:default"}, matching the agent,
+ *       which runs its "generic" resolver (Mode == onPremise) and emits {@code "generic:default"}
+ *       there -- it never leaves Environment empty
+ * </ol>
+ *
+ * <p>Scope is the LOCAL environment only ({@code aws.local.environment}); remote-environment
+ * correlation is out of scope (it depends on the agent's cluster-wide pod watcher).
+ *
+ * <p>The Auto Scaling group is supplied lazily via a {@link Supplier} that is invoked ONLY when the
+ * resolver reaches the EC2 branch, so EKS/ECS/explicit-env workloads never trigger an IMDS lookup.
+ */
+public final class EnvironmentResolver {
+
+  /** Resource attribute key holding the resolved local environment. */
+  public static final AttributeKey<String> LOCAL_ENVIRONMENT_KEY =
+      AttributeKey.stringKey("aws.local.environment");
+
+  private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT_NAME =
+      AttributeKey.stringKey("deployment.environment.name");
+  private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
+      AttributeKey.stringKey("deployment.environment");
+  private static final AttributeKey<String> K8S_CLUSTER_NAME =
+      AttributeKey.stringKey("k8s.cluster.name");
+  private static final AttributeKey<String> K8S_NAMESPACE_NAME =
+      AttributeKey.stringKey("k8s.namespace.name");
+  private static final AttributeKey<String> CLOUD_PLATFORM =
+      AttributeKey.stringKey("cloud.platform");
+  private static final AttributeKey<String> AWS_ECS_CLUSTER_ARN =
+      AttributeKey.stringKey("aws.ecs.cluster.arn");
+  private static final AttributeKey<String> HOST_ID = AttributeKey.stringKey("host.id");
+
+  private static final String AWS_EKS = "aws_eks";
+  private static final String AWS_EC2 = "aws_ec2";
+  private static final String UNKNOWN_NAMESPACE = "UnknownNamespace";
+
+  // Memoizes the (at most one) IMDS Auto Scaling group lookup across the whole agent, so the EC2
+  // branch never hits IMDS more than once regardless of how many callers resolve the environment.
+  private static final AtomicReference<String> CACHED_ASG = new AtomicReference<>(null);
+
+  private EnvironmentResolver() {}
+
+  /**
+   * Resolves {@code aws.local.environment} from the given resource, using a process-wide memoized
+   * IMDS lookup for the EC2 Auto Scaling group (performed only if the resolver reaches the EC2
+   * branch).
+   */
+  public static String resolveLocalEnvironment(Resource resource) {
+    return resolveLocalEnvironment(resource, EnvironmentResolver::cachedAutoScalingGroup);
+  }
+
+  /** Stamps {@code aws.local.environment} using the process-wide memoized ASG lookup. */
+  public static Resource withLocalEnvironment(Resource resource) {
+    return withLocalEnvironment(resource, EnvironmentResolver::cachedAutoScalingGroup);
+  }
+
+  private static String cachedAutoScalingGroup() {
+    String existing = CACHED_ASG.get();
+    if (existing != null) {
+      return existing;
+    }
+    String fetched = new Ec2AutoScalingGroupFetcher().fetch();
+    CACHED_ASG.compareAndSet(null, fetched);
+    return CACHED_ASG.get();
+  }
+
+  /**
+   * Resolves {@code aws.local.environment} from the given resource attributes.
+   *
+   * <p>The EC2 branch is gated on the host actually being EC2, mirroring the CloudWatch agent
+   * (whose environment branches only run for EC2 / Kubernetes). On a non-AWS / non-K8s host the
+   * agent leaves the Environment empty, so this returns {@code ""} rather than falsely claiming
+   * {@code ec2:default}.
+   *
+   * @param resource the OTel resource (its attributes drive resolution)
+   * @param asgSupplier supplies the EC2 Auto Scaling group name; invoked only on the EC2 branch.
+   *     May be {@code null}, in which case the EC2 branch falls back to {@code ec2:default}.
+   * @return the resolved environment string, or {@code ""} on a non-AWS / undetected host.
+   */
+  public static String resolveLocalEnvironment(Resource resource, Supplier<String> asgSupplier) {
+    if (resource == null) {
+      // No resource at all -> no platform signal -> same non-AWS fallback as below.
+      return "generic:default";
+    }
+
+    // 1. Explicit deployment.environment[.name] wins outright.
+    String explicit =
+        firstNonEmpty(
+            get(resource, DEPLOYMENT_ENVIRONMENT_NAME), get(resource, DEPLOYMENT_ENVIRONMENT));
+    if (!explicit.isEmpty()) {
+      return explicit;
+    }
+
+    // 2. Kubernetes (EKS / K8s): "<prefix>:<cluster>/<namespace>".
+    String k8sCluster = get(resource, K8S_CLUSTER_NAME);
+    if (!k8sCluster.isEmpty()) {
+      String namespace = get(resource, K8S_NAMESPACE_NAME);
+      if (namespace.isEmpty()) {
+        namespace = UNKNOWN_NAMESPACE;
+      }
+      String prefix = AWS_EKS.equals(get(resource, CLOUD_PLATFORM)) ? "eks" : "k8s";
+      return prefix + ":" + k8sCluster + "/" + namespace;
+    }
+
+    // 3. ECS: "ecs:<cluster>" — cluster name is the last segment of the ECS cluster ARN.
+    String ecsClusterArn = get(resource, AWS_ECS_CLUSTER_ARN);
+    if (!ecsClusterArn.isEmpty()) {
+      String ecsCluster = ecsClusterArn.substring(ecsClusterArn.lastIndexOf('/') + 1);
+      if (!ecsCluster.isEmpty()) {
+        return "ecs:" + ecsCluster;
+      }
+    }
+
+    // 4. EC2: only when the host is actually EC2 (matches the agent's Platform == ModeEC2 gate).
+    //    Signals: cloud.platform=aws_ec2, host.id (EC2 instance id from the OTel EC2 detector),
+    //    or the ASG tag (an IMDS-only EC2 signal, fetched lazily on this branch only).
+    String asg = "";
+    if (asgSupplier != null) {
+      asg = trim(asgSupplier.get());
+    }
+    boolean isEc2 =
+        AWS_EC2.equals(get(resource, CLOUD_PLATFORM))
+            || !get(resource, HOST_ID).isEmpty()
+            || !asg.isEmpty();
+    if (isEc2) {
+      return asg.isEmpty() ? "ec2:default" : "ec2:" + asg;
+    }
+
+    // 5. Non-AWS / undetected host: the CloudWatch agent runs its "generic" resolver here and
+    //    emits "generic:default" (never empty), so mirror that instead of returning empty.
+    return "generic:default";
+  }
+
+  /**
+   * Returns true if the resource carries enough platform context for {@code ec2:default} to be a
+   * real answer (rather than the empty-resource fallback). Callers that cache the resolved value
+   * use this to avoid caching {@code ec2:default} before resource detection has populated.
+   */
+  public static boolean hasPlatformContext(Resource resource) {
+    if (resource == null) {
+      return false;
+    }
+    return !get(resource, CLOUD_PLATFORM).isEmpty()
+        || !get(resource, K8S_CLUSTER_NAME).isEmpty()
+        || !get(resource, AWS_ECS_CLUSTER_ARN).isEmpty()
+        || !get(resource, HOST_ID).isEmpty();
+  }
+
+  /**
+   * Returns a Resource with {@code aws.local.environment} stamped, computed via {@link
+   * #resolveLocalEnvironment}. Idempotent: if the attribute is already present it is left
+   * untouched. The resolver always yields a non-empty value (a platform scope, an explicit env, or
+   * the {@code "generic:default"} fallback), matching the CloudWatch agent, which always sets
+   * Environment. The empty-string guards below are defensive only.
+   */
+  public static Resource withLocalEnvironment(Resource resource, Supplier<String> asgSupplier) {
+    if (resource == null) {
+      String env = resolveLocalEnvironment(null, asgSupplier);
+      return env.isEmpty()
+          ? Resource.empty()
+          : Resource.create(Attributes.of(LOCAL_ENVIRONMENT_KEY, env));
+    }
+    if (!get(resource, LOCAL_ENVIRONMENT_KEY).isEmpty()) {
+      return resource;
+    }
+    String env = resolveLocalEnvironment(resource, asgSupplier);
+    if (env.isEmpty()) {
+      return resource;
+    }
+    return resource.merge(Resource.create(Attributes.of(LOCAL_ENVIRONMENT_KEY, env)));
+  }
+
+  private static String get(Resource resource, AttributeKey<String> key) {
+    return trim(resource.getAttribute(key));
+  }
+
+  private static String firstNonEmpty(String a, String b) {
+    return !a.isEmpty() ? a : b;
+  }
+
+  private static String trim(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/environment/EnvironmentResolver.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/environment/EnvironmentResolver.java
@@ -102,13 +102,15 @@ public final class EnvironmentResolver {
    *
    * <p>The EC2 branch is gated on the host actually being EC2, mirroring the CloudWatch agent
    * (whose environment branches only run for EC2 / Kubernetes). On a non-AWS / non-K8s host the
-   * agent leaves the Environment empty, so this returns {@code ""} rather than falsely claiming
-   * {@code ec2:default}.
+   * agent runs its "generic" resolver and emits {@code generic:default} — it never leaves
+   * Environment empty — so this returns {@code generic:default} rather than falsely claiming {@code
+   * ec2:default}.
    *
    * @param resource the OTel resource (its attributes drive resolution)
    * @param asgSupplier supplies the EC2 Auto Scaling group name; invoked only on the EC2 branch.
    *     May be {@code null}, in which case the EC2 branch falls back to {@code ec2:default}.
-   * @return the resolved environment string, or {@code ""} on a non-AWS / undetected host.
+   * @return the resolved environment string; never empty — {@code generic:default} on a non-AWS /
+   *     undetected host.
    */
   public static String resolveLocalEnvironment(Resource resource, Supplier<String> asgSupplier) {
     if (resource == null) {

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/config/DynamicInstrumentationConfigTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/config/DynamicInstrumentationConfigTest.java
@@ -146,7 +146,31 @@ class DynamicInstrumentationConfigTest {
             .resource(resource)
             .build();
 
+    // No platform context yet -> ec2:default is not cached; reported as UnknownEnvironment so a
+    // later-populated Resource is picked up on the next call.
     assertThat(config.getDeploymentEnvironment()).isEqualTo("UnknownEnvironment");
+  }
+
+  @Test
+  void testGetDeploymentEnvironment_resolvesEksFromResource() {
+    // SDK-only resolution: with no explicit env, DI uses the same eks:<cluster>/<namespace> the
+    // CloudWatch agent resolves for Application Signals.
+    Resource resource =
+        Resource.create(
+            Attributes.builder()
+                .put(ServiceAttributes.SERVICE_NAME, "test-service")
+                .put(AttributeKey.stringKey("cloud.platform"), "aws_eks")
+                .put(AttributeKey.stringKey("k8s.cluster.name"), "my-cluster")
+                .put(AttributeKey.stringKey("k8s.namespace.name"), "default")
+                .build());
+
+    DynamicInstrumentationConfig config =
+        DynamicInstrumentationConfig.builder()
+            .apiUrl("http://localhost:2000")
+            .resource(resource)
+            .build();
+
+    assertThat(config.getDeploymentEnvironment()).isEqualTo("eks:my-cluster/default");
   }
 
   @Test

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/environment/Ec2AutoScalingGroupFetcherTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/environment/Ec2AutoScalingGroupFetcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The custom fetcher reads aws:autoscaling:groupName from IMDS instance tags (the stock OTel
+ * Ec2Resource does not), so the SDK can resolve ec2:&lt;asg&gt; like the CloudWatch agent. A local
+ * HTTP server stands in for IMDS.
+ */
+class Ec2AutoScalingGroupFetcherTest {
+
+  private static final String TOKEN = "fake-token";
+  private static final String TOKEN_PATH = "/latest/api/token";
+  private static final String ASG_PATH =
+      "/latest/meta-data/tags/instance/aws:autoscaling:groupName";
+
+  private HttpServer server;
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+      server = null;
+    }
+  }
+
+  private String endpointFor(HttpHandler handler) throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", handler);
+    server.start();
+    return "127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(status, bytes.length == 0 ? -1 : bytes.length);
+    try (OutputStream os = exchange.getResponseBody()) {
+      os.write(bytes);
+    }
+  }
+
+  @Test
+  void fetchesAsgFromImdsTags() throws IOException {
+    AtomicReference<String> seenToken = new AtomicReference<>();
+    String endpoint =
+        endpointFor(
+            exchange -> {
+              String path = exchange.getRequestURI().getPath();
+              if ("PUT".equals(exchange.getRequestMethod()) && TOKEN_PATH.equals(path)) {
+                respond(exchange, 200, TOKEN);
+              } else if (ASG_PATH.equals(path)) {
+                seenToken.set(exchange.getRequestHeaders().getFirst("X-aws-ec2-metadata-token"));
+                respond(exchange, 200, "my-asg");
+              } else {
+                respond(exchange, 404, "");
+              }
+            });
+
+    String asg = new Ec2AutoScalingGroupFetcher(endpoint).fetch();
+
+    assertThat(asg).isEqualTo("my-asg");
+    // The token from the PUT must be forwarded on the tag GET.
+    assertThat(seenToken.get()).isEqualTo(TOKEN);
+  }
+
+  @Test
+  void trimsWhitespaceFromAsgValue() throws IOException {
+    String endpoint =
+        endpointFor(
+            exchange -> {
+              if (ASG_PATH.equals(exchange.getRequestURI().getPath())) {
+                respond(exchange, 200, "  my-asg\n");
+              } else {
+                respond(exchange, 200, TOKEN);
+              }
+            });
+
+    assertThat(new Ec2AutoScalingGroupFetcher(endpoint).fetch()).isEqualTo("my-asg");
+  }
+
+  @Test
+  void emptyWhenTagsDisabled() throws IOException {
+    // 404 on the tag path mimics instance metadata tags not being enabled.
+    String endpoint =
+        endpointFor(
+            exchange -> {
+              if (TOKEN_PATH.equals(exchange.getRequestURI().getPath())) {
+                respond(exchange, 200, TOKEN);
+              } else {
+                respond(exchange, 404, "");
+              }
+            });
+
+    assertThat(new Ec2AutoScalingGroupFetcher(endpoint).fetch()).isEmpty();
+  }
+
+  @Test
+  void emptyWhenNotOnEc2() {
+    // Point at a closed port — connection refused, mimicking "not on EC2".
+    assertThat(new Ec2AutoScalingGroupFetcher("127.0.0.1:1").fetch()).isEmpty();
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/environment/EnvironmentResolverTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/environment/EnvironmentResolverTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers.environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The SDK-side resolver must produce the SAME aws.local.environment the CloudWatch agent's
+ * awsapplicationsignals resolver produces, from the same OTel resource attributes. Precedence:
+ * explicit deployment.environment[.name] -> eks/k8s cluster/namespace -> ecs:&lt;cluster&gt; ->
+ * ec2:&lt;asg&gt; -> ec2:default.
+ */
+class EnvironmentResolverTest {
+
+  private static final Supplier<String> NO_ASG = () -> "";
+
+  private static Resource resourceOf(String... keyValues) {
+    AttributesBuilder builder = Attributes.builder();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      builder.put(keyValues[i], keyValues[i + 1]);
+    }
+    return Resource.create(builder.build());
+  }
+
+  private static String resolve(Resource resource, Supplier<String> asg) {
+    return EnvironmentResolver.resolveLocalEnvironment(resource, asg);
+  }
+
+  @Test
+  void explicitEnvironmentNameWins() {
+    Resource resource =
+        resourceOf(
+            "deployment.environment.name", "my-env",
+            "k8s.cluster.name", "c",
+            "k8s.namespace.name", "ns",
+            "cloud.platform", "aws_eks",
+            "ec2.tag.aws:autoscaling:groupName", "asg");
+    assertThat(resolve(resource, () -> "asg")).isEqualTo("my-env");
+  }
+
+  @Test
+  void legacyDeploymentEnvironmentHonored() {
+    assertThat(resolve(resourceOf("deployment.environment", "legacy-env"), NO_ASG))
+        .isEqualTo("legacy-env");
+  }
+
+  @Test
+  void environmentNamePreferredOverLegacy() {
+    Resource resource =
+        resourceOf("deployment.environment.name", "new", "deployment.environment", "legacy");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("new");
+  }
+
+  @Test
+  void eksClusterNamespace() {
+    Resource resource =
+        resourceOf(
+            "cloud.platform", "aws_eks",
+            "k8s.cluster.name", "my-cluster",
+            "k8s.namespace.name", "default");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("eks:my-cluster/default");
+  }
+
+  @Test
+  void eksMissingNamespaceFallsBackToUnknown() {
+    Resource resource = resourceOf("cloud.platform", "aws_eks", "k8s.cluster.name", "my-cluster");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("eks:my-cluster/UnknownNamespace");
+  }
+
+  @Test
+  void nonEksKubernetesUsesK8sPrefix() {
+    Resource resource = resourceOf("k8s.cluster.name", "c", "k8s.namespace.name", "team-a");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("k8s:c/team-a");
+  }
+
+  @Test
+  void ecsClusterFromArn() {
+    Resource resource =
+        resourceOf(
+            "cloud.platform", "aws_ecs",
+            "aws.ecs.cluster.arn", "arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("ecs:my-ecs-cluster");
+  }
+
+  @Test
+  void explicitEnvironmentWinsOverEcs() {
+    Resource resource =
+        resourceOf(
+            "deployment.environment.name", "prod",
+            "cloud.platform", "aws_ecs",
+            "aws.ecs.cluster.arn", "arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("prod");
+  }
+
+  @Test
+  void ec2WithAsg() {
+    Resource resource = resourceOf("cloud.platform", "aws_ec2");
+    assertThat(resolve(resource, () -> "my-asg")).isEqualTo("ec2:my-asg");
+  }
+
+  @Test
+  void ec2WithoutAsgDefaults() {
+    Resource resource = resourceOf("cloud.platform", "aws_ec2");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("ec2:default");
+  }
+
+  @Test
+  void emptyResourceNonAwsReturnsGenericDefault() {
+    // No platform signal (non-AWS / undetected host): the agent runs its "generic" resolver and
+    // emits "generic:default", so the SDK matches that rather than claiming ec2:default.
+    assertThat(resolve(Resource.empty(), NO_ASG)).isEqualTo("generic:default");
+  }
+
+  @Test
+  void nullResourceReturnsGenericDefault() {
+    assertThat(resolve(null, NO_ASG)).isEqualTo("generic:default");
+  }
+
+  @Test
+  void ec2DefaultWhenHostIdPresent() {
+    // host.id (EC2 instance id from the OTel EC2 detector) marks the host as EC2.
+    assertThat(resolve(resourceOf("cloud.platform", "aws_ec2", "host.id", "i-0abc"), NO_ASG))
+        .isEqualTo("ec2:default");
+  }
+
+  @Test
+  void nonAwsHostWithServiceNameReturnsGenericDefault() {
+    assertThat(resolve(resourceOf("service.name", "svc", "host.name", "my-vm"), NO_ASG))
+        .isEqualTo("generic:default");
+  }
+
+  @Test
+  void kubernetesPrecedesEc2() {
+    // When both k8s and ec2 ASG are present (unusual), Kubernetes wins, matching the agent.
+    Resource resource = resourceOf("k8s.cluster.name", "c", "k8s.namespace.name", "ns");
+    assertThat(resolve(resource, () -> "asg")).isEqualTo("k8s:c/ns");
+  }
+
+  @Test
+  void asgSupplierNotInvokedWhenNotEc2Branch() {
+    // EKS resolves without ever calling the ASG supplier (no IMDS lookup off the EC2 path).
+    Resource resource =
+        resourceOf("cloud.platform", "aws_eks", "k8s.cluster.name", "c", "k8s.namespace.name", "n");
+    Supplier<String> throwingAsg =
+        () -> {
+          throw new AssertionError("ASG supplier must not be invoked on the EKS branch");
+        };
+    assertThat(resolve(resource, throwingAsg)).isEqualTo("eks:c/n");
+  }
+
+  @Test
+  void whitespaceOnlyExplicitEnvIgnored() {
+    Resource resource =
+        resourceOf(
+            "deployment.environment.name", "   ",
+            "cloud.platform", "aws_eks",
+            "k8s.cluster.name", "my-cluster",
+            "k8s.namespace.name", "default");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("eks:my-cluster/default");
+  }
+
+  @Test
+  void ecsEmptyClusterArnFallsThroughToGenericDefault() {
+    // Empty cluster segment + cloud.platform=aws_ecs (not aws_ec2) and no EC2 signal →
+    // "generic:default" (the agent's generic resolver), not ec2:default.
+    Resource resource =
+        resourceOf("cloud.platform", "aws_ecs", "aws.ecs.cluster.arn", "arn:.../cluster/");
+    assertThat(resolve(resource, NO_ASG)).isEqualTo("generic:default");
+  }
+
+  @Test
+  void withLocalEnvironmentStampsResolvedValue() {
+    Resource resource =
+        resourceOf(
+            "cloud.platform", "aws_eks",
+            "k8s.cluster.name", "my-cluster",
+            "k8s.namespace.name", "default");
+    Resource stamped = EnvironmentResolver.withLocalEnvironment(resource, NO_ASG);
+    assertThat(stamped.getAttribute(EnvironmentResolver.LOCAL_ENVIRONMENT_KEY))
+        .isEqualTo("eks:my-cluster/default");
+  }
+
+  @Test
+  void withLocalEnvironmentDoesNotOverwriteExisting() {
+    Resource resource =
+        Resource.create(
+            Attributes.builder()
+                .put("aws.local.environment", "already-set")
+                .put("cloud.platform", "aws_eks")
+                .put("k8s.cluster.name", "c")
+                .put("k8s.namespace.name", "ns")
+                .build());
+    Resource stamped = EnvironmentResolver.withLocalEnvironment(resource, NO_ASG);
+    assertThat(stamped.getAttribute(EnvironmentResolver.LOCAL_ENVIRONMENT_KEY))
+        .isEqualTo("already-set");
+  }
+
+  @Test
+  void withLocalEnvironmentStampsGenericDefaultOnNonAwsHost() {
+    // Non-AWS host → resolver returns "generic:default" (matches the agent's generic resolver),
+    // so the key is stamped with that rather than omitted or set to ec2:default.
+    Resource resource = resourceOf("service.name", "svc", "host.name", "my-vm");
+    Resource stamped = EnvironmentResolver.withLocalEnvironment(resource, NO_ASG);
+    assertThat(stamped.getAttribute(EnvironmentResolver.LOCAL_ENVIRONMENT_KEY))
+        .isEqualTo("generic:default");
+  }
+
+  @Test
+  void hasPlatformContextTrueForKnownPlatform() {
+    assertThat(EnvironmentResolver.hasPlatformContext(resourceOf("cloud.platform", "aws_ec2")))
+        .isTrue();
+    assertThat(EnvironmentResolver.hasPlatformContext(Resource.empty())).isFalse();
+    assertThat(EnvironmentResolver.hasPlatformContext(null)).isFalse();
+  }
+}

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/ServiceEventsInstrumentation.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/ServiceEventsInstrumentation.java
@@ -44,6 +44,7 @@ import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.exp
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.exporter.ServiceEventsCloudWatchLogFileExporter;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.exporter.ServiceEventsCloudWatchMetricFileExporter;
 import software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.exporter.ServiceEventsOtlpEmitter;
+import software.amazon.opentelemetry.javaagent.providers.environment.EnvironmentResolver;
 import software.amazon.opentelemetry.javaagent.providers.exporter.otlp.aws.logs.OtlpAwsLogRecordExporterBuilder;
 
 /**
@@ -484,12 +485,16 @@ public class ServiceEventsInstrumentation {
               java.lang.reflect.Method getResource = holderClass.getMethod("getResource");
               Resource holderResource = (Resource) getResource.invoke(null);
               if (holderResource != null && !holderResource.equals(Resource.getDefault())) {
-                return holderResource;
+                // SDK-only environment resolution: stamp aws.local.environment computed from the
+                // detected resource using the same precedence as the CloudWatch agent, so
+                // ServiceEvents correlates with Application Signals. An explicit
+                // deployment.environment[.name] still wins via the resolver's precedence.
+                return EnvironmentResolver.withLocalEnvironment(holderResource);
               }
             } catch (Throwable ignored) {
               // ResourceHolder not available or not yet populated — use fallback
             }
-            return fallbackResource;
+            return EnvironmentResolver.withLocalEnvironment(fallbackResource);
           };
 
       // Log the endpoint mode now (before lazy init)


### PR DESCRIPTION
ServiceEvents and Dynamic Instrumentation need aws.local.environment, which today only the CloudWatch agent sets. This adds an SDK-side resolver that computes the same value the agent's awsapplicationsignals resolver would, from the OTel Resource, with no dependency on the agent process:

- EnvironmentResolver: mirror the agent's precedence — explicit deployment.environment[.name] -> eks/k8s:<cluster>/<namespace> -> ecs:<cluster> -> ec2:<asg>/ec2:default -> generic:default (never empty, matching the agent's generic resolver off-platform).
- Ec2AutoScalingGroupFetcher: read the ASG name from IMDS instance tags (the stock OTel EC2 detector omits it), invoked lazily only on the EC2 branch and memoized process-wide.
- DI: resolve aws.local.environment for the instrumentation-config lookup key from the autoconfigured resource.

Unit tests included for the resolver, ASG fetcher, and DI config.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
