### PR TITLE
feat: attribute presigned S3 URLs as AWS::S3 dependencies (opt-in, default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: attribute presigned S3 URLs as `AWS::S3` dependencies in Application Signals, opt-in via
+  `otel.aws.application.signals.presigned-url-attribution.enabled`
+  ([#1423](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1423))
 - Update Lambda layer compatible runtimes to include java25
   ([#1407](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1407))
 - fix(serviceevents): fold throw-site origin (`class.method`) into the incident-snapshot dedup hash

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsApplicationSignalsCustomizerProvider.java
@@ -120,6 +120,8 @@ public final class AwsApplicationSignalsCustomizerProvider
   private static final String DEPRECATED_APP_SIGNALS_ENABLED_CONFIG =
       "otel.aws.app.signals.enabled";
   static final String APPLICATION_SIGNALS_ENABLED_CONFIG = "otel.aws.application.signals.enabled";
+  static final String PRESIGNED_URL_ATTRIBUTION_ENABLED_CONFIG =
+      "otel.aws.application.signals.presigned-url-attribution.enabled";
   static final String OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS =
       "otel.metrics.add.application.signals.dimensions";
 
@@ -192,6 +194,12 @@ public final class AwsApplicationSignalsCustomizerProvider
 
   static boolean shouldAddApplicationSignalsDimensionsEnabled(ConfigProperties props) {
     return props.getBoolean(OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS, true);
+  }
+
+  private static AwsMetricAttributeGenerator createMetricAttributeGenerator(
+      ConfigProperties configProps) {
+    return new AwsMetricAttributeGenerator(
+        configProps.getBoolean(PRESIGNED_URL_ATTRIBUTION_ENABLED_CONFIG, false));
   }
 
   private static Optional<String> getAwsRegionFromConfig(ConfigProperties configProps) {
@@ -397,6 +405,7 @@ public final class AwsApplicationSignalsCustomizerProvider
         SpanExporter appSignalsSpanExporter =
             AwsMetricAttributesSpanExporterBuilder.create(
                     spanExporter, ResourceHolder.getResource())
+                .setGenerator(createMetricAttributeGenerator(configProps))
                 .build();
 
         tracerProviderBuilder.addSpanProcessor(
@@ -430,6 +439,7 @@ public final class AwsApplicationSignalsCustomizerProvider
       AwsSpanMetricsProcessorBuilder awsSpanMetricsProcessorBuilder =
           AwsSpanMetricsProcessorBuilder.create(
               meterProvider, ResourceHolder.getResource(), meterProvider::forceFlush);
+      awsSpanMetricsProcessorBuilder.setGenerator(createMetricAttributeGenerator(configProps));
       if (this.sampler != null) {
         awsSpanMetricsProcessorBuilder.setSampler(this.sampler);
       }
@@ -510,6 +520,7 @@ public final class AwsApplicationSignalsCustomizerProvider
     if (isApplicationSignalsEnabled(configProps)) {
       spanExporter =
           AwsMetricAttributesSpanExporterBuilder.create(spanExporter, ResourceHolder.getResource())
+              .setGenerator(createMetricAttributeGenerator(configProps))
               .build();
     }
 

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java
@@ -159,6 +159,22 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
 
   private static final String DB_CONNECTION_RESOURCE_TYPE = "DB::Connection";
 
+  // Whether presigned AWS URL attribution is enabled. Resolved once from ConfigProperties at
+  // startup by AwsApplicationSignalsCustomizerProvider and injected here, so we avoid reading
+  // system properties on the per-span hot path.
+  private final boolean presignedUrlAttributionEnabled;
+
+  AwsMetricAttributeGenerator() {
+    this(false);
+  }
+
+  AwsMetricAttributeGenerator(boolean presignedUrlAttributionEnabled) {
+    this.presignedUrlAttributionEnabled = presignedUrlAttributionEnabled;
+    if (presignedUrlAttributionEnabled) {
+      logger.log(Level.INFO, "Application Signals presigned S3 URL attribution is enabled.");
+    }
+  }
+
   // This method is used by the AwsSpanMetricsProcessor to generate service and dependency metrics
   @Override
   public Map<String, Attributes> generateMetricAttributeMapFromSpan(
@@ -191,9 +207,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     AttributesBuilder builder = Attributes.builder();
     setService(resource, span, builder);
     setEgressOperation(span, builder);
-    setRemoteServiceAndOperation(span, builder);
+    // Presigned AWS URL attribution is resolved lazily as a fallback inside
+    // setRemoteServiceAndOperation (only when no higher-priority remote attribute matched). It
+    // returns the resolved attribution, if any, so the remote resource can reuse it without
+    // re-parsing the URL.
+    Optional<PresignedUrlAttributor.PresignedUrlAttribution> presignedAttribution =
+        setRemoteServiceAndOperation(span, builder);
     setRemoteEnvironment(span, builder);
-    boolean isRemoteResourceIdentifierPresent = setRemoteResourceTypeAndIdentifier(span, builder);
+    boolean isRemoteResourceIdentifierPresent =
+        setRemoteResourceTypeAndIdentifier(span, builder, presignedAttribution);
     if (isRemoteResourceIdentifierPresent) {
       boolean isAccountIdAndRegionPresent = setRemoteResourceAccountIdAndRegion(span, builder);
       if (!isAccountIdAndRegionPresent) {
@@ -277,9 +299,12 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * `net.peer.sock.port` and `http.url` will be used to derive the RemoteService. And `http.method`
    * and `http.url` will be used to derive the RemoteOperation.
    */
-  private static void setRemoteServiceAndOperation(SpanData span, AttributesBuilder builder) {
+  private Optional<PresignedUrlAttributor.PresignedUrlAttribution> setRemoteServiceAndOperation(
+      SpanData span, AttributesBuilder builder) {
     String remoteService = UNKNOWN_REMOTE_SERVICE;
     String remoteOperation = UNKNOWN_REMOTE_OPERATION;
+    Optional<PresignedUrlAttributor.PresignedUrlAttribution> presignedAttribution =
+        Optional.empty();
 
     if (isKeyPresent(span, AWS_REMOTE_SERVICE) || isKeyPresent(span, AWS_REMOTE_OPERATION)) {
       remoteService = getRemoteService(span, AWS_REMOTE_SERVICE);
@@ -307,6 +332,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     } else if (isKeyPresent(span, GRAPHQL_OPERATION_TYPE)) {
       remoteService = GRAPHQL;
       remoteOperation = getRemoteOperation(span, GRAPHQL_OPERATION_TYPE);
+    } else if (presignedUrlAttributionEnabled && !isAwsSDKSpan(span)) {
+      // Fallback for raw HTTP calls using a presigned URL. Exclude AWS SDK spans explicitly: they
+      // use the SDK attribution path even when their RPC service or method attributes are absent.
+      // Parse the URL only when we reach this branch.
+      presignedAttribution = PresignedUrlAttributor.attribute(span);
+      if (presignedAttribution.isPresent()) {
+        remoteService = presignedAttribution.get().getRemoteService();
+        remoteOperation = presignedAttribution.get().getRemoteOperation();
+      }
     }
 
     // Peer service takes priority as RemoteService over everything but AWS Remote.
@@ -318,12 +352,17 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     if (remoteService.equals(UNKNOWN_REMOTE_SERVICE)) {
       remoteService = generateRemoteService(span);
     }
-    if (remoteOperation.equals(UNKNOWN_REMOTE_OPERATION)) {
+    // When a presigned AWS URL was attributed, keep its remote operation as-is. Resolvers
+    // intentionally return UnknownRemoteOperation for ambiguous calls (e.g. a bucket-level S3 GET),
+    // and falling back to the generic HTTP path here would reintroduce the high-cardinality
+    // "GET /<key>" operation this feature is meant to avoid.
+    if (remoteOperation.equals(UNKNOWN_REMOTE_OPERATION) && !presignedAttribution.isPresent()) {
       remoteOperation = generateRemoteOperation(span);
     }
 
     builder.put(AWS_REMOTE_SERVICE, remoteService);
     builder.put(AWS_REMOTE_OPERATION, remoteOperation);
+    return presignedAttribution;
   }
 
   /**
@@ -511,7 +550,9 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    * Cloud Control resource format</a>.
    */
   private static boolean setRemoteResourceTypeAndIdentifier(
-      SpanData span, AttributesBuilder builder) {
+      SpanData span,
+      AttributesBuilder builder,
+      Optional<PresignedUrlAttributor.PresignedUrlAttribution> presignedAttribution) {
     Optional<String> remoteResourceType = Optional.empty();
     Optional<String> remoteResourceIdentifier = Optional.empty();
     Optional<String> cloudformationPrimaryIdentifier = Optional.empty();
@@ -627,6 +668,14 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         remoteResourceType = Optional.of(NORMALIZED_LAMBDA_SERVICE_NAME + "::EventSourceMapping");
         remoteResourceIdentifier =
             Optional.ofNullable(escapeDelimiters(span.getAttributes().get(AWS_LAMBDA_RESOURCE_ID)));
+      }
+    } else if (presignedAttribution.isPresent()) {
+      Optional<PresignedUrlAttributor.RemoteResource> remoteResource =
+          presignedAttribution.get().getRemoteResource();
+      if (remoteResource.isPresent()) {
+        remoteResourceType = Optional.of(remoteResource.get().getType());
+        remoteResourceIdentifier =
+            Optional.ofNullable(escapeDelimiters(remoteResource.get().getIdentifier()));
       }
     } else if (isDBSpan(span)) {
       remoteResourceType = Optional.of(DB_CONNECTION_RESOURCE_TYPE);

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/PresignedAwsUrl.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/PresignedAwsUrl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A parsed SigV4 presigned AWS URL. Wraps the standard {@link URI} and delegates URL parts (host,
+ * path) to it, adding only the request context that {@link URI} cannot express: the HTTP method
+ * (which comes from the span, not the URL) and the parsed query parameters (the JDK does not parse
+ * the query string into a map).
+ *
+ * <p>The signing service is intentionally not carried here: it is derived by the SigV4 credential
+ * scope, which the agent's URL sanitization redacts. Service identity is instead determined from
+ * the endpoint hostname by the service-specific attributor.
+ */
+final class PresignedAwsUrl {
+  private final URI uri;
+  private final Optional<String> httpMethod;
+  private final Map<String, List<String>> queryParameters;
+
+  PresignedAwsUrl(URI uri, Optional<String> httpMethod, Map<String, List<String>> queryParameters) {
+    this.uri = uri;
+    this.httpMethod = httpMethod;
+    this.queryParameters = Collections.unmodifiableMap(queryParameters);
+  }
+
+  Optional<String> getHttpMethod() {
+    return httpMethod;
+  }
+
+  String getHost() {
+    return uri.getHost();
+  }
+
+  String getPath() {
+    String rawPath = uri.getRawPath();
+    if (rawPath == null || rawPath.isEmpty()) {
+      return "/";
+    }
+    return rawPath;
+  }
+
+  Optional<String> getFirstQueryParameterValue(String name) {
+    List<String> values = queryParameters.get(name);
+    if (values == null || values.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(values.get(0));
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/PresignedAwsUrlParser.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/PresignedAwsUrlParser.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_URL;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.getKeyValueWithFallback;
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.isKeyPresentWithFallback;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Recognizes a SigV4/SigV4a presigned AWS URL from a span's URL.
+ *
+ * <p>Detection relies only on non-sensitive signals. A presigned (query-authenticated) request
+ * carries all six SigV4 query parameters: {@code X-Amz-Algorithm}, {@code X-Amz-Credential}, {@code
+ * X-Amz-Signature}, {@code X-Amz-Date}, {@code X-Amz-Expires}, and {@code X-Amz-SignedHeaders}. Of
+ * these, only the {@code X-Amz-Algorithm} value is inspected (against an allowlist); {@code
+ * X-Amz-Credential} and {@code X-Amz-Signature} are required to be present with a non-empty value
+ * but their values are never read, because the agent's default URL sanitization replaces them with
+ * {@code REDACTED} before metric attribution runs. {@code X-Amz-Date}, {@code X-Amz-Expires}, and
+ * {@code X-Amz-SignedHeaders} are never redacted, so requiring them provides cheap verification.
+ * The signing service is identified downstream from the endpoint hostname, not from the credential
+ * scope.
+ */
+final class PresignedAwsUrlParser {
+  private static final String X_AMZ_ALGORITHM = "X-Amz-Algorithm";
+  private static final String X_AMZ_CREDENTIAL = "X-Amz-Credential";
+  private static final String X_AMZ_SIGNATURE = "X-Amz-Signature";
+  private static final String X_AMZ_DATE = "X-Amz-Date";
+  private static final String X_AMZ_EXPIRES = "X-Amz-Expires";
+  private static final String X_AMZ_SIGNED_HEADERS = "X-Amz-SignedHeaders";
+  private static final Set<String> SIGV4_ALGORITHMS =
+      new HashSet<>(Arrays.asList("AWS4-HMAC-SHA256", "AWS4-ECDSA-P256-SHA256"));
+
+  private PresignedAwsUrlParser() {}
+
+  static Optional<PresignedAwsUrl> parse(SpanData span) {
+    if (!isKeyPresentWithFallback(span, URL_FULL, HTTP_URL)) {
+      return Optional.empty();
+    }
+
+    String url = getKeyValueWithFallback(span, URL_FULL, HTTP_URL);
+    String httpMethod = getKeyValueWithFallback(span, HTTP_REQUEST_METHOD, HTTP_METHOD);
+    return parse(url, httpMethod);
+  }
+
+  static Optional<PresignedAwsUrl> parse(String url, String httpMethod) {
+    if (url == null || url.isEmpty()) {
+      return Optional.empty();
+    }
+
+    URI uri;
+    try {
+      uri = new URI(url);
+    } catch (URISyntaxException e) {
+      return Optional.empty();
+    }
+
+    if (uri.getHost() == null || uri.getHost().isEmpty()) {
+      return Optional.empty();
+    }
+
+    Map<String, List<String>> queryParameters = parseQueryParameters(uri.getRawQuery());
+    if (!isPresignedSigV4Request(queryParameters)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(new PresignedAwsUrl(uri, Optional.ofNullable(httpMethod), queryParameters));
+  }
+
+  /**
+   * A request is a presigned SigV4/SigV4a request when it carries the signing algorithm,
+   * credential, and signature parameters together with the presigned query parameters that AWS
+   * always includes ({@code X-Amz-Date}, {@code X-Amz-Expires}, {@code X-Amz-SignedHeaders}). Only
+   * the algorithm value is inspected against an allowlist; the credential and signature must be
+   * present with a value but the value itself is not read, because sanitization replaces it with a
+   * non-empty {@code REDACTED}. Empty values are rejected as malformed. The date, expiry, and
+   * signed-headers parameters are never redacted, so requiring them (non-empty) is a cheap way to
+   * reject partial or spoofed URLs without reading any sensitive value.
+   *
+   * <p>Query-string (presigned) SigV4 authentication parameters are defined here: <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html">Authenticating
+   * Requests: Using Query Parameters (AWS Signature Version 4)</a>. Per <a
+   * href="https://docs.aws.amazon.com/prescriptive-guidance/latest/presigned-url-best-practices/overview.html">Overview
+   * of presigned URLs</a>, the {@code X-Amz-Expires} parameter is what distinguishes a presigned
+   * URL from other signed requests.
+   */
+  private static boolean isPresignedSigV4Request(Map<String, List<String>> queryParameters) {
+    Optional<String> algorithm = getFirstValue(queryParameters, X_AMZ_ALGORITHM);
+    return algorithm.isPresent()
+        && SIGV4_ALGORITHMS.contains(algorithm.get())
+        && hasNonEmptyValue(queryParameters, X_AMZ_CREDENTIAL)
+        && hasNonEmptyValue(queryParameters, X_AMZ_SIGNATURE)
+        && hasNonEmptyValue(queryParameters, X_AMZ_DATE)
+        && hasNonEmptyValue(queryParameters, X_AMZ_EXPIRES)
+        && hasNonEmptyValue(queryParameters, X_AMZ_SIGNED_HEADERS);
+  }
+
+  private static boolean hasNonEmptyValue(Map<String, List<String>> queryParameters, String name) {
+    return getFirstValue(queryParameters, name).filter(value -> !value.isEmpty()).isPresent();
+  }
+
+  private static Optional<String> getFirstValue(
+      Map<String, List<String>> queryParameters, String name) {
+    List<String> values = queryParameters.get(name);
+    if (values == null || values.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(values.get(0));
+  }
+
+  private static Map<String, List<String>> parseQueryParameters(String rawQuery) {
+    Map<String, List<String>> queryParameters = new HashMap<>();
+    if (rawQuery == null || rawQuery.isEmpty()) {
+      return queryParameters;
+    }
+
+    String[] pairs = rawQuery.split("&");
+    for (String pair : pairs) {
+      int delimiterIndex = pair.indexOf('=');
+      String name = delimiterIndex >= 0 ? pair.substring(0, delimiterIndex) : pair;
+      String value = delimiterIndex >= 0 ? pair.substring(delimiterIndex + 1) : "";
+      queryParameters.computeIfAbsent(decode(name), unused -> new ArrayList<>()).add(decode(value));
+    }
+    return queryParameters;
+  }
+
+  private static String decode(String value) {
+    try {
+      return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/PresignedUrlAttributor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/PresignedUrlAttributor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.Optional;
+
+/**
+ * Derives Application Signals attribution from a presigned AWS URL. Parses the span's URL once,
+ * then lets each service-specific attributor try to claim it based on the endpoint hostname (the
+ * signing service cannot be read from the credential scope because it is redacted). If none claims
+ * the URL — custom CNAMEs, unknown endpoints, or non-presigned URLs — attribution falls back to the
+ * existing behavior.
+ */
+final class PresignedUrlAttributor {
+  private PresignedUrlAttributor() {}
+
+  static Optional<PresignedUrlAttribution> attribute(SpanData span) {
+    return PresignedAwsUrlParser.parse(span).flatMap(PresignedUrlAttributor::attribute);
+  }
+
+  private static Optional<PresignedUrlAttribution> attribute(PresignedAwsUrl presignedAwsUrl) {
+    // Only S3 is supported today. Additional services (e.g. SQS, execute-api) can be tried here in
+    // turn, each claiming the URL only when it recognizes the endpoint.
+    return S3PresignedUrlAttributor.attribute(presignedAwsUrl);
+  }
+
+  /**
+   * The Application Signals remote attribution derived from a presigned AWS URL. A resource is
+   * present only when the service-specific attributor can identify it confidently.
+   */
+  static final class PresignedUrlAttribution {
+    private final String remoteService;
+    private final String remoteOperation;
+    private final Optional<RemoteResource> remoteResource;
+
+    PresignedUrlAttribution(
+        String remoteService, String remoteOperation, Optional<RemoteResource> remoteResource) {
+      this.remoteService = remoteService;
+      this.remoteOperation = remoteOperation;
+      this.remoteResource = remoteResource;
+    }
+
+    String getRemoteService() {
+      return remoteService;
+    }
+
+    String getRemoteOperation() {
+      return remoteOperation;
+    }
+
+    Optional<RemoteResource> getRemoteResource() {
+      return remoteResource;
+    }
+  }
+
+  static final class RemoteResource {
+    private final String type;
+    private final String identifier;
+
+    RemoteResource(String type, String identifier) {
+      this.type = type;
+      this.identifier = identifier;
+    }
+
+    String getType() {
+      return type;
+    }
+
+    String getIdentifier() {
+      return identifier;
+    }
+  }
+}

--- a/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/S3PresignedUrlAttributor.java
+++ b/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/S3PresignedUrlAttributor.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static software.amazon.opentelemetry.javaagent.providers.AwsSpanProcessingUtil.UNKNOWN_REMOTE_OPERATION;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import software.amazon.opentelemetry.javaagent.providers.PresignedUrlAttributor.PresignedUrlAttribution;
+import software.amazon.opentelemetry.javaagent.providers.PresignedUrlAttributor.RemoteResource;
+
+/**
+ * Derives {@code AWS::S3} attribution from a presigned S3 URL by recognizing S3 endpoint hostnames.
+ *
+ * <p>Because the signing service cannot be read from the (redacted) credential scope, S3 is
+ * identified purely from the endpoint host. Only the standard virtual-hosted and path-style S3
+ * endpoint forms are recognized. Anything else — custom CNAMEs, access points, unknown endpoints —
+ * fails closed (returns empty) so we never mis-attribute a non-S3 or unverifiable request.
+ *
+ * <p>The remote operation is derived from the HTTP method, whether an object key is present
+ * (bucket- vs object-level), and the S3 subresource/multipart query parameters. Operation names
+ * follow the S3 REST API. References:
+ *
+ * <ul>
+ *   <li>Endpoints: https://docs.aws.amazon.com/general/latest/gr/s3.html
+ *   <li>Virtual-hosted vs path-style:
+ *       https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+ *   <li>S3 REST API operations: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations.html
+ * </ul>
+ */
+final class S3PresignedUrlAttributor {
+  private static final String NORMALIZED_S3_SERVICE_NAME = "AWS::S3";
+  private static final String S3_BUCKET_RESOURCE_TYPE = NORMALIZED_S3_SERVICE_NAME + "::Bucket";
+
+  // Standard S3 endpoint host forms, including global, regional, legacy regional, dual-stack,
+  // transfer acceleration, FIPS (incl. FIPS dual-stack), and China (.com.cn). The optional segment
+  // after "s3" covers the mutually exclusive endpoint styles.
+  //
+  // The legacy "-<label>" alternative is intentionally broad: besides legacy regional hosts
+  // (s3-us-west-2) it also matches other s3-prefixed AWS hosts such as s3-website-<region>. This is
+  // accepted deliberately as low risk — all such hosts are S3-owned domains anchored to
+  // amazonaws.com, and presigned object requests do not target website/other endpoints.
+  // https://docs.aws.amazon.com/general/latest/gr/s3.html
+  // https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html
+  private static final String S3_ENDPOINT_SUFFIX =
+      "s3(?:"
+          + "\\.(?:dualstack\\.)?[a-z0-9-]+" // s3.<region> | s3.dualstack.<region>
+          + "|-fips(?:\\.dualstack)?\\.[a-z0-9-]+" // s3-fips.<region> | s3-fips.dualstack.<region>
+          + "|-accelerate(?:\\.dualstack)?" // s3-accelerate | s3-accelerate.dualstack
+          + "|-[a-z0-9-]+" // s3-<region> (legacy regional)
+          + ")?\\.amazonaws\\.com(?:\\.cn)?";
+  private static final Pattern VIRTUAL_HOSTED_S3_ENDPOINT =
+      Pattern.compile("^(.+)\\." + S3_ENDPOINT_SUFFIX + "$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern PATH_STYLE_S3_ENDPOINT =
+      Pattern.compile("^" + S3_ENDPOINT_SUFFIX + "$", Pattern.CASE_INSENSITIVE);
+
+  private S3PresignedUrlAttributor() {}
+
+  static Optional<PresignedUrlAttribution> attribute(PresignedAwsUrl presignedAwsUrl) {
+    String host = presignedAwsUrl.getHost();
+    boolean pathStyle = PATH_STYLE_S3_ENDPOINT.matcher(host).matches();
+
+    Optional<String> bucket;
+    if (pathStyle) {
+      bucket = getPathStyleBucket(presignedAwsUrl);
+    } else {
+      bucket = getVirtualHostedStyleBucket(host);
+      if (!bucket.isPresent()) {
+        // Not a recognized S3 endpoint (custom CNAME, access point, unknown host). Fail closed:
+        // the signing service cannot be recovered from a redacted credential scope.
+        return Optional.empty();
+      }
+    }
+
+    Optional<RemoteResource> remoteResource =
+        bucket.map(b -> new RemoteResource(S3_BUCKET_RESOURCE_TYPE, b));
+    return Optional.of(
+        new PresignedUrlAttribution(
+            NORMALIZED_S3_SERVICE_NAME,
+            getRemoteOperation(presignedAwsUrl, pathStyle),
+            remoteResource));
+  }
+
+  private static String getRemoteOperation(PresignedAwsUrl presignedAwsUrl, boolean pathStyle) {
+    Optional<String> httpMethod = presignedAwsUrl.getHttpMethod();
+    if (!httpMethod.isPresent()) {
+      return UNKNOWN_REMOTE_OPERATION;
+    }
+
+    String normalizedMethod = httpMethod.get().toUpperCase(Locale.ROOT);
+    boolean hasObjectKey = hasObjectKey(presignedAwsUrl, pathStyle);
+
+    // ListObjectsV2 is a bucket-level GET (no object key).
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+    if ("GET".equals(normalizedMethod)
+        && !hasObjectKey
+        && "2".equals(presignedAwsUrl.getFirstQueryParameterValue("list-type").orElse(null))) {
+      return "ListObjectsV2";
+    }
+    // S3 multipart REST API operations:
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+    if (presignedAwsUrl.getFirstQueryParameterValue("uploadId").isPresent()) {
+      if ("PUT".equals(normalizedMethod)
+          && presignedAwsUrl.getFirstQueryParameterValue("partNumber").isPresent()) {
+        return "UploadPart";
+      }
+      if ("GET".equals(normalizedMethod)) {
+        return "ListParts";
+      }
+      if ("POST".equals(normalizedMethod)) {
+        return "CompleteMultipartUpload";
+      }
+      if ("DELETE".equals(normalizedMethod)) {
+        return "AbortMultipartUpload";
+      }
+    }
+
+    if (presignedAwsUrl.getFirstQueryParameterValue("uploads").isPresent()) {
+      if ("POST".equals(normalizedMethod) && hasObjectKey) {
+        return "CreateMultipartUpload";
+      }
+      if ("GET".equals(normalizedMethod) && !hasObjectKey) {
+        return "ListMultipartUploads";
+      }
+    }
+
+    // Subresource operations selected by a query parameter. They are object-level when an object
+    // key is present and bucket-level otherwise.
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html
+    if (presignedAwsUrl.getFirstQueryParameterValue("acl").isPresent()) {
+      if ("GET".equals(normalizedMethod)) {
+        return hasObjectKey ? "GetObjectAcl" : "GetBucketAcl";
+      }
+      if ("PUT".equals(normalizedMethod)) {
+        return hasObjectKey ? "PutObjectAcl" : "PutBucketAcl";
+      }
+    }
+    if (presignedAwsUrl.getFirstQueryParameterValue("tagging").isPresent()) {
+      if ("GET".equals(normalizedMethod)) {
+        return hasObjectKey ? "GetObjectTagging" : "GetBucketTagging";
+      }
+      if ("PUT".equals(normalizedMethod)) {
+        return hasObjectKey ? "PutObjectTagging" : "PutBucketTagging";
+      }
+      if ("DELETE".equals(normalizedMethod)) {
+        return hasObjectKey ? "DeleteObjectTagging" : "DeleteBucketTagging";
+      }
+    }
+
+    // Object-only subresources. These operate on an object, so they require an object key.
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectRetention.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTorrent.html
+    if (hasObjectKey) {
+      if (presignedAwsUrl.getFirstQueryParameterValue("retention").isPresent()) {
+        if ("GET".equals(normalizedMethod)) {
+          return "GetObjectRetention";
+        }
+        if ("PUT".equals(normalizedMethod)) {
+          return "PutObjectRetention";
+        }
+      }
+      if (presignedAwsUrl.getFirstQueryParameterValue("legal-hold").isPresent()) {
+        if ("GET".equals(normalizedMethod)) {
+          return "GetObjectLegalHold";
+        }
+        if ("PUT".equals(normalizedMethod)) {
+          return "PutObjectLegalHold";
+        }
+      }
+      if ("GET".equals(normalizedMethod)
+          && presignedAwsUrl.getFirstQueryParameterValue("torrent").isPresent()) {
+        return "GetObjectTorrent";
+      }
+    }
+
+    if (!hasObjectKey) {
+      return UNKNOWN_REMOTE_OPERATION;
+    }
+
+    switch (normalizedMethod) {
+      case "GET":
+        return "GetObject";
+      case "HEAD":
+        return "HeadObject";
+      case "PUT":
+        return "PutObject";
+      case "DELETE":
+        return "DeleteObject";
+      default:
+        return UNKNOWN_REMOTE_OPERATION;
+    }
+  }
+
+  private static boolean hasObjectKey(PresignedAwsUrl presignedAwsUrl, boolean pathStyle) {
+    String[] pathSegments = getPathSegments(presignedAwsUrl.getPath());
+    if (pathStyle) {
+      // Path-style URLs carry the bucket as the first path segment, so an object key requires a
+      // second segment.
+      return pathSegments.length > 1;
+    }
+    return pathSegments.length > 0;
+  }
+
+  private static Optional<String> getPathStyleBucket(PresignedAwsUrl presignedAwsUrl) {
+    String[] pathSegments = getPathSegments(presignedAwsUrl.getPath());
+    if (pathSegments.length == 0) {
+      return Optional.empty();
+    }
+    return Optional.of(pathSegments[0]);
+  }
+
+  private static Optional<String> getVirtualHostedStyleBucket(String host) {
+    Matcher matcher = VIRTUAL_HOSTED_S3_ENDPOINT.matcher(host);
+    if (!matcher.matches()) {
+      return Optional.empty();
+    }
+    return Optional.of(matcher.group(1));
+  }
+
+  private static String[] getPathSegments(String path) {
+    String normalizedPath = path == null ? "" : path;
+    while (normalizedPath.startsWith("/")) {
+      normalizedPath = normalizedPath.substring(1);
+    }
+    if (normalizedPath.isEmpty()) {
+      return new String[0];
+    }
+    return normalizedPath.split("/");
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGeneratorTest.java
@@ -114,7 +114,7 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link AwsMetricAttributeGenerator}. */
 class AwsMetricAttributeGeneratorTest {
 
-  private static final AwsMetricAttributeGenerator GENERATOR = new AwsMetricAttributeGenerator();
+  private AwsMetricAttributeGenerator generator = new AwsMetricAttributeGenerator();
 
   // String constants that are used many times in these tests.
   private static final String AWS_LOCAL_OPERATION_VALUE = "AWS local operation";
@@ -260,7 +260,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
     Map<String, Attributes> actualAttributesMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     assertThat(actualAttributesMap).isEqualTo(expectedAttributesMap);
   }
 
@@ -280,7 +280,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.INTERNAL);
     Map<String, Attributes> actualAttributesMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     assertThat(actualAttributesMap).isEqualTo(expectedAttributesMap);
   }
 
@@ -311,7 +311,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     Map<String, Attributes> actualAttributesMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     assertThat(actualAttributesMap).isEqualTo(expectedAttributesMap);
   }
 
@@ -343,7 +343,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
     Map<String, Attributes> actualAttributesMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     assertThat(actualAttributesMap).isEqualTo(expectedAttributesMap);
   }
 
@@ -375,7 +375,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.PRODUCER);
     Map<String, Attributes> actualAttributesMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     assertThat(actualAttributesMap).isEqualTo(expectedAttributesMap);
   }
 
@@ -705,6 +705,120 @@ class AwsMetricAttributeGeneratorTest {
     validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, UNKNOWN_REMOTE_OPERATION);
   }
 
+  @Test
+  public void testPresignedS3AttributionDisabledByDefault() {
+    mockAttribute(URL_FULL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_REQUEST_METHOD, "PUT");
+
+    validateExpectedRemoteAttributes("example-bucket.s3.us-west-2.amazonaws.com", "PUT /object");
+    validateRemoteResourceAttributes(null, null);
+  }
+
+  @Test
+  public void testPresignedS3UrlAttributes() {
+    enablePresignedUrlAttribution();
+    mockAttribute(URL_FULL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_REQUEST_METHOD, "GET");
+
+    validateExpectedRemoteAttributes("AWS::S3", "GetObject");
+    validateRemoteResourceAttributes("AWS::S3::Bucket", "example-bucket");
+  }
+
+  @Test
+  public void testPresignedS3UrlUnknownOperationDoesNotFallBackToHttpPath() {
+    enablePresignedUrlAttribution();
+    // Bucket-level GET (no object key) is an ambiguous S3 operation, so the resolver returns
+    // UnknownRemoteOperation. The generic HTTP operation fallback must not overwrite it with a
+    // high-cardinality "GET /..." value.
+    mockAttribute(URL_FULL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/"));
+    mockAttribute(HTTP_REQUEST_METHOD, "GET");
+
+    validateExpectedRemoteAttributes("AWS::S3", UNKNOWN_REMOTE_OPERATION);
+    validateRemoteResourceAttributes("AWS::S3::Bucket", "example-bucket");
+  }
+
+  @Test
+  public void testPresignedS3UrlUsesLegacyHttpUrlFallback() {
+    enablePresignedUrlAttribution();
+    mockAttribute(HTTP_URL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_METHOD, "HEAD");
+
+    validateExpectedRemoteAttributes("AWS::S3", "HeadObject");
+    validateRemoteResourceAttributes("AWS::S3::Bucket", "example-bucket");
+  }
+
+  @Test
+  public void testPresignedS3UrlExplicitRemoteAttributesWin() {
+    enablePresignedUrlAttribution();
+    mockAttribute(URL_FULL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_REQUEST_METHOD, "PUT");
+    mockAttribute(AWS_REMOTE_SERVICE, AWS_REMOTE_SERVICE_VALUE);
+    mockAttribute(AWS_REMOTE_OPERATION, AWS_REMOTE_OPERATION_VALUE);
+
+    validateExpectedRemoteAttributes(AWS_REMOTE_SERVICE_VALUE, AWS_REMOTE_OPERATION_VALUE);
+  }
+
+  @Test
+  public void testPresignedS3UrlDoesNotAttributeAwsSdkSpan() {
+    enablePresignedUrlAttribution();
+    mockAttribute(URL_FULL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_REQUEST_METHOD, "GET");
+    mockAttribute(RPC_SYSTEM, "aws-api");
+
+    validateExpectedRemoteAttributes("example-bucket.s3.us-west-2.amazonaws.com", "GET /object");
+    validateRemoteResourceAttributes(null, null);
+  }
+
+  @Test
+  public void testPresignedS3UrlPeerServiceOverrideIsUnchanged() {
+    enablePresignedUrlAttribution();
+    mockAttribute(URL_FULL, presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_REQUEST_METHOD, "PUT");
+    mockAttribute(PEER_SERVICE, "PeerService");
+
+    validateExpectedRemoteAttributes("PeerService", "PutObject");
+  }
+
+  @Test
+  public void testNonS3PresignedEndpointIsUnchanged() {
+    enablePresignedUrlAttribution();
+    mockAttribute(
+        URL_FULL, presignedUrl("sqs.us-west-2.amazonaws.com", "/123456789012/example-queue"));
+    mockAttribute(HTTP_REQUEST_METHOD, "GET");
+
+    validateExpectedRemoteAttributes("sqs.us-west-2.amazonaws.com", "GET /123456789012");
+    validateRemoteResourceAttributes(null, null);
+  }
+
+  @Test
+  public void testPresignedS3UrlWithUnrecognizedEndpointIsUnchanged() {
+    // An access-point host is not a recognized bucket-bearing S3 endpoint. Since the signing
+    // service cannot be recovered from the redacted credential, attribution fails closed and the
+    // span keeps the existing generic HTTP attribution.
+    enablePresignedUrlAttribution();
+    mockAttribute(
+        URL_FULL, presignedUrl("example-bucket.s3-accesspoint.us-west-2.amazonaws.com", "/object"));
+    mockAttribute(HTTP_REQUEST_METHOD, "GET");
+
+    validateExpectedRemoteAttributes(
+        "example-bucket.s3-accesspoint.us-west-2.amazonaws.com", "GET /object");
+    validateRemoteResourceAttributes(null, null);
+  }
+
+  @Test
+  public void testDbResourceAttributionUnaffectedWhenPresignedAttributionEnabled() {
+    // Enabling presigned attribution must not shadow DB resource attribution: a DB span has no
+    // presigned URL, so it should still resolve to DB::Connection rather than falling through
+    // empty.
+    enablePresignedUrlAttribution();
+    mockAttribute(DB_SYSTEM, "mysql");
+    mockAttribute(DB_NAME, "db_name");
+    mockAttribute(SERVER_ADDRESS, "abc.com");
+    mockAttribute(SERVER_PORT, 3306L);
+
+    validateRemoteResourceAttributes("DB::Connection", "db_name|abc.com|3306");
+  }
+
   // Validate behaviour of various combinations of DB attributes.
   @Test
   public void testGetDBStatementRemoteOperation() {
@@ -863,7 +977,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo("TestString");
   }
 
@@ -1328,7 +1442,7 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(SERVER_PORT, 3306L);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
     mockAttribute(SERVER_PORT, null);
@@ -1364,7 +1478,7 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(NET_PEER_PORT, 3306L);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
     mockAttribute(NET_PEER_PORT, null);
@@ -1396,7 +1510,7 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(NETWORK_PEER_PORT, 3306L);
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
     mockAttribute(NETWORK_PEER_PORT, null);
@@ -1405,13 +1519,13 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(DB_NAME, "db_name");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
 
     mockAttribute(DB_NAMESPACE, "db_namespace");
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
 
@@ -1453,13 +1567,13 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(DB_CONNECTION_STRING, "hsqldb:mem:");
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
 
     mockAttribute(DB_NAMESPACE, "db_namespace");
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isNull();
 
@@ -1500,6 +1614,20 @@ class AwsMetricAttributeGeneratorTest {
     validateHttpStatusWithThrowable(new ThrowableWithoutStatusCode(), null);
   }
 
+  private void enablePresignedUrlAttribution() {
+    generator = new AwsMetricAttributeGenerator(true);
+  }
+
+  private static String presignedUrl(String host, String path) {
+    // Realistic sanitized presigned URL: the agent redacts the credential and signature values
+    // before metric attribution runs. The non-redacted presigned parameters remain.
+    return "https://"
+        + host
+        + path
+        + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=REDACTED&X-Amz-Signature=REDACTED"
+        + "&X-Amz-Date=20260710T120000Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host";
+  }
+
   private <T> void mockAttribute(AttributeKey<T> key, T value) {
     when(attributesMock.get(key)).thenReturn(value);
   }
@@ -1508,7 +1636,7 @@ class AwsMetricAttributeGeneratorTest {
       Attributes expectedAttributes, SpanKind kind) {
     when(spanDataMock.getKind()).thenReturn(kind);
     Map<String, Attributes> attributeMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     Attributes serviceAttributes = attributeMap.get(SERVICE_METRIC);
     Attributes dependencyAttributes = attributeMap.get(DEPENDENCY_METRIC);
     if (!attributeMap.isEmpty()) {
@@ -1534,13 +1662,13 @@ class AwsMetricAttributeGeneratorTest {
       String expectedRemoteService, String expectedRemoteOperation) {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo(expectedRemoteService);
     assertThat(actualAttributes.get(AWS_REMOTE_OPERATION)).isEqualTo(expectedRemoteOperation);
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.PRODUCER);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo(expectedRemoteService);
     assertThat(actualAttributes.get(AWS_REMOTE_OPERATION)).isEqualTo(expectedRemoteOperation);
   }
@@ -1573,7 +1701,7 @@ class AwsMetricAttributeGeneratorTest {
     // Validate that peer service value takes precedence over whatever remoteServiceKey was set
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo("PeerService");
 
     mockAttribute(remoteServiceKey, null);
@@ -1587,7 +1715,7 @@ class AwsMetricAttributeGeneratorTest {
     for (SpanKind spanKind : spanKinds) {
       when(spanDataMock.getKind()).thenReturn(spanKind);
       Attributes actualAttributes =
-          GENERATOR
+          generator
               .generateMetricAttributeMapFromSpan(spanDataMock, resource)
               .get(DEPENDENCY_METRIC);
 
@@ -1615,7 +1743,7 @@ class AwsMetricAttributeGeneratorTest {
     // Server span should not generate remote resource attributes
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_ACCESS_KEY)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_ACCOUNT_ID)).isNull();
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_REGION)).isNull();
@@ -1630,7 +1758,7 @@ class AwsMetricAttributeGeneratorTest {
     // Client, Producer and Consumer spans should generate the expected remote resource attributes
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isEqualTo(type);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isEqualTo(identifier);
     assertThat(actualAttributes.get(AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER))
@@ -1638,7 +1766,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.PRODUCER);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isEqualTo(type);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isEqualTo(identifier);
     assertThat(actualAttributes.get(AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER))
@@ -1646,7 +1774,7 @@ class AwsMetricAttributeGeneratorTest {
 
     when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isEqualTo(type);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isEqualTo(identifier);
     assertThat(actualAttributes.get(AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER))
@@ -1655,7 +1783,7 @@ class AwsMetricAttributeGeneratorTest {
     // Server span should not generate remote resource attributes
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_TYPE)).isEqualTo(null);
     assertThat(actualAttributes.get(AWS_REMOTE_RESOURCE_IDENTIFIER)).isEqualTo(null);
     assertThat(actualAttributes.get(AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER)).isEqualTo(null);
@@ -1677,7 +1805,7 @@ class AwsMetricAttributeGeneratorTest {
       SpanKind spanKind, Long expectedStatusCode) {
     when(spanDataMock.getKind()).thenReturn(spanKind);
     Map<String, Attributes> attributeMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
     Attributes actualAttributes = Attributes.empty();
     if (!attributeMap.isEmpty()) {
       if (SpanKind.PRODUCER.equals(spanKind)
@@ -1701,7 +1829,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_OPERATION)).isEqualTo("db_operation");
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isEqualTo("db_user");
   }
@@ -1712,7 +1840,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isNull();
   }
 
@@ -1723,7 +1851,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isEqualTo("non_db_user");
   }
 
@@ -1734,7 +1862,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.SERVER);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(SERVICE_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isNull();
   }
 
@@ -1744,7 +1872,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_DB_USER)).isNull();
   }
 
@@ -1785,7 +1913,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo(serviceName);
   }
 
@@ -1838,7 +1966,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_SERVICE)).isEqualTo(expectedRemoteService);
   }
 
@@ -1852,27 +1980,27 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CLIENT);
 
     Attributes actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_ENVIRONMENT)).isEqualTo("lambda:default");
 
     // Test 2: NOT setting it when RPC_SYSTEM is missing
     mockAttribute(RPC_SYSTEM, null);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_ENVIRONMENT)).isNull();
     mockAttribute(RPC_SYSTEM, "aws-api");
 
     // Test 3: NOT setting it when RPC_METHOD is missing
     mockAttribute(RPC_METHOD, null);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_ENVIRONMENT)).isNull();
     mockAttribute(RPC_METHOD, "Invoke");
 
     // Test 4: Still setting it to lambda:default when AWS_LAMBDA_NAME is missing
     mockAttribute(AWS_LAMBDA_NAME, null);
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_ENVIRONMENT)).isEqualTo("lambda:default");
     mockAttribute(AWS_LAMBDA_NAME, "testFunction");
 
