### PR TITLE
Bump Netty to 4.1.136.Final to fix HIGH CVEs

### DIFF
--- a/appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts
+++ b/appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 dependencies {
-  implementation("io.netty:netty-all:4.1.135.Final")
+  implementation("io.netty:netty-all:4.1.136.Final")
   implementation("com.sparkjava:spark-core")
   implementation("org.slf4j:slf4j-simple")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/appsignals-tests/images/http-servers/netty-server/build.gradle.kts
+++ b/appsignals-tests/images/http-servers/netty-server/build.gradle.kts
@@ -27,7 +27,7 @@ java {
 }
 
 dependencies {
-  implementation("io.netty:netty-all:4.1.135.Final")
+  implementation("io.netty:netty-all:4.1.136.Final")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.slf4j:slf4j-simple:1.7.30")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -40,7 +40,7 @@ val dependencyBoms = listOf(
   "com.google.protobuf:protobuf-bom:3.25.1",
   "com.linecorp.armeria:armeria-bom:1.26.4",
   "io.grpc:grpc-bom:1.59.1",
-  "io.netty:netty-bom:4.1.135.Final",
+  "io.netty:netty-bom:4.1.136.Final",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",
   "org.junit:junit-bom:5.10.1",


### PR DESCRIPTION
Bumps Netty to 4.1.136.Final to fix the HIGH CVEs flagged by the daily scan (CVE-2026-59901, CVE-2026-55831, CVE-2026-55833, CVE-2026-56745).

Fixes the CVEs suppressed in https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1431