### PR TITLE
ci: parallelize contract tests and fix ECR rate limits

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch', '.github/patches/versions') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
@@ -235,7 +235,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch', '.github/patches/versions') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -248,7 +248,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
-          java-version: 23
+          java-version-file: .java-version
           distribution: 'temurin'
       - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #v4.4.3
 
@@ -270,10 +270,10 @@ jobs:
             ~/.m2/repository/io/opentelemetry/
           key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
-      - name: Pull base image of Contract Tests Sample Apps
+      - name: Pull base image of DI Contract Tests Sample Apps
         run: |
           for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine && break
             echo "Pull attempt $i failed, retrying in $((i * 15))s..."
             sleep $((i * 15))
           done

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -197,59 +197,26 @@ jobs:
   # AppSignals Contract Tests
   contract-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - { name: contract-tests, task: contractTests }
+          - { name: di-contract-tests, task: diContractTests }
+          - { name: serviceevents-contract-tests, task: serviceeventsContractTests }
+    name: ${{ matrix.suite.name }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.sha }}
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
-        with:
-          java-version: 23
-          distribution: 'temurin'
-      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #v4.4.3
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-      - name: Log in to AWS ECR
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-        with:
-          registry: public.ecr.aws
-
-      - name: Cache local Maven repository
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
-        with:
-          path: |
-            ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
-      - name: Pull base image of Contract Tests Sample Apps
-        run: |
-          for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
-            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
-          done
-
-      - name: Run contract tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
-        with:
-          arguments: contractTests -PlocalDocker=true
-
-  di-contract-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.ref || github.sha }}
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           java-version-file: .java-version
           distribution: 'temurin'
+
       - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #v4.4.3
 
       - name: Configure AWS Credentials
@@ -270,69 +237,26 @@ jobs:
             ~/.m2/repository/io/opentelemetry/
           key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_password: ${{ secrets.GPG_PASSPHRASE }}
+
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           java-version: 23
           distribution: 'temurin'
 
-      - name: Pull base images for DI Contract Tests
+      - name: Pull base images
         run: |
-          for image in public.ecr.aws/docker/library/amazoncorretto:23-alpine public.ecr.aws/docker/library/amazoncorretto:17-alpine; do
-            for i in 1 2 3 4 5; do
-              docker pull $image && break
-              echo "Pull attempt $i for $image failed, retrying in $((i * 15))s..."
-              sleep $((i * 15))
-            done
-          done
+          docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+          docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine
 
-      - name: Run DI contract tests
+      - name: Run ${{ matrix.suite.name }}
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: diContractTests -PlocalDocker=true
-
-  serviceevents-contract-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.ref || github.sha }}
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
-        with:
-          java-version: 23
-          distribution: 'temurin'
-      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #v4.4.3
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-      - name: Log in to AWS ECR
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-        with:
-          registry: public.ecr.aws
-
-      - name: Cache local Maven repository
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
-        with:
-          path: |
-            ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
-      - name: Pull base image of Contract Tests Sample Apps
-        run: |
-          for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
-            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
-          done
-
-      - name: Run Service Events contract tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
-        with:
-          arguments: serviceeventsContractTests -PlocalDocker=true
+          arguments: ${{ matrix.suite.task }} -PlocalDocker=true
 
   application-signals-lambda-layer-build:
     runs-on: ubuntu-latest
@@ -374,7 +298,7 @@ jobs:
 
   publish-build-status:
     name: "Publish Main Build Status"
-    needs: [ build, e2e-test, contract-tests, di-contract-tests, serviceevents-contract-tests, application-signals-lambda-layer-build, application-signals-e2e-test ]
+    needs: [ build, e2e-test, contract-tests, application-signals-lambda-layer-build, application-signals-e2e-test ]
     runs-on: ubuntu-latest
     if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/v'))
     steps:
@@ -386,7 +310,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' && needs.di-contract-tests.result == 'success' && needs.serviceevents-contract-tests.result == 'success' && needs.application-signals-lambda-layer-build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0' }}"
+          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-lambda-layer-build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0' }}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -275,12 +275,14 @@ jobs:
           java-version: 23
           distribution: 'temurin'
 
