### PR TITLE
ci: run CodeQL on pull requests to gate merges (parity with Python/JS/.NET)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main", "release/v*" ]
+  pull_request:
+    branches: [ "main", "release/v*" ]
+  schedule:
+    - cron: '30 4 * * 1'
 
 permissions:
   security-events: write
@@ -82,7 +86,7 @@ jobs:
           fi
           
           # Extract all job names from workflow (excluding this gate job)
-          all_jobs=$(yq eval '.jobs | keys | .[]' .github/workflows/codeql.yml | grep -v "all-codeql-checks-pass" | sort)
+          all_jobs=$(yq eval '.jobs | keys | .[]' .github/workflows/codeql-analysis.yml | grep -v "all-codeql-checks-pass" | sort)
           
           # Extract job names from needs array
           needed_jobs='${{ toJSON(needs) }}'


### PR DESCRIPTION
## Description

ADOT Java does not block PRs on CodeQL failures, unlike the other three ADOT languages.

CodeQL previously ran only on `push` to `main`, so the `all-codeql-checks-pass` gate job could never block a PR. Python, JS, and .NET all run their CodeQL workflow on `pull_request` (and on a weekly `schedule`), so a CodeQL failure surfaces as a PR check and can gate merges. This brings Java to **PR-gating parity** with them.

### Changes
- Add `pull_request` and `schedule` triggers to `codeql-analysis.yml` (and `release/v*` on push), matching the other three languages.
- Fix a latent bug in the `all-codeql-checks-pass` gate: its self-check grepped `.github/workflows/codeql.yml`, but the Java workflow file is named `codeql-analysis.yml`, so the step would error even when the analysis passed.

### On the "secrets block fork PRs" concern
There was a concern that the `GPG_PRIVATE_KEY`/`GPG_PASSPHRASE` secrets needed for "Publish patched dependencies to maven local" would make fork PRs fail. That's not the case:
- `patch.sh` does no signing.
- The `patch-dependencies` action only exports the GPG vars **when they are non-empty**; they're consumed solely for artifact *signing* during `publishToMavenLocal`.
- `pr-build.yml` **already** runs `patch-dependencies` on PRs with **no secrets passed** and builds fine.

So a fork PR simply publishes *unsigned* patched dependencies to maven-local, which is fine for CodeQL analysis.

### Follow-up (requires a maintainer)
Branch protection rules for `main` and `release/v*` need `all-codeql-checks-pass` added as a required status check so the job actually blocks merges.

> Note: This is a CI-only change with no SDK behavior impact — please apply the **Skip Changelog** label.
