### PR TITLE
fix(lambda): publish the signed layer instead of the unsigned one

### DIFF
--- a/.github/workflows/region-build-release.yml
+++ b/.github/workflows/region-build-release.yml
@@ -135,7 +135,7 @@ jobs:
           SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text 2>/dev/null)
           echo "SIGNED value: '$SIGNED'"
           if [ -n "$SIGNED" ]; then
-            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }} --clobber"
+            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
             echo "Signed layer moved successfully"
           else
             echo "No SIGNED value returned, skipping move"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -354,7 +354,7 @@ jobs:
           SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text 2>/dev/null)
           echo "SIGNED value: '$SIGNED'"
           if [ -n "$SIGNED" ]; then
-            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }} --clobber"
+            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
             echo "Signed layer moved successfully"
           else
             echo "No SIGNED value returned, skipping move"


### PR DESCRIPTION
## Description

The Lambda layer signing step moved the signed S3 object to a malformed destination key. The `--clobber` text was placed **inside** the quoted destination path:

```bash
aws s3 mv "s3://$BUCKET/$SIGNED" "s3://$BUCKET/${LAYER_ARTIFACT_NAME} --clobber"
```

Two problems:
1. `--clobber` is not a valid `aws s3 mv` flag (it belongs to `gh release upload`).
2. Because it was inside the quotes, the signed object was moved to the literal key `"<layer>.zip --clobber"` instead of `<layer>.zip`.

As a result the signed artifact never overwrote the original, and `publish-layer-version` published the **unsigned** layer. The failure was silently swallowed by `continue-on-error: true` and the `|| exit 0` guards.

## Fix

Drop the stray `--clobber` so the destination is the correct key and the signed layer overwrites the published artifact — matching the working behavior in the Python distro.

Applied to both workflows that contain this step:
- `.github/workflows/release-build.yml`
- `.github/workflows/region-build-release.yml`

## Testing

Change is limited to the S3 destination key of a single `aws s3 mv`; verified the resulting command matches the equivalent (working) step in aws-otel-python-instrumentation.