### PR TITLE
Redact AWS presigned URL credentials in span attributes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 - fix(serviceevents): gate incident correlation on SAMPLED + per-collector fault isolation
   ([#1416](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1416))
+- fix: redact AWS presigned URL credentials from span attributes
+  ([#1419](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1419))
 
 ## v2.29.0 - 2026-07-02
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProvider.java
@@ -20,6 +20,21 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvide
 import java.util.HashMap;
 
 public class AwsAgentPropertiesCustomizerProvider implements AutoConfigurationCustomizerProvider {
+
+  static final String SENSITIVE_QUERY_PARAMETERS_CONFIG =
+      "otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters";
+
+  static final String AWS_SENSITIVE_QUERY_PARAMETERS =
+      String.join(
+          ",",
+          "AWSAccessKeyId",
+          "Signature",
+          "sig",
+          "X-Goog-Signature",
+          "X-Amz-Signature",
+          "X-Amz-Credential",
+          "X-Amz-Security-Token");
+
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
     autoConfiguration.addPropertiesSupplier(
@@ -31,6 +46,7 @@ public class AwsAgentPropertiesCustomizerProvider implements AutoConfigurationCu
                 put(
                     "otel.instrumentation.aws-sdk.experimental-record-individual-http-error",
                     "true");
+                put(SENSITIVE_QUERY_PARAMETERS_CONFIG, AWS_SENSITIVE_QUERY_PARAMETERS);
               }
             });
   }

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProviderTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsAgentPropertiesCustomizerProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAgentPropertiesCustomizerProvider.AWS_SENSITIVE_QUERY_PARAMETERS;
+import static software.amazon.opentelemetry.javaagent.providers.AwsAgentPropertiesCustomizerProvider.SENSITIVE_QUERY_PARAMETERS_CONFIG;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AwsAgentPropertiesCustomizerProviderTest {
+
+  @Test
+  void sensitiveQueryParametersConfigKeyIsCorrect() {
+    assertThat(SENSITIVE_QUERY_PARAMETERS_CONFIG)
+        .isEqualTo("otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters");
+  }
+
+  @Test
+  void sensitiveQueryParametersIncludesAwsPresignedUrlCredentials() {
+    Set<String> params = new HashSet<>(Arrays.asList(AWS_SENSITIVE_QUERY_PARAMETERS.split(",")));
+
+    assertThat(params).contains("X-Amz-Signature");
+    assertThat(params).contains("X-Amz-Credential");
+    assertThat(params).contains("X-Amz-Security-Token");
+  }
+
+  @Test
+  void sensitiveQueryParametersIncludesUpstreamDefaults() {
+    Set<String> params = new HashSet<>(Arrays.asList(AWS_SENSITIVE_QUERY_PARAMETERS.split(",")));
+
+    assertThat(params).contains("AWSAccessKeyId");
+    assertThat(params).contains("Signature");
+    assertThat(params).contains("sig");
+    assertThat(params).contains("X-Goog-Signature");
+  }
+}


### PR DESCRIPTION
The OTel semconv spec mandates that X-Amz-Signature, X-Amz-Credential, and X-Amz-Security-Token are redacted by default, but the upstream Java instrumentation only ships AWSAccessKeyId, Signature, sig, and X-Goog-Signature. This causes presigned S3 URL credentials to leak into trace stores unredacted.

Set otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters to include the full spec-mandated list as a default property in the ADOT agent, so customers get safe-by-default behavior without needing to configure the env var themselves.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
