### PR TITLE
Add throw-site origin to incident-snapshot dedup hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 - Update Lambda layer compatible runtimes to include java25
   ([#1407](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1407))
+- fix(serviceevents): fold throw-site origin (`class.method`) into the incident-snapshot dedup hash
+  ([#1422](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1422))
 - fix(serviceevents): preserve map key order in OTLP log body so incident snapshot fields
   (e.g. `exception_info`) serialize in schema order instead of reversed
   ([#1421](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1421))

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/IncidentRateLimiter.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/IncidentRateLimiter.java
@@ -15,9 +15,12 @@
 
 package software.amazon.opentelemetry.serviceevents;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Rate limiter for incident snapshots. Handles global per-minute limiting and per-error-hash
@@ -54,6 +57,14 @@ final class IncidentRateLimiter {
 
   /** Maximum distinct error hashes tracked for deduplication. */
   private static final int MAX_ERROR_HASH_ENTRIES = 1000;
+
+  /**
+   * Matches a complete top JVM frame line: indented {@code "at <class.method>(<source>)"} running
+   * to end of line. Compiled once — {@link Pattern} is thread-safe and {@link #extractOriginMethod}
+   * runs on every recorded incident.
+   */
+  private static final Pattern TOP_FRAME_PATTERN =
+      Pattern.compile("(?m)^\\s+at\\s+([\\w$.<>/]+)\\([^()]*\\)\\s*$");
 
   /** All per-window rate-limiting state, atomically swapped on window boundaries. */
   private static final class Window {
@@ -128,7 +139,7 @@ final class IncidentRateLimiter {
     }
     try {
       java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
-      byte[] digest = md.digest(hashInput.getBytes());
+      byte[] digest = md.digest(hashInput.getBytes(StandardCharsets.UTF_8));
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < digest.length; i++) {
         sb.append(String.format("%02x", Byte.valueOf(digest[i])));
@@ -165,9 +176,7 @@ final class IncidentRateLimiter {
     // syntactically perfect, tab-indented full frame is indistinguishable from a real one in a flat
     // string and would still match; that is an accepted residual for this seam, which only ever
     // receives an already-formatted string.)
-    java.util.regex.Matcher m =
-        java.util.regex.Pattern.compile("(?m)^\\s+at\\s+([\\w$.<>/]+)\\([^()]*\\)\\s*$")
-            .matcher(stackTrace);
+    Matcher m = TOP_FRAME_PATTERN.matcher(stackTrace);
     if (m.find()) {
       return m.group(1);
     }

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/IncidentRateLimiter.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/IncidentRateLimiter.java
@@ -102,19 +102,29 @@ final class IncidentRateLimiter {
   }
 
   /**
-   * Generate a hash for deduplication based on operation and exception type.
+   * Generate a hash for deduplication based on operation, exception type, and throw-site method.
    *
    * <p>Intentionally excludes exceptionMessage to avoid unbounded hash proliferation when messages
-   * contain request-specific data (user IDs, timestamps, etc.).
+   * contain request-specific data (user IDs, timestamps, etc.). The origin method (parsed from the
+   * stack trace by {@link #extractOriginMethod}) is a bounded, deploy-stable substitute that still
+   * keeps distinct errors sharing one exception type apart — mirroring the file-qualified
+   * throw-site origin the Python ({@code module/path.function}) and JS ({@code file.function})
+   * distros fold into their key.
    *
+   * @param operation the operation the incident occurred on (never null at the call site)
+   * @param exceptionType exception class name, or null for a latency incident
+   * @param originMethod fully-qualified throw-site method, or null/empty if unavailable
    * @return hex-encoded MD5 hash, or hashCode fallback if MD5 is unavailable
    */
-  static String generateErrorHash(String operation, String exceptionType) {
+  static String generateErrorHash(String operation, String exceptionType, String originMethod) {
     String hashInput;
     if (exceptionType == null) {
+      // Latency incident: no exception → operation-only key (matches the pre-refactor behavior).
       hashInput = "op:" + operation;
-    } else {
+    } else if (originMethod == null || originMethod.isEmpty()) {
       hashInput = "op:" + operation + "|exc:" + exceptionType;
+    } else {
+      hashInput = "op:" + operation + "|exc:" + exceptionType + ":" + originMethod;
     }
     try {
       java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
@@ -127,6 +137,41 @@ final class IncidentRateLimiter {
     } catch (java.security.NoSuchAlgorithmException e) {
       return String.valueOf(hashInput.hashCode());
     }
+  }
+
+  /**
+   * Extract the fully-qualified throw-site method from the top frame of a JVM stack trace string.
+   *
+   * <p>The stack trace text (as produced by {@code Throwable.printStackTrace}) lists the throw site
+   * first, on the first complete frame line — indented and of the form {@code "\tat
+   * com.example.Foo.bar(Foo.java:42)"}. This returns the {@code com.example.Foo.bar} portion —
+   * class + method, without the {@code (file:line)} suffix. The line number is deliberately
+   * dropped: it is the least stable field (any edit above the throw site shifts it), so including
+   * it would make a recurring error re-fire as a brand-new incident after every deploy.
+   *
+   * @param stackTrace the exception stack trace string, or null
+   * @return the {@code class.method} of the throw site, or empty string if unparseable/absent
+   */
+  static String extractOriginMethod(String stackTrace) {
+    if (stackTrace == null || stackTrace.isEmpty()) {
+      return "";
+    }
+    // Match a complete frame line, not the header. A real JVM frame is indented and has the full
+    // "at <class.method>(<source>)" grammar: a method reference (word chars, '.', '$', '/' for the
+    // module prefix, and '<>' for the <init>/<clinit> constructor and static-initializer names)
+    // followed by a balanced "(...)" running to end of line. Requiring the whole grammar — not just
+    // a bare "at X(" prefix — means a message that embeds a truncated fragment (e.g.
+    // "boom\n\tat evil.pwn(") cannot false-match the real top frame. (A message embedding a
+    // syntactically perfect, tab-indented full frame is indistinguishable from a real one in a flat
+    // string and would still match; that is an accepted residual for this seam, which only ever
+    // receives an already-formatted string.)
+    java.util.regex.Matcher m =
+        java.util.regex.Pattern.compile("(?m)^\\s+at\\s+([\\w$.<>/]+)\\([^()]*\\)\\s*$")
+            .matcher(stackTrace);
+    if (m.find()) {
+      return m.group(1);
+    }
+    return "";
   }
 
   /**

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStore.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStore.java
@@ -578,9 +578,17 @@ public final class ServiceEventsDataStore {
         return;
       }
 
-      // Deduplication: reject if the same error hash has been seen too many times this period
+      // Deduplication: reject if the same error hash has been seen too many times this period.
+      // Key on operation + exception type + throw-site method. The origin method is parsed from the
+      // stack trace here (Python/JS recover the equivalent file-qualified origin); it keeps
+      // distinct
+      // errors sharing one exception type apart without folding the unbounded exception message
+      // into
+      // the key.
       String effectiveOperation = operation != null ? operation : method + " " + route;
-      String errorHash = IncidentRateLimiter.generateErrorHash(effectiveOperation, exceptionType);
+      String originMethod = IncidentRateLimiter.extractOriginMethod(stackTrace);
+      String errorHash =
+          IncidentRateLimiter.generateErrorHash(effectiveOperation, exceptionType, originMethod);
       if (!IncidentRateLimiter.checkErrorDeduplication(errorHash)) {
         return;
       }

--- a/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStoreIncidentRateLimitTest.java
+++ b/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStoreIncidentRateLimitTest.java
@@ -211,6 +211,137 @@ class ServiceEventsDataStoreIncidentRateLimitTest {
   }
 
   // ========================================================================
+  // Origin-method keying (bounded substitute for the unbounded exception message)
+  // ========================================================================
+
+  @Test
+  void dedup_sameTypeDifferentOriginMethodsAreIndependent() {
+    ServiceEventsDataStore.setIncidentSnapshotMaxPerMinute(100);
+    ServiceEventsDataStore.setIncidentSnapshotMaxSameError(1);
+
+    // Same route + same exception type, but thrown from two different methods → distinct hashes.
+    recordExceptionIncidentWithStack(
+        "/api/test", "RuntimeException", "boom", "\tat com.example.Foo.alpha(Foo.java:10)\n");
+    recordExceptionIncidentWithStack(
+        "/api/test", "RuntimeException", "boom", "\tat com.example.Foo.beta(Foo.java:20)\n");
+
+    assertEquals(
+        2,
+        emitIncidentCallCount.get(),
+        "Same type from different origin methods should be independent dedup buckets");
+  }
+
+  @Test
+  void dedup_sameTypeAndOriginMethodDifferentMessagesCollapse() {
+    ServiceEventsDataStore.setIncidentSnapshotMaxPerMinute(100);
+    ServiceEventsDataStore.setIncidentSnapshotMaxSameError(1);
+
+    // Same route + type + origin method, differing only in request-specific message text. The
+    // message is NOT part of the key, so these dedup together (the unbounded-key fix).
+    recordExceptionIncidentWithStack(
+        "/api/test",
+        "RuntimeException",
+        "user 1 not found",
+        "\tat com.example.Foo.lookup(Foo.java:10)\n");
+    recordExceptionIncidentWithStack(
+        "/api/test",
+        "RuntimeException",
+        "user 2 not found",
+        "\tat com.example.Foo.lookup(Foo.java:10)\n");
+
+    assertEquals(
+        1,
+        emitIncidentCallCount.get(),
+        "Same type + origin method with different messages should dedup together");
+  }
+
+  @Test
+  void dedup_lineNumberDoesNotAffectHash() {
+    ServiceEventsDataStore.setIncidentSnapshotMaxPerMinute(100);
+    ServiceEventsDataStore.setIncidentSnapshotMaxSameError(1);
+
+    // Same class.method but a shifted line number (e.g. after an edit above the throw site) must
+    // still dedup — the line is deliberately excluded so a recurring bug doesn't re-fire per
+    // deploy.
+    recordExceptionIncidentWithStack(
+        "/api/test", "RuntimeException", "boom", "\tat com.example.Foo.lookup(Foo.java:10)\n");
+    recordExceptionIncidentWithStack(
+        "/api/test", "RuntimeException", "boom", "\tat com.example.Foo.lookup(Foo.java:99)\n");
+
+    assertEquals(
+        1, emitIncidentCallCount.get(), "A shifted line number must not change the dedup hash");
+  }
+
+  @Test
+  void extractOriginMethod_parsesTopFrameClassAndMethod() {
+    String stack =
+        "java.lang.RuntimeException: boom\n"
+            + "\tat com.example.Service.handle(Service.java:42)\n"
+            + "\tat com.example.Controller.route(Controller.java:7)\n";
+    assertEquals("com.example.Service.handle", IncidentRateLimiter.extractOriginMethod(stack));
+  }
+
+  @Test
+  void extractOriginMethod_ignoresHeaderMessageContainingAtToken() {
+    // The header line contains "at " inside the message; the parser must skip it and match the
+    // frame.
+    String stack =
+        "java.lang.IllegalStateException: failed at startup\n"
+            + "\tat com.example.Boot.start(Boot.java:1)\n";
+    assertEquals("com.example.Boot.start", IncidentRateLimiter.extractOriginMethod(stack));
+  }
+
+  @Test
+  void extractOriginMethod_ignoresMultiLineMessageWithTruncatedFrameFragment() {
+    // A wrapped exception whose MESSAGE embeds a truncated frame fragment ("\tat evil.pwn(") must
+    // not hijack the parse: the fragment lacks the full "(...)"-to-line-end grammar, so the parser
+    // skips it and matches the real top frame. Guards against request-specific text in the message
+    // re-inflating the dedup key.
+    String stack =
+        "java.lang.RuntimeException: db failed\n"
+            + "\tat evil.Injected.pwn(\n"
+            + "\tat com.example.Real.throwHere(Real.java:10)\n";
+    assertEquals("com.example.Real.throwHere", IncidentRateLimiter.extractOriginMethod(stack));
+  }
+
+  @Test
+  void extractOriginMethod_parsesConstructorAndStaticInitializerFrames() {
+    // Constructor (<init>) and static-initializer (<clinit>) throw sites are real top frames; the
+    // grammar must accept the angle-bracketed names, not skip past them to the caller.
+    assertEquals(
+        "com.example.Foo.<init>",
+        IncidentRateLimiter.extractOriginMethod(
+            "java.lang.IllegalArgumentException: bad\n"
+                + "\tat com.example.Foo.<init>(Foo.java:10)\n"
+                + "\tat com.example.Handler.build(Handler.java:5)\n"));
+    assertEquals(
+        "com.example.Foo.<clinit>",
+        IncidentRateLimiter.extractOriginMethod(
+            "X: y\n\tat com.example.Foo.<clinit>(Foo.java:3)\n"));
+  }
+
+  @Test
+  void extractOriginMethod_parsesModulePrefixedAndLambdaFrames() {
+    // Module-prefixed frames (java.base/...) and synthetic lambda methods are real JVM frame shapes
+    // the tightened grammar must still accept.
+    assertEquals(
+        "java.base/java.lang.Thread.run",
+        IncidentRateLimiter.extractOriginMethod(
+            "X: y\n\tat java.base/java.lang.Thread.run(Thread.java:829)\n"));
+    assertEquals(
+        "com.example.Svc.lambda$doWork$0",
+        IncidentRateLimiter.extractOriginMethod(
+            "X: y\n\tat com.example.Svc.lambda$doWork$0(Svc.java:42)\n"));
+  }
+
+  @Test
+  void extractOriginMethod_returnsEmptyForNullOrUnparseable() {
+    assertEquals("", IncidentRateLimiter.extractOriginMethod(null));
+    assertEquals("", IncidentRateLimiter.extractOriginMethod(""));
+    assertEquals("", IncidentRateLimiter.extractOriginMethod("no frames here"));
+  }
+
+  // ========================================================================
   // Setter validation
   // ========================================================================
 
@@ -230,6 +361,11 @@ class ServiceEventsDataStoreIncidentRateLimitTest {
   // ========================================================================
 
   private void recordExceptionIncident(String route, String exceptionType, String message) {
+    recordExceptionIncidentWithStack(route, exceptionType, message, "stack trace");
+  }
+
+  private void recordExceptionIncidentWithStack(
+      String route, String exceptionType, String message, String stackTrace) {
     ServiceEventsDataStore.recordPotentialIncident(
         route,
         "GET",
@@ -237,7 +373,7 @@ class ServiceEventsDataStoreIncidentRateLimitTest {
         5.0,
         exceptionType,
         message,
-        "stack trace",
+        stackTrace,
         Collections.<String, String>emptyMap(),
         Collections.<String, Object>emptyMap(),
         null,

--- a/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStoreIncidentRateLimitTest.java
+++ b/serviceevents-bootstrap-bridge/src/test/java/software/amazon/opentelemetry/serviceevents/ServiceEventsDataStoreIncidentRateLimitTest.java
@@ -341,6 +341,37 @@ class ServiceEventsDataStoreIncidentRateLimitTest {
     assertEquals("", IncidentRateLimiter.extractOriginMethod("no frames here"));
   }
 
+  @Test
+  void generateErrorHash_distinguishesOperationExceptionAndOrigin() {
+    // Latency incident (null exception): keyed on operation alone, so a different exception type on
+    // the same operation cannot collide with it, and the same operation always maps to one hash.
+    String latency = IncidentRateLimiter.generateErrorHash("GET /a", null, "");
+    assertEquals(latency, IncidentRateLimiter.generateErrorHash("GET /a", null, "some.origin"));
+    assertNotEquals(latency, IncidentRateLimiter.generateErrorHash("GET /b", null, ""));
+
+    // Error incident: operation + exception type + throw-site origin all participate in the key.
+    String withOrigin =
+        IncidentRateLimiter.generateErrorHash("GET /a", "Boom", "com.example.Foo.f");
+    assertNotEquals(latency, withOrigin);
+    assertNotEquals(
+        withOrigin, IncidentRateLimiter.generateErrorHash("GET /a", "Boom", "com.example.Foo.g"));
+    assertNotEquals(
+        withOrigin, IncidentRateLimiter.generateErrorHash("POST /a", "Boom", "com.example.Foo.f"));
+    assertNotEquals(
+        withOrigin, IncidentRateLimiter.generateErrorHash("GET /a", "Other", "com.example.Foo.f"));
+  }
+
+  @Test
+  void generateErrorHash_nullAndEmptyOriginCollapseToTheSameKey() {
+    // The origin short-circuit (`origin == null || origin.isEmpty()`) must treat an absent origin
+    // and an empty-string origin (what extractOriginMethod returns when unparseable) identically —
+    // both drop the `:origin` segment, so an error with no recoverable throw site dedups on
+    // operation + exception type alone.
+    assertEquals(
+        IncidentRateLimiter.generateErrorHash("GET /a", "Boom", null),
+        IncidentRateLimiter.generateErrorHash("GET /a", "Boom", ""));
+  }
+
   // ========================================================================
   // Setter validation
   // ========================================================================


### PR DESCRIPTION
The incident-snapshot deduplication hash keyed on operation + exception
type only, so two distinct errors sharing one exception type on the same
operation collapsed into a single deduplicated incident.

Fold a bounded, deploy-stable throw-site method (class.method, parsed from
the top frame of the stack trace) into the key: op:<operation>|exc:<type>:
<originMethod>. The exception message is deliberately excluded — it embeds
request-specific data (IDs, timestamps) and would proliferate the hash per
request. The line number is dropped so a recurring error does not re-fire as
a new incident after every deploy.

extractOriginMethod requires the complete "at <class.method>(<source>)" frame
grammar (anchored to end of line, method names include <init>/<clinit> and
the module prefix) so a truncated frame fragment embedded in an exception
message cannot hijack the parse.

This mirrors the file-qualified origin the Python and Node distros fold into
their keys. Hashes are compared only within a distro; the empty-origin branch
is intentionally not byte-identical across distros (Java omits the :origin
segment, Python/Node emit a trailing colon).

## Testing
- Unit: `serviceevents-bootstrap-bridge` tests pass (incl. new origin-keying + `extractOriginMethod` grammar tests: constructors/static-init, module-prefixed/lambda frames, truncated-frame-fragment injection).
- Contract: `serviceeventsContractTests` green (OTLP incident-snapshot + call-path-python-compatible assertions).
- Lint: `spotlessCheck` clean.
- E2E: EC2 dev-loop against live CloudWatch — 5/5 Service Events validators pass.