-      - name: Pull base image of Contract Tests Sample Apps
+      - name: Pull base images for DI Contract Tests
         run: |
-          for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
-            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
+          for image in public.ecr.aws/docker/library/amazoncorretto:23-alpine public.ecr.aws/docker/library/amazoncorretto:17-alpine; do
+            for i in 1 2 3 4 5; do
+              docker pull $image && break
+              echo "Pull attempt $i for $image failed, retrying in $((i * 15))s..."
+              sleep $((i * 15))
+            done
           done
 
       - name: Run DI contract tests

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -270,10 +270,15 @@ jobs:
             ~/.m2/repository/io/opentelemetry/
           key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
-      - name: Pull base image of DI Contract Tests Sample Apps
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
+        with:
+          java-version: 23
+          distribution: 'temurin'
+
+      - name: Pull base image of Contract Tests Sample Apps
         run: |
           for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine && break
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
             echo "Pull attempt $i failed, retrying in $((i * 15))s..."
             sleep $((i * 15))
           done

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -197,7 +197,6 @@ jobs:
   # AppSignals Contract Tests
   contract-tests:
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
@@ -220,9 +219,7 @@ jobs:
         with:
           registry: public.ecr.aws
 
-      # cache local patch outputs
       - name: Cache local Maven repository
-        id: cache-local-maven-repo
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
         with:
           path: |
@@ -230,12 +227,105 @@ jobs:
           key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
 
       - name: Pull base image of Contract Tests Sample Apps
-        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
 
-      - name: Build snapshot with Gradle
+      - name: Run contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
           arguments: contractTests -PlocalDocker=true
+
+  di-contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.sha }}
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
+        with:
+          java-version: 23
+          distribution: 'temurin'
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #v4.4.3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: public.ecr.aws
+
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
+      - name: Pull base image of Contract Tests Sample Apps
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
+
+      - name: Run DI contract tests
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
+        with:
+          arguments: diContractTests -PlocalDocker=true
+
+  serviceevents-contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.sha }}
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
+        with:
+          java-version: 23
+          distribution: 'temurin'
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #v4.4.3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Log in to AWS ECR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: public.ecr.aws
+
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
+      - name: Pull base image of Contract Tests Sample Apps
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
+
+      - name: Run Service Events contract tests
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
+        with:
+          arguments: serviceeventsContractTests -PlocalDocker=true
 
   application-signals-lambda-layer-build:
     runs-on: ubuntu-latest
@@ -277,7 +367,7 @@ jobs:
 
   publish-build-status:
     name: "Publish Main Build Status"
-    needs: [ build, e2e-test, contract-tests, application-signals-lambda-layer-build, application-signals-e2e-test ]
+    needs: [ build, e2e-test, contract-tests, di-contract-tests, serviceevents-contract-tests, application-signals-lambda-layer-build, application-signals-e2e-test ]
     runs-on: ubuntu-latest
     if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/v'))
     steps:
@@ -289,7 +379,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' && needs.application-signals-lambda-layer-build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0' }}"
+          value="${{ needs.build.result == 'success' && needs.e2e-test.result == 'success' && needs.contract-tests.result == 'success' && needs.di-contract-tests.result == 'success' && needs.serviceevents-contract-tests.result == 'success' && needs.application-signals-lambda-layer-build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0' }}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -288,18 +288,10 @@ jobs:
           java-version: 23
           distribution: temurin
 
-      - name: Pull base image of Contract Tests Sample Apps
-        run: |
-          for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
-            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
-          done
-
       - name: Run contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: contractTests -PlocalDocker=true -i
+          arguments: contractTests -i
 
   di-contract-tests:
     runs-on: ubuntu-latest
@@ -333,20 +325,10 @@ jobs:
           java-version: 23
           distribution: temurin
 
-      - name: Pull base images for DI Contract Tests
-        run: |
-          for image in public.ecr.aws/docker/library/amazoncorretto:23-alpine public.ecr.aws/docker/library/amazoncorretto:17-alpine; do
-            for i in 1 2 3 4 5; do
-              docker pull $image && break
-              echo "Pull attempt $i for $image failed, retrying in $((i * 15))s..."
-              sleep $((i * 15))
-            done
-          done
-
       - name: Run DI contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: diContractTests -PlocalDocker=true -i