@@ -1880,14 +2008,14 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(RPC_SERVICE, "S3");
     mockAttribute(RPC_METHOD, "GetObject");
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_ENVIRONMENT)).isNull();
 
     // Test 6: NOT setting it for Lambda non-Invoke operations
     mockAttribute(RPC_SERVICE, "Lambda");
     mockAttribute(RPC_METHOD, "GetFunction");
     actualAttributes =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource).get(DEPENDENCY_METRIC);
     assertThat(actualAttributes.get(AWS_REMOTE_ENVIRONMENT)).isNull();
   }
 
@@ -1899,7 +2027,7 @@ class AwsMetricAttributeGeneratorTest {
     when(spanDataMock.getKind()).thenReturn(SpanKind.CONSUMER);
 
     Map<String, Attributes> attributeMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
 
     Attributes serviceAttributes = attributeMap.get(SERVICE_METRIC);
     Attributes dependencyAttributes = attributeMap.get(DEPENDENCY_METRIC);
@@ -1917,7 +2045,7 @@ class AwsMetricAttributeGeneratorTest {
     when(parentSpanContextMock.isValid()).thenReturn(false);
 
     Map<String, Attributes> attributeMap =
-        GENERATOR.generateMetricAttributeMapFromSpan(spanDataMock, resource);
+        generator.generateMetricAttributeMapFromSpan(spanDataMock, resource);
 
     Attributes serviceAttributes = attributeMap.get(SERVICE_METRIC);
     Attributes dependencyAttributes = attributeMap.get(DEPENDENCY_METRIC);

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/PresignedAwsUrlParserTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/PresignedAwsUrlParserTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The parser detects presigned SigV4/SigV4a requests from non-sensitive signals only. It must work
+ * with the agent's default URL sanitization, which replaces the {@code X-Amz-Credential} and {@code
+ * X-Amz-Signature} values with {@code REDACTED}; therefore these tests use redacted values. The
+ * non-redacted presigned parameters ({@code X-Amz-Date}, {@code X-Amz-Expires}, {@code
+ * X-Amz-SignedHeaders}) are required, so valid URLs include them.
+ */
+class PresignedAwsUrlParserTest {
+
+  private static final String OBJECT_URL =
+      "https://example-bucket.s3.us-west-2.amazonaws.com/object";
+  private static final String CREDENTIAL_AND_SIGNATURE =
+      "&X-Amz-Credential=REDACTED&X-Amz-Signature=REDACTED";
+  private static final String PRESIGN_PARAMS =
+      "&X-Amz-Date=20260710T120000Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host";
+
+  @Test
+  void detectsSigV4PresignedRequest() {
+    Optional<PresignedAwsUrl> parsed =
+        PresignedAwsUrlParser.parse(
+            presignedUrl("example-bucket.s3.us-west-2.amazonaws.com", "/photos/seed.jpg"), "GET");
+
+    assertThat(parsed).isPresent();
+    assertThat(parsed.get().getHttpMethod()).contains("GET");
+    assertThat(parsed.get().getHost()).isEqualTo("example-bucket.s3.us-west-2.amazonaws.com");
+    assertThat(parsed.get().getPath()).isEqualTo("/photos/seed.jpg");
+  }
+
+  @Test
+  void detectsSigV4aPresignedRequest() {
+    assertThat(
+            PresignedAwsUrlParser.parse(
+                presignedUrl(
+                    "example-bucket.s3.amazonaws.com", "/object", "AWS4-ECDSA-P256-SHA256"),
+                "GET"))
+        .isPresent();
+  }
+
+  @Test
+  void detectsRequestWithNonRedactedCredentialAndSignature() {
+    // Detection must also work before sanitization (e.g. when redaction is disabled), where the
+    // credential and signature carry real values.
+    Optional<PresignedAwsUrl> parsed =
+        PresignedAwsUrlParser.parse(
+            "https://example-bucket.s3.us-west-2.amazonaws.com/object"
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + "&X-Amz-Credential=AKIAEXAMPLE%2F20260710%2Fus-west-2%2Fs3%2Faws4_request"
+                + "&X-Amz-Signature=1234567890abcdef"
+                + PRESIGN_PARAMS,
+            "GET");
+
+    assertThat(parsed).isPresent();
+  }
+
+  @Test
+  void parsesUrlWithValuelessQueryParameterAndEmptyPath() {
+    Optional<PresignedAwsUrl> parsed =
+        PresignedAwsUrlParser.parse(
+            "https://example-bucket.s3.amazonaws.com"
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + CREDENTIAL_AND_SIGNATURE
+                + PRESIGN_PARAMS
+                + "&x-id",
+            "GET");
+
+    assertThat(parsed).isPresent();
+    assertThat(parsed.get().getPath()).isEqualTo("/");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("malformedOrNonPresignedUrls")
+  void rejectsMalformedOrNonPresignedUrl(String description, String url) {
+    assertThat(PresignedAwsUrlParser.parse(url, "GET")).isEmpty();
+  }
+
+  private static Stream<Arguments> malformedOrNonPresignedUrls() {
+    return Stream.of(
+        arguments("null url", null),
+        arguments("empty url", ""),
+        arguments("unparseable uri", "http://exa mple.com/object"),
+        arguments("plain url without SigV4 parameters", "https://example.com/object"),
+        arguments(
+            "cloudfront signed url",
+            "https://d111111abcdef8.cloudfront.net/image.jpg"
+                + "?Policy=policy&Signature=sig&Key-Pair-Id=key"),
+        arguments(
+            "missing algorithm",
+            OBJECT_URL + "?" + CREDENTIAL_AND_SIGNATURE.substring(1) + PRESIGN_PARAMS),
+        arguments(
+            "unsupported algorithm",
+            OBJECT_URL + "?X-Amz-Algorithm=AWS5-FAKE" + CREDENTIAL_AND_SIGNATURE + PRESIGN_PARAMS),
+        arguments(
+            "missing credential",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=REDACTED"
+                + PRESIGN_PARAMS),
+        arguments(
+            "missing signature",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=REDACTED"
+                + PRESIGN_PARAMS),
+        arguments(
+            "empty credential",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=&X-Amz-Signature=REDACTED"
+                + PRESIGN_PARAMS),
+        arguments(
+            "empty signature",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=REDACTED&X-Amz-Signature="
+                + PRESIGN_PARAMS),
+        arguments(
+            "missing date",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + CREDENTIAL_AND_SIGNATURE
+                + "&X-Amz-Expires=3600&X-Amz-SignedHeaders=host"),
+        arguments(
+            "missing expires",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + CREDENTIAL_AND_SIGNATURE
+                + "&X-Amz-Date=20260710T120000Z&X-Amz-SignedHeaders=host"),
+        arguments(
+            "missing signed headers",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + CREDENTIAL_AND_SIGNATURE
+                + "&X-Amz-Date=20260710T120000Z&X-Amz-Expires=3600"),
+        arguments(
+            "empty presigned parameter value",
+            OBJECT_URL
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + CREDENTIAL_AND_SIGNATURE
+                + "&X-Amz-Date=&X-Amz-Expires=3600&X-Amz-SignedHeaders=host"),
+        arguments(
+            "url without host",
+            "/object?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + CREDENTIAL_AND_SIGNATURE
+                + PRESIGN_PARAMS));
+  }
+
+  private static String presignedUrl(String host, String path) {
+    return presignedUrl(host, path, "AWS4-HMAC-SHA256");
+  }
+
+  /** Builds a presigned URL with sanitized (redacted) credential and signature values. */
+  private static String presignedUrl(String host, String path, String algorithm) {
+    return "https://"
+        + host
+        + path
+        + "?X-Amz-Algorithm="
+        + algorithm
+        + CREDENTIAL_AND_SIGNATURE
+        + PRESIGN_PARAMS;
+  }
+}

--- a/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/S3PresignedUrlAttributorTest.java
+++ b/awsagentprovider/src/test/java/software/amazon/opentelemetry/javaagent/providers/S3PresignedUrlAttributorTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.providers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.opentelemetry.javaagent.providers.PresignedUrlAttributor.PresignedUrlAttribution;
+
+/**
+ * S3 attribution is driven purely by the endpoint hostname (the signing service cannot be read from
+ * the redacted credential scope). Tests use realistic sanitized URLs (redacted credential and
+ * signature).
+ */
+class S3PresignedUrlAttributorTest {
+
+  /**
+   * Every supported bucket endpoint form resolves to the bucket. Covers virtual-hosted and
+   * path-style, plus regional, legacy regional, dual-stack, transfer acceleration, FIPS (incl. FIPS
+   * dual-stack), and China. Access points and other specialized endpoints are intentionally
+   * excluded (see the fail-closed cases). References:
+   *
+   * <ul>
+   *   <li>https://docs.aws.amazon.com/general/latest/gr/s3.html
+   *   <li>https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+   *   <li>https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html
+   *   <li>https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html
+   * </ul>
+   */
+  @ParameterizedTest
+  @CsvSource({
+    // Virtual-hosted style: host, path, expected bucket
+    "example-bucket.s3.amazonaws.com,/object,example-bucket",
+    "example-bucket.s3.us-west-2.amazonaws.com,/object,example-bucket",
+    "example-bucket.s3-us-west-2.amazonaws.com,/object,example-bucket",
+    "example.s3.bucket.s3.us-west-2.amazonaws.com,/object,example.s3.bucket",
+    "example-bucket.s3.cn-north-1.amazonaws.com.cn,/object,example-bucket",
+    "example-bucket.s3.dualstack.us-west-2.amazonaws.com,/object,example-bucket",
+    "example-bucket.s3-accelerate.amazonaws.com,/object,example-bucket",
+    "example-bucket.s3-accelerate.dualstack.amazonaws.com,/object,example-bucket",
+    "example-bucket.s3-fips.us-west-2.amazonaws.com,/object,example-bucket",
+    "example-bucket.s3-fips.dualstack.us-east-1.amazonaws.com,/object,example-bucket",
+    // Path-style: bucket is the first path segment
+    "s3.amazonaws.com,/example-bucket/object,example-bucket",
+    "s3.us-west-2.amazonaws.com,/example-bucket/object,example-bucket",
+    "s3.cn-north-1.amazonaws.com.cn,/example-bucket/object,example-bucket",
+    "s3-fips.us-west-2.amazonaws.com,/example-bucket/object,example-bucket",
+    "s3-fips.dualstack.us-east-1.amazonaws.com,/example-bucket/object,example-bucket",
+  })
+  void resolvesBucketForEndpointVariant(String host, String path, String expectedBucket) {
+    PresignedUrlAttribution attribution = attribute(presignedUrl("GET", host, path));
+
+    assertThat(attribution.getRemoteService()).isEqualTo("AWS::S3");
+    assertThat(attribution.getRemoteResource()).isPresent();
+    assertThat(attribution.getRemoteResource().get().getType()).isEqualTo("AWS::S3::Bucket");
+    assertThat(attribution.getRemoteResource().get().getIdentifier()).isEqualTo(expectedBucket);
+  }
+
+  /**
+   * The remote operation is derived from the HTTP method, whether an object key is present (bucket-
+   * vs object-level), and the S3 subresource/multipart query parameters. See the S3 REST API:
+   * https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations.html
+   */
+  @ParameterizedTest
+  @CsvSource({
+    // method, path, extra query params, expected operation
+    "GET,/object,'',GetObject",
+    "PUT,/object,'',PutObject",
+    "HEAD,/object,'',HeadObject",
+    "DELETE,/object,'',DeleteObject",
+    "PATCH,/object,'',UnknownRemoteOperation",
+    // ListObjectsV2 is bucket-level only
+    "GET,/,&list-type=2,ListObjectsV2",
+    "GET,/object,&list-type=2,GetObject",
+    "PUT,/object,&list-type=2,PutObject",
+    // Multipart
+    "PUT,/object,&partNumber=1&uploadId=upload,UploadPart",
+    "PUT,/object,&uploadId=upload,PutObject",
+    "GET,/object,&uploadId=upload,ListParts",
+    "POST,/object,&uploadId=upload,CompleteMultipartUpload",
+    "DELETE,/object,&uploadId=upload,AbortMultipartUpload",
+    "POST,/object,&uploads,CreateMultipartUpload",
+    "GET,/,&uploads,ListMultipartUploads",
+    "GET,/object,&uploads,GetObject",
+    // ACL / tagging (object- and bucket-level)
+    "GET,/object,&acl,GetObjectAcl",
+    "PUT,/object,&acl,PutObjectAcl",
+    "GET,/,&acl,GetBucketAcl",
+    "PUT,/,&acl,PutBucketAcl",
+    "GET,/object,&tagging,GetObjectTagging",
+    "PUT,/object,&tagging,PutObjectTagging",
+    "DELETE,/object,&tagging,DeleteObjectTagging",
+    "GET,/,&tagging,GetBucketTagging",
+    "PUT,/,&tagging,PutBucketTagging",
+    "DELETE,/,&tagging,DeleteBucketTagging",
+    // Object-only subresources
+    "GET,/object,&retention,GetObjectRetention",
+    "PUT,/object,&retention,PutObjectRetention",
+    "GET,/object,&legal-hold,GetObjectLegalHold",
+    "PUT,/object,&legal-hold,PutObjectLegalHold",
+    "GET,/object,&torrent,GetObjectTorrent",
+  })
+  void resolvesOperation(String method, String path, String extraQuery, String expectedOperation) {
+    assertThat(
+            attribute(
+                    presignedUrl(
+                        method, "example-bucket.s3.us-west-2.amazonaws.com", path, extraQuery))
+                .getRemoteOperation())
+        .isEqualTo(expectedOperation);
+  }
+
+  /**
+   * Path-style operation detection: the first path segment is the bucket, so {@code hasObjectKey}
+   * (and thus bucket- vs object-level classification) is computed differently than for
+   * virtual-hosted hosts.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    // method, path, extra query params, expected operation
+    "GET,/example-bucket,&list-type=2,ListObjectsV2",
+    "GET,/example-bucket/object,'',GetObject",
+    "DELETE,/example-bucket/object,'',DeleteObject",
+    "GET,/example-bucket,&acl,GetBucketAcl",
+    "GET,/example-bucket/object,&acl,GetObjectAcl",
+  })
+  void resolvesPathStyleOperation(
+      String method, String path, String extraQuery, String expectedOperation) {
+    assertThat(
+            attribute(presignedUrl(method, "s3.us-west-2.amazonaws.com", path, extraQuery))
+                .getRemoteOperation())
+        .isEqualTo(expectedOperation);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // Access point host (bucket not identifiable from the endpoint form)
+        "example-bucket.s3-accesspoint.us-west-2.amazonaws.com",
+        // Custom CNAME
+        "s3.mycompany.com",
+        // Non-S3 AWS service endpoint
+        "sqs.us-west-2.amazonaws.com",
+      })
+  void failsClosedForUnrecognizedEndpoint(String host) {
+    assertThat(S3PresignedUrlAttributor.attribute(presignedUrl("GET", host, "/object"))).isEmpty();
+  }
+
+  @Test
+  void usesUnknownOperationForAmbiguousBucketOperation() {
+    PresignedUrlAttribution attribution =
+        attribute(presignedUrl("GET", "example-bucket.s3.us-west-2.amazonaws.com", "/"));
+
+    assertThat(attribution.getRemoteService()).isEqualTo("AWS::S3");
+    assertThat(attribution.getRemoteOperation()).isEqualTo("UnknownRemoteOperation");
+    assertThat(attribution.getRemoteResource()).isPresent();
+  }
+
+  @Test
+  void missingHttpMethodUsesUnknownOperation() {
+    PresignedUrlAttribution attribution =
+        attribute(presignedUrl(null, "example-bucket.s3.us-west-2.amazonaws.com", "/object"));
+
+    assertThat(attribution.getRemoteService()).isEqualTo("AWS::S3");
+    assertThat(attribution.getRemoteOperation()).isEqualTo("UnknownRemoteOperation");
+  }
+
+  @Test
+  void pathStyleWithoutBucketAttributesS3WithoutResource() {
+    PresignedUrlAttribution attribution =
+        attribute(presignedUrl("GET", "s3.us-west-2.amazonaws.com", "/"));
+
+    assertThat(attribution.getRemoteService()).isEqualTo("AWS::S3");
+    assertThat(attribution.getRemoteResource()).isEmpty();
+  }
+
+  /** Unwraps an attribution expected to be present. */
+  private static PresignedUrlAttribution attribute(PresignedAwsUrl url) {
+    Optional<PresignedUrlAttribution> attribution = S3PresignedUrlAttributor.attribute(url);
+    assertThat(attribution).isPresent();
+    return attribution.get();
+  }
+
+  private static PresignedAwsUrl presignedUrl(String method, String host, String path) {
+    return presignedUrl(method, host, path, "");
+  }
+
+  /** Builds a presigned URL with sanitized (redacted) credential and signature values. */
+  private static PresignedAwsUrl presignedUrl(
+      String method, String host, String path, String extraQueryParameters) {
+    return PresignedAwsUrlParser.parse(
+            "https://"
+                + host
+                + path
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + "&X-Amz-Credential=REDACTED"
+                + "&X-Amz-Signature=REDACTED"
+                + "&X-Amz-Date=20260710T120000Z"
+                + "&X-Amz-Expires=3600"
+                + "&X-Amz-SignedHeaders=host"
+                + extraQueryParameters,
+            method)
+        .get();
+  }
+}


### PR DESCRIPTION
## Context

Presigned URLs are a first-class Amazon S3 pattern for granting temporary, credential-free
access to a single object — commonly used for browser/mobile direct uploads and downloads and
for sharing objects across parties. The standard way to *use* a presigned URL is to issue a
plain HTTP request to it with a generic HTTP client, not through the S3 service client. AWS
documents exactly this:

- The AWS SDK for Java 2.x guide generates the URL with `S3Presigner` and then performs the
  upload/download with `java.net.HttpURLConnection`, the JDK `HttpClient`, or the SDK's
  low-level `SdkHttpClient`.
- The Amazon S3 User Guide describes uploading objects via presigned URLs with an HTTP `PUT`.

Because that HTTP request runs *below* the AWS SDK instrumentation pipeline, the S3 execution
interceptor that would normally stamp `rpc.system=aws-api` / `rpc.service=S3` never fires.

## Problem

With the call invisible to SDK instrumentation, Application Signals records a presigned S3
request as a generic HTTP call to the bucket host:

- **Attribution** — it appears as a dependency on the bucket hostname rather than an `AWS::S3`
  dependency, so it does not roll up with the service's other S3 usage on the service map.
- **Cardinality** — the remote operation becomes `<METHOD> /<object-key>`, i.e. one unique
  value per object, which inflates operation/dependency cardinality.

## What this changes

Adds an **opt-in**, generic SigV4/SigV4a presigned-URL attribution path, with S3 as the first
supported service. It complements the credential-redaction change in #1419: that PR keeps signing
material out of span attributes; this PR fixes how the call is *attributed*.

Crucially, detection is **redaction-aware** — it must work *after* the agent's default URL
sanitization has replaced the `X-Amz-Credential` and `X-Amz-Signature` values with `REDACTED`:

- The parser recognizes a presigned request from non-sensitive signals only: the presence of the
  six SigV4 query parameters (`X-Amz-Algorithm`, `X-Amz-Credential`, `X-Amz-Signature`,
  `X-Amz-Date`, `X-Amz-Expires`, `X-Amz-SignedHeaders`), with only the `X-Amz-Algorithm` value
  checked against an allowlist. Credential and signature values are never read, so a sanitized
  (redacted) URL still resolves.
- The signing service is **not** derived from the credential scope (it may be redacted); S3 is
  identified from the **endpoint hostname** — virtual-hosted and path-style forms, including
  regional, legacy regional, dual-stack, transfer acceleration, FIPS (incl. FIPS dual-stack), and
  China.
- Attributes set for a recognized S3 request:
  - `aws.remote.service = AWS::S3`
  - `aws.remote.operation` = normalized S3 operation, derived from the HTTP method, whether an
    object key is present (bucket- vs object-level), and the S3 subresource/multipart query
    parameters — covering object CRUD, `ListObjectsV2`, multipart, and the ACL / tagging /
    retention / legal-hold / torrent subresources.
  - when the bucket is identifiable: `aws.remote.resource.type = AWS::S3::Bucket`,
    `aws.remote.resource.identifier = <bucket>`
- Resolved lazily as the last fallback in remote-service/operation derivation, so it only runs
  for spans not already attributed via RPC/DB/messaging/etc., and the URL is parsed at most once
  per span.
- **Fail closed:** non-presigned URLs and non-S3 or unrecognized endpoints (custom CNAMEs, access
  points) keep the existing behavior. A recognized S3 endpoint whose bucket cannot be identified
  (e.g. a path-style request with no bucket segment) is still attributed to `AWS::S3`, without an
  `AWS::S3::Bucket` resource; its operation is normalized when identifiable and otherwise remains
  `UnknownRemoteOperation`.

## Scope

This changes only the AWS Application Signals presentation layer — the `aws.remote.*`
attribution the agent derives for the Application Signals service map and RED (Request/Error/
Duration) metrics. It does **not** modify the underlying span: the span name and the standard
HTTP/URL attributes (e.g. `url.full`, `http.request.method`) are left untouched, span names are
not rewritten, and no new spans are created. Only the values of the derived remote attributes
change (from bucket-host / `<METHOD> /<object-key>` to `AWS::S3` / normalized operation /
`AWS::S3::Bucket`). Redaction of signing material in the URL attribute is handled separately in
#1419.

## Configuration

Opt-in, disabled by default:

- `otel.aws.application.signals.presigned-url-attribution.enabled`
- `OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED`

Resolved from `ConfigProperties` at startup and injected into the metric attribute generator.

## Backward compatibility

Disabled by default, so existing behavior is unchanged unless the flag is set.

When enabled, attribution for presigned S3 calls changes: what previously appeared as a
dependency on the bucket host with a high-cardinality `<METHOD> /<object-key>` operation is now
attributed to `AWS::S3` with a normalized operation and, when the bucket is identifiable, an
`AWS::S3::Bucket` resource. Operators
with dashboards or alarms keyed on the previous shape should update them when enabling the flag.

## Testing

```
./scripts/local_patch.sh
./gradlew build
```

- Parameterized unit tests for the SigV4 parser (detection plus malformed / non-presigned
  rejection cases), the S3 attributor (virtual-hosted and path-style endpoint forms, operation
  mapping, and fail-closed cases), and generator precedence / remote-resource behavior.

## References

- AWS SDK for Java 2.x — Work with Amazon S3 pre-signed URLs (executes the presigned request with
  `HttpURLConnection` / JDK `HttpClient` / `SdkHttpClient`):
  https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/examples-s3-presign.html
- Amazon S3 User Guide — Uploading objects with presigned URLs:
  https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html
- Amazon S3 User Guide — Sharing objects with presigned URLs:
  https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html
- AWS General Reference — Authenticating requests: using query parameters (SigV4):
  https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
- Related: #1419 (redact presigned URL credentials from span attributes)

## Type of change

- [x] New feature (opt-in, disabled by default)
- [x] Changes behavior when enabled: reshapes attribution of presigned S3 calls (see Backward compatibility)

## Checklist

- [x] Unit tests added/updated and passing
- [x] CHANGELOG.md updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.