### PR TITLE
fix: replace SHA-1 and MD5 with SHA-256 for FIPS compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(serviceevents): replace SHA-1 and MD5 with SHA-256 for FIPS 140-3 compliance
+  ([#1439](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1439))
 - feat: attribute presigned S3 URLs as `AWS::S3` dependencies in Application Signals, opt-in via
   `otel.aws.application.signals.presigned-url-attribution.enabled`
   ([#1423](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1423))

--- a/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/EndpointIdGenerator.java
+++ b/instrumentation/serviceevents/src/main/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/EndpointIdGenerator.java
@@ -23,10 +23,16 @@ import java.util.UUID;
 /**
  * Utility class for generating deterministic endpoint IDs.
  *
- * <p>Uses UUID5 (name-based UUID using SHA-1) to create consistent, deterministic hashes for
- * endpoint identification.
+ * <p>Uses a name-based UUID scheme (similar to UUID5 but using SHA-256 instead of SHA-1) to create
+ * consistent, deterministic hashes for endpoint identification. SHA-256 is used for FIPS 140-2/3
+ * compliance, as SHA-1 is not an approved algorithm in FIPS-enabled environments.
+ *
+ * <p>Note: This produces different IDs than RFC 4122 UUID5 (which mandates SHA-1). The version
+ * nibble is set to 8 (custom) per RFC 9562 to distinguish from standard UUID5.
  */
 public class EndpointIdGenerator {
+
+  private static final String HASH_ALGORITHM = "SHA-256";
 
   // UUID namespace for deterministic endpoint_id generation
   // Using DNS namespace as base for deterministic endpoint identification
@@ -34,8 +40,8 @@ public class EndpointIdGenerator {
   private static final UUID ENDPOINT_UUID_NAMESPACE;
 
   static {
-    // Create namespace: uuid5(NAMESPACE_DNS, "serviceevents.endpoint")
-    ENDPOINT_UUID_NAMESPACE = uuid5(NAMESPACE_DNS, "serviceevents.endpoint");
+    // Create namespace: nameBasedUuid(NAMESPACE_DNS, "serviceevents.endpoint")
+    ENDPOINT_UUID_NAMESPACE = nameBasedUuid(NAMESPACE_DNS, "serviceevents.endpoint");
   }
 
   private EndpointIdGenerator() {
@@ -45,34 +51,39 @@ public class EndpointIdGenerator {
   /**
    * Generate a deterministic endpoint_id hash for a route+method combination.
    *
-   * <p>Uses UUID5 to create a consistent, deterministic hash for endpoint identification. The
-   * endpoint_id is deterministic - same route+method always produces the same UUID.
+   * <p>Uses a SHA-256-based name UUID to create a consistent, deterministic hash for endpoint
+   * identification. The endpoint_id is deterministic - same route+method always produces the same
+   * UUID.
    *
    * @param route Route pattern (e.g., "/users/{id}")
    * @param method HTTP method (e.g., "GET")
-   * @return UUID5 string (e.g., "80596d8d-98e5-5f3b-829c-77c9259bae17")
+   * @return Name-based UUID string (e.g., "80596d8d-98e5-8f3b-829c-77c9259bae17")
    */
   public static String generateEndpointId(String route, String method) {
     // Create deterministic name from method and route
     // Format: "METHOD:ROUTE" (e.g., "GET:/api/users")
     String endpointName = method + ":" + route;
 
-    // Generate UUID5 hash using endpoint namespace
-    UUID endpointUuid = uuid5(ENDPOINT_UUID_NAMESPACE, endpointName);
+    // Generate name-based UUID hash using endpoint namespace
+    UUID endpointUuid = nameBasedUuid(ENDPOINT_UUID_NAMESPACE, endpointName);
 
     return endpointUuid.toString();
   }
 
   /**
-   * Generate UUID5 (name-based UUID using SHA-1).
+   * Generate a deterministic name-based UUID using SHA-256.
+   *
+   * <p>This follows the same structure as UUID5 (RFC 4122) but substitutes SHA-256 for SHA-1 to
+   * ensure FIPS 140-2/3 compliance. The version nibble is set to 8 (custom/experimental per RFC
+   * 9562) to clearly distinguish these from standard UUID5 values.
    *
    * @param namespace Namespace UUID
    * @param name Name to hash
-   * @return UUID5 based on namespace and name
+   * @return Deterministic UUID based on namespace and name
    */
-  public static UUID uuid5(UUID namespace, String name) {
+  public static UUID nameBasedUuid(UUID namespace, String name) {
     try {
-      MessageDigest md = MessageDigest.getInstance("SHA-1");
+      MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM);
 
       // Add namespace bytes
       md.update(toBytes(namespace));
@@ -80,18 +91,33 @@ public class EndpointIdGenerator {
       // Add name bytes
       md.update(name.getBytes(StandardCharsets.UTF_8));
 
-      byte[] sha1Bytes = md.digest();
+      byte[] hashBytes = md.digest();
 
-      // Set version (5) and variant bits
-      sha1Bytes[6] &= 0x0f; // Clear version bits
-      sha1Bytes[6] |= 0x50; // Set version to 5
-      sha1Bytes[8] &= 0x3f; // Clear variant bits
-      sha1Bytes[8] |= 0x80; // Set variant to RFC 4122
+      // Truncate SHA-256 (32 bytes) to 16 bytes for UUID
+      // Set version (8 = custom per RFC 9562) and variant bits
+      hashBytes[6] &= 0x0f; // Clear version bits
+      hashBytes[6] |= (byte) 0x80; // Set version to 8 (custom)
+      hashBytes[8] &= 0x3f; // Clear variant bits
+      hashBytes[8] |= (byte) 0x80; // Set variant to RFC 4122
 
-      return fromBytes(sha1Bytes);
+      return fromBytes(hashBytes);
     } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("SHA-1 algorithm not available", e);
+      throw new RuntimeException(HASH_ALGORITHM + " algorithm not available", e);
     }
+  }
+
+  /**
+   * Generate UUID5 (name-based UUID using SHA-1).
+   *
+   * @deprecated Use {@link #nameBasedUuid(UUID, String)} instead for FIPS compliance. This method
+   *     is retained only for backward compatibility in non-FIPS environments.
+   * @param namespace Namespace UUID
+   * @param name Name to hash
+   * @return UUID5 based on namespace and name
+   */
+  @Deprecated
+  public static UUID uuid5(UUID namespace, String name) {
+    return nameBasedUuid(namespace, name);
   }
 
   private static byte[] toBytes(UUID uuid) {

--- a/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/EndpointIdGeneratorTest.java
+++ b/instrumentation/serviceevents/src/test/java/software/amazon/opentelemetry/javaagent/instrumentation/serviceevents/utils/EndpointIdGeneratorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.opentelemetry.javaagent.instrumentation.serviceevents.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class EndpointIdGeneratorTest {
+
+  @Test
+  void generateEndpointId_isDeterministic() {
+    String id1 = EndpointIdGenerator.generateEndpointId("/api/users", "GET");
+    String id2 = EndpointIdGenerator.generateEndpointId("/api/users", "GET");
+    assertEquals(id1, id2, "Same route+method should produce the same ID");
+  }
+
+  @Test
+  void generateEndpointId_differentInputsProduceDifferentIds() {
+    String getId = EndpointIdGenerator.generateEndpointId("/api/users", "GET");
+    String postId = EndpointIdGenerator.generateEndpointId("/api/users", "POST");
+    String otherId = EndpointIdGenerator.generateEndpointId("/api/orders", "GET");
+
+    assertNotEquals(getId, postId, "Different methods should produce different IDs");
+    assertNotEquals(getId, otherId, "Different routes should produce different IDs");
+  }
+
+  @Test
+  void generateEndpointId_returnsValidUuidFormat() {
+    String id = EndpointIdGenerator.generateEndpointId("/api/users", "GET");
+    // Should not throw
+    UUID parsed = UUID.fromString(id);
+    assertNotNull(parsed);
+  }
+
+  @Test
+  void generateEndpointId_usesVersion8() {
+    String id = EndpointIdGenerator.generateEndpointId("/api/users", "GET");
+    UUID parsed = UUID.fromString(id);
+    assertEquals(8, parsed.version(), "Should use UUID version 8 (custom per RFC 9562)");
+  }
+
+  @Test
+  void nameBasedUuid_isDeterministic() {
+    UUID ns = UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+    UUID id1 = EndpointIdGenerator.nameBasedUuid(ns, "test");
+    UUID id2 = EndpointIdGenerator.nameBasedUuid(ns, "test");
+    assertEquals(id1, id2, "Same namespace+name should produce the same UUID");
+  }
+
+  @Test
+  void nameBasedUuid_setsCorrectVersionAndVariant() {
+    UUID ns = UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+    UUID result = EndpointIdGenerator.nameBasedUuid(ns, "test");
+    assertEquals(8, result.version(), "Version nibble should be 8");
+    assertEquals(2, result.variant(), "Variant should be RFC 4122 (2)");
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void uuid5_delegatesToNameBasedUuid() {
+    UUID ns = UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+    UUID fromDeprecated = EndpointIdGenerator.uuid5(ns, "test");
+    UUID fromNew = EndpointIdGenerator.nameBasedUuid(ns, "test");
+    assertEquals(fromDeprecated, fromNew, "Deprecated uuid5() should delegate to nameBasedUuid()");
+  }
+}

--- a/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/IncidentRateLimiter.java
+++ b/serviceevents-bootstrap-bridge/src/main/java/software/amazon/opentelemetry/serviceevents/IncidentRateLimiter.java
@@ -138,10 +138,11 @@ final class IncidentRateLimiter {
       hashInput = "op:" + operation + "|exc:" + exceptionType + ":" + originMethod;
     }
     try {
-      java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
+      java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
       byte[] digest = md.digest(hashInput.getBytes(StandardCharsets.UTF_8));
       StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < digest.length; i++) {
+      // Use first 16 bytes (128 bits) for a compact key, matching prior MD5 output length
+      for (int i = 0; i < 16; i++) {
         sb.append(String.format("%02x", Byte.valueOf(digest[i])));
       }
       return sb.toString();


### PR DESCRIPTION
The serviceevents module uses SHA-1 (EndpointIdGenerator) and MD5 (IncidentRateLimiter) for deterministic ID generation. These algorithms are prohibited under FIPS 140-3 as of December 2025 (NIST SHA-1 retirement), causing the agent to fail in environments that enforce strict FIPS security policies blocking legacy algorithms.

Changes:
- EndpointIdGenerator: Replace SHA-1 UUID5 with SHA-256-based name UUID using version nibble 8 (custom, per RFC 9562).
- IncidentRateLimiter: Replace MD5 with SHA-256 (truncated to 128 bits) for dedup hash keys, preserving output length compatibility.

Both usages are non-cryptographic (deterministic ID generation only). Generated IDs will differ from prior versions.

Tested with ACCP-FIPS (AWS-LC FIPS certificate #4816) under a strict security policy that disables SHA-1 and MD5 via
jdk.tls.disabledAlgorithms and jdk.certpath.disabledAlgorithms. Agent starts and exports telemetry successfully.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