+          arguments: diContractTests -i
 
   serviceevents-contract-tests:
     runs-on: ubuntu-latest
@@ -380,18 +362,10 @@ jobs:
           java-version: 23
           distribution: temurin
 
-      - name: Pull base image of Contract Tests Sample Apps
-        run: |
-          for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
-            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
-          done
-
       - name: Run Service Events contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: serviceeventsContractTests -PlocalDocker=true -i
+          arguments: serviceeventsContractTests -i
 
   build-lambda:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -328,10 +328,15 @@ jobs:
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
 
-      - name: Pull base image of DI Contract Tests Sample Apps
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: 23
+          distribution: temurin
+
+      - name: Pull base image of Contract Tests Sample Apps
         run: |
           for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine && break
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
             echo "Pull attempt $i failed, retrying in $((i * 15))s..."
             sleep $((i * 15))
           done

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -256,8 +256,27 @@ jobs:
           arguments: build --stacktrace -PenableCoverage=true
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
 
+  pull-base-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull and export base images
+        run: |
+          docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+          docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine
+          docker save \
+            public.ecr.aws/docker/library/amazoncorretto:23-alpine \
+            public.ecr.aws/docker/library/amazoncorretto:17-alpine \
+            -o base-images.tar
+      - name: Upload base images
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: contract-test-base-images
+          path: base-images.tar
+          retention-days: 1
+
   contract-tests:
     runs-on: ubuntu-latest
+    needs: pull-base-images
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
@@ -287,14 +306,22 @@ jobs:
         with:
           java-version: 23
           distribution: temurin
+
+      - name: Download base images
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: contract-test-base-images
+      - name: Load base images
+        run: docker load -i base-images.tar
 
       - name: Run contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: contractTests -i
+          arguments: contractTests -PlocalDocker=true -i
 
   di-contract-tests:
     runs-on: ubuntu-latest
+    needs: pull-base-images
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
@@ -324,14 +351,22 @@ jobs:
         with:
           java-version: 23
           distribution: temurin
+
+      - name: Download base images
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: contract-test-base-images
+      - name: Load base images
+        run: docker load -i base-images.tar
 
       - name: Run DI contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: diContractTests -i
+          arguments: diContractTests -PlocalDocker=true -i
 
   serviceevents-contract-tests:
     runs-on: ubuntu-latest
+    needs: pull-base-images
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
@@ -362,10 +397,17 @@ jobs:
           java-version: 23
           distribution: temurin
 
+      - name: Download base images
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: contract-test-base-images
+      - name: Load base images
+        run: docker load -i base-images.tar
+
       - name: Run Service Events contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: serviceeventsContractTests -i
+          arguments: serviceeventsContractTests -PlocalDocker=true -i
 
   build-lambda:
     runs-on: ubuntu-latest
@@ -392,7 +434,7 @@ jobs:
 
   all-pr-checks-pass:
     runs-on: ubuntu-latest
-    needs: [static-code-checks, testpatch, build, contract-tests, di-contract-tests, serviceevents-contract-tests, build-lambda]
+    needs: [static-code-checks, testpatch, build, pull-base-images, contract-tests, di-contract-tests, serviceevents-contract-tests, build-lambda]
     if: always()
     steps:
       - name: Checkout to get workflow file

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -208,28 +208,6 @@ jobs:
         run: |
           ./gradlew build -p exporters/aws-distro-opentelemetry-xray-udp-span-exporter
 
-      - name: Set up Java version for tests
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version: 23
-          distribution: temurin
-
-      - name: Pull base image of Contract Tests Sample Apps
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
-
-      - name: Run contract tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        with:
-          arguments: contractTests -PlocalDocker=true -i
-
-      - name: Set up Java version for image build
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version-file: .java-version
-          distribution: temurin
-
       - name: Get current version
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
@@ -278,6 +256,126 @@ jobs:
           arguments: build --stacktrace -PenableCoverage=true
       - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
 
