### PR TITLE
chore(trivy): suppress two jackson CVEs pending upstream OTel bump

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -18,6 +18,9 @@ vulnerabilities:
   - id: GHSA-r7wm-3cxj-wff9
     statement: "jackson-core async parser maxNumberLength bypass via chunked digit accumulation. Fix: bump jackson to 2.22.1. https://github.com/advisories/GHSA-r7wm-3cxj-wff9"
     expired_at: 2026-08-14
+  - id: CVE-2026-59889
+    statement: "jackson-databind @JsonView bypassed for @JsonUnwrapped container properties on deserialization. No fix available for the bundled 2.22.0 line yet (2.21.5 unreleased, 2.22.1 pending). jackson-databind 2.22.0 is bundled by the shaded upstream OTel javaagent, so this repo's jackson-bom pin does not control it. https://avd.aquasec.com/nvd/cve-2026-59889"
+    expired_at: 2026-08-14
 
   - id: CVE-2026-59901
     statement: "Netty Bzip2Decoder infinite loop in RLE state machine leads to event-loop thread starvation. Fix: bump netty-codec to 4.1.136.Final. https://avd.aquasec.com/nvd/cve-2026-59901"

--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -12,3 +12,9 @@ vulnerabilities:
   - id: CVE-2026-54515
     statement: "jackson-databind vulnerability. No fix available in 2.21.x yet (Trivy DB lists 2.21.5 which has not been released). https://avd.aquasec.com/nvd/cve-2026-54515"
     expired_at: 2026-07-31
+  - id: GHSA-r7wm-3cxj-wff9
+    statement: "jackson-core async parser maxNumberLength bypass via chunked digit accumulation. jackson-core 2.22.0 is bundled by the shaded upstream OTel javaagent, so this repo's jackson-bom pin does not control it. Fix: upstream OTel release bundling jackson 2.22.1. https://github.com/advisories/GHSA-r7wm-3cxj-wff9"
+    expired_at: 2026-08-14
+  - id: CVE-2026-59889
+    statement: "jackson-databind @JsonView bypassed for @JsonUnwrapped container properties on deserialization. No fix available for the bundled 2.22.0 line yet (2.21.5 unreleased, 2.22.1 pending). jackson-databind 2.22.0 is bundled by the shaded upstream OTel javaagent, so this repo's jackson-bom pin does not control it. https://avd.aquasec.com/nvd/cve-2026-59889"
+    expired_at: 2026-08-14


### PR DESCRIPTION
## Description of changes

Suppress two Jackson vulnerabilities currently failing the Trivy image scan on `javaagent.jar`. Added to both `pr-build` and `daily-scan` trivyignore files, following the same pattern as #1375.

| ID | Severity | Library | Fixed in |
|---|---|---|---|
| `GHSA-r7wm-3cxj-wff9` | HIGH | jackson-core 2.22.0 | 2.22.1 |
| `CVE-2026-59889` | MEDIUM | jackson-databind 2.22.0 | 2.22.1 |

### Why suppress (low exploitability for the ADOT Java agent)

- **GHSA-r7wm-3cxj-wff9**: `maxNumberLength` / `StreamReadConstraints` bypass in the **async / non-blocking** parser via chunked digit accumulation (a DoS hardening limit). The agent parses only trusted, operator-provided config using the blocking parser, no attacker-controlled JSON reaches the async API.
- **CVE-2026-59889**: `@JsonView` is not enforced for `@JsonUnwrapped` container properties during deserialization. The agent does not use `@JsonView` as a security boundary on untrusted input.

### Source of the vulnerable version

`2.22.0` is bundled by the upstream `opentelemetry-javaagent` (isolated/shaded into the final agent jar), not resolved via this repo's `jackson-bom` (`2.21.1`) or the `awsagentprovider` pin (`2.16.1`). A local BOM bump therefore does not clear these findings.

### Removal condition

Both are fixed in Jackson `2.22.1`. Remove these entries once we pick up an upstream OTel agent release bundling `2.22.1` (bump `otelVersion`). Entries expire `2026-08-28`.

## Test plan

Scan-configuration only, no code or dependency changes. The PR build image scan should now pass on these two findings.

## By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
