### PR TITLE
Use get-signing-profile for ECR image signing

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -584,13 +584,14 @@ jobs:
       # Query ECR signing profile ARN
       - name: Query ECR Signing Profile ARN
         id: ecr-signing-profile
+        continue-on-error: true
         run: |
-          PROFILE_ARN=$(aws signer list-signing-profiles --region ${{ env.AWS_PUBLIC_ECR_REGION }} --query "profiles[?profileName=='ADOTECRSigningProfile'].arn" --output text 2>/dev/null)
-          if [ -n "$PROFILE_ARN" ]; then
+          PROFILE_ARN=$(aws signer get-signing-profile --region ${{ env.AWS_PUBLIC_ECR_REGION }} --profile-name ADOTECRSigningProfile --query "arn" --output text) || PROFILE_ARN=""
+          if [ -n "$PROFILE_ARN" ] && [ "$PROFILE_ARN" != "None" ]; then
             echo "profile_arn=$PROFILE_ARN" >> $GITHUB_OUTPUT
             echo "Found ECR signing profile: $PROFILE_ARN"
           else
-            echo "ECR signing profile 'ADOTECRSigningProfile' not found"
+            echo "ECR signing profile 'ADOTECRSigningProfile' not found or lookup failed; skipping image signing."
             exit 0
           fi
 


### PR DESCRIPTION
## Description

The `sign-public-ecr-image` job was failing at the *Query ECR Signing Profile ARN* step with exit code 254. The step called `aws signer list-signing-profiles`, which requires the account-wide `signer:ListSigningProfiles` permission that the release role does not (and should not) have.

## Changes

- Look the profile up by name with `aws signer get-signing-profile --profile-name ADOTECRSigningProfile` instead of listing all profiles. This maps to `signer:GetSigningProfile`, which the release role already holds scoped to the `ADOTECRSigningProfile` ARN — no account-wide list permission needed.
- Make the step resilient:
  - `continue-on-error: true`
  - guard the command substitution under `set -e` with `|| PROFILE_ARN=""` so the not-found path actually runs
  - handle a `None` result
  - drop `2>/dev/null` so CLI errors are visible in the logs