+  contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version-file: .java-version
+          distribution: temurin
+
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Clean up old installations
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: 23
+          distribution: temurin
+
+      - name: Pull base image of Contract Tests Sample Apps
+        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+
+      - name: Run contract tests
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
+        with:
+          arguments: contractTests -PlocalDocker=true -i
+
+  di-contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version-file: .java-version
+          distribution: temurin
+
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Clean up old installations
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: 23
+          distribution: temurin
+
+      - name: Pull base image of Contract Tests Sample Apps
+        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+
+      - name: Run DI contract tests
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
+        with:
+          arguments: diContractTests -PlocalDocker=true -i
+
+  serviceevents-contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version-file: .java-version
+          distribution: temurin
+
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
+      - name: Clean up old installations
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
+      - name: Publish patched dependencies to maven local
+        uses: ./.github/actions/patch-dependencies
+
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: 23
+          distribution: temurin
+
+      - name: Pull base image of Contract Tests Sample Apps
+        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+
+      - name: Run Service Events contract tests
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
+        with:
+          arguments: serviceeventsContractTests -PlocalDocker=true -i
+
   build-lambda:
     runs-on: ubuntu-latest
     steps:
@@ -290,13 +388,20 @@ jobs:
           java-version-file: .java-version
           distribution: temurin
 
+      - name: Cache local Maven repository
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: |
+            ~/.m2/repository/io/opentelemetry/
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+
       - name: Build layer
         working-directory: lambda-layer
         run: ./build-layer.sh
 
   all-pr-checks-pass:
     runs-on: ubuntu-latest
-    needs: [static-code-checks, testpatch, build, build-lambda]
+    needs: [static-code-checks, testpatch, build, contract-tests, di-contract-tests, serviceevents-contract-tests, build-lambda]
     if: always()
     steps:
       - name: Checkout to get workflow file

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -328,15 +328,10 @@ jobs:
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
 
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version: 23
-          distribution: temurin
-
-      - name: Pull base image of Contract Tests Sample Apps
+      - name: Pull base image of DI Contract Tests Sample Apps
         run: |
           for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            docker pull public.ecr.aws/docker/library/amazoncorretto:17-alpine && break
             echo "Pull attempt $i failed, retrying in $((i * 15))s..."
             sleep $((i * 15))
           done

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch', '.github/patches/versions') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies
@@ -258,6 +258,7 @@ jobs:
 
   pull-base-images:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Pull and export base images
         run: |
@@ -306,7 +307,7 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
+          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch', '.github/patches/versions') }}
 
       - name: Publish patched dependencies to maven local
         uses: ./.github/actions/patch-dependencies

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -277,6 +277,15 @@ jobs:
   contract-tests:
     runs-on: ubuntu-latest
     needs: pull-base-images
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - { name: contract-tests, task: contractTests }
+          - { name: di-contract-tests, task: diContractTests }
+          - { name: serviceevents-contract-tests, task: serviceeventsContractTests }
+    name: ${{ matrix.suite.name }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
@@ -314,103 +323,14 @@ jobs:
       - name: Load base images
         run: docker load -i base-images.tar
 
-      - name: Run contract tests
+      - name: Run ${{ matrix.suite.name }}
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
         with:
-          arguments: contractTests -PlocalDocker=true -i
-
-  di-contract-tests:
-    runs-on: ubuntu-latest
-    needs: pull-base-images
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version-file: .java-version
-          distribution: temurin
-
-      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
-
-      - name: Clean up old installations
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-
-      - name: Cache local Maven repository
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
-        with:
-          path: |
-            ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
-      - name: Publish patched dependencies to maven local
-        uses: ./.github/actions/patch-dependencies
-
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version: 23
-          distribution: temurin
-
-      - name: Download base images
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-        with:
-          name: contract-test-base-images
-      - name: Load base images
-        run: docker load -i base-images.tar
-
-      - name: Run DI contract tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
-        with:
-          arguments: diContractTests -PlocalDocker=true -i
-
-  serviceevents-contract-tests:
-    runs-on: ubuntu-latest
-    needs: pull-base-images
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version-file: .java-version
-          distribution: temurin
-
-      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
-
-      - name: Clean up old installations
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-
-      - name: Cache local Maven repository
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
-        with:
-          path: |
-            ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
-      - name: Publish patched dependencies to maven local
-        uses: ./.github/actions/patch-dependencies
-
-      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          java-version: 23
-          distribution: temurin
-
-      - name: Download base images
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-        with:
-          name: contract-test-base-images
-      - name: Load base images
-        run: docker load -i base-images.tar
-
-      - name: Run Service Events contract tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
-        with:
-          arguments: serviceeventsContractTests -PlocalDocker=true -i
+          arguments: ${{ matrix.suite.task }} -PlocalDocker=true -i
 
   build-lambda:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -421,20 +341,13 @@ jobs:
           java-version-file: .java-version
           distribution: temurin
 
-      - name: Cache local Maven repository
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
-        with:
-          path: |
-            ~/.m2/repository/io/opentelemetry/
-          key: ${{ runner.os }}-maven-local-${{ hashFiles('.github/patches/opentelemetry-java*.patch') }}
-
       - name: Build layer
         working-directory: lambda-layer
         run: ./build-layer.sh
 
   all-pr-checks-pass:
     runs-on: ubuntu-latest
-    needs: [static-code-checks, testpatch, build, pull-base-images, contract-tests, di-contract-tests, serviceevents-contract-tests, build-lambda]
+    needs: [static-code-checks, testpatch, build, pull-base-images, contract-tests, build-lambda]
     if: always()
     steps:
       - name: Checkout to get workflow file

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -289,7 +289,12 @@ jobs:
           distribution: temurin
 
       - name: Pull base image of Contract Tests Sample Apps
-        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
 
       - name: Run contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
@@ -329,7 +334,12 @@ jobs:
           distribution: temurin
 
       - name: Pull base image of Contract Tests Sample Apps
-        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
 
       - name: Run DI contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0
@@ -369,7 +379,12 @@ jobs:
           distribution: temurin
 
       - name: Pull base image of Contract Tests Sample Apps
-        run: docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
+            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
 
       - name: Run Service Events contract tests
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 #v3.5.0

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -333,12 +333,14 @@ jobs:
           java-version: 23
           distribution: temurin
 
-      - name: Pull base image of Contract Tests Sample Apps
+      - name: Pull base images for DI Contract Tests
         run: |
-          for i in 1 2 3 4 5; do
-            docker pull public.ecr.aws/docker/library/amazoncorretto:23-alpine && break
-            echo "Pull attempt $i failed, retrying in $((i * 15))s..."
-            sleep $((i * 15))
+          for image in public.ecr.aws/docker/library/amazoncorretto:23-alpine public.ecr.aws/docker/library/amazoncorretto:17-alpine; do
+            for i in 1 2 3 4 5; do
+              docker pull $image && break
+              echo "Pull attempt $i for $image failed, retrying in $((i * 15))s..."
+              sleep $((i * 15))
+            done
           done
 
       - name: Run DI contract tests


### PR DESCRIPTION
## Summary
- **Shard contract tests into parallel matrix**: Split the monolithic ubuntu `build` job's contract tests into 3 independent parallel jobs via `strategy.matrix` (contractTests, diContractTests, serviceeventsContractTests). Each runs with its own patched dependencies.
- **Fix ECR rate limits (PR build)**: Add a `pull-base-images` job that pulls amazoncorretto base images once, exports as a tarball artifact. Contract test shards download and `docker load` before running with `-PlocalDocker=true`.
- **Fix ECR rate limits (main build)**: Uses authenticated ECR login (higher rate limit) with direct pulls — no retry loops needed.
- **Add `timeout-minutes: 45`** to contract-tests and build-lambda to prevent hung jobs from burning 6h of runner time.
- **Main-build: add `patch-dependencies`** to contract test jobs (fixes correctness bug on cache miss when jobs run without `needs: build`).

## Test plan
- [ ] PR build completes with all jobs green
- [ ] All 3 contract test matrix entries pass
- [ ] No ECR rate limit failures
- [ ] Main build contract tests pass on cache miss (patch-dependencies runs)
- [ ] Overall PR build wall-clock time is reduced vs baseline