### PR TITLE
Bump Netty to 4.1.137.Final to fix CVE-2026-59903

### DIFF
--- a/appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts
+++ b/appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 dependencies {
-  implementation("io.netty:netty-all:4.1.136.Final")
+  implementation("io.netty:netty-all:4.1.137.Final")
   implementation("com.sparkjava:spark-core")
   implementation("org.slf4j:slf4j-simple")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/appsignals-tests/images/http-servers/netty-server/build.gradle.kts
+++ b/appsignals-tests/images/http-servers/netty-server/build.gradle.kts
@@ -27,7 +27,7 @@ java {
 }
 
 dependencies {
-  implementation("io.netty:netty-all:4.1.136.Final")
+  implementation("io.netty:netty-all:4.1.137.Final")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.slf4j:slf4j-simple:1.7.30")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -40,7 +40,7 @@ val dependencyBoms = listOf(
   "com.google.protobuf:protobuf-bom:3.25.1",
   "com.linecorp.armeria:armeria-bom:1.26.4",
   "io.grpc:grpc-bom:1.59.1",
-  "io.netty:netty-bom:4.1.136.Final",
+  "io.netty:netty-bom:4.1.137.Final",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelAlphaVersion",
   "org.apache.logging.log4j:log4j-bom:2.21.1",
   "org.junit:junit-bom:5.10.1",


### PR DESCRIPTION
## Description of changes

Bumps Netty from `4.1.136.Final` to `4.1.137.Final` to fix **CVE-2026-59903**.

The Trivy image scan in `pr-build` currently fails on:

| Library | Vulnerability | Severity | Installed | Fixed |
|---|---|---|---|---|
| `io.netty:netty-codec-http` | `CVE-2026-59903` | MEDIUM | 4.1.136.Final | 4.2.17.Final, **4.1.137.Final** |

This blocks **every** PR, not any individual change, since the finding comes from a bundled dependency. It is currently the sole reason `all-pr-checks-pass` fails on open PRs (for example #1434, where the only failing step in `Build on ubuntu-latest` is "Perform image scan").

Bumping is preferred over a `trivyignore` suppression here because a patch release with the fix is already available, consistent with #1432 (4.1.136.Final), #1389 (4.1.135.Final), and #1374 (4.1.133.Final).

### Files changed

- `dependencyManagement/build.gradle.kts` — `netty-bom`
- `appsignals-tests/images/http-clients/netty-http-client/build.gradle.kts` — `netty-all`
- `appsignals-tests/images/http-servers/netty-server/build.gradle.kts` — `netty-all`

The two contract-test app pins are bumped alongside the BOM to keep them in sync, matching #1432.

## Test plan

Verified locally before pushing:

- `netty-bom`, `netty-all`, and `netty-codec-http` 4.1.137.Final are all published on Maven Central.
- Gradle configuration succeeds (`:dependencyManagement:help` → `BUILD SUCCESSFUL`).
- Dependency resolution confirms the new version takes effect, including upgrading transitives:
  ```
  io.netty:netty-all:4.1.137.Final
  io.netty:netty-codec-http:4.1.137.Final
  io.netty:netty-codec-http:4.1.100.Final -> 4.1.137.Final (c)
  ```

CI provides the authoritative verification: the `pr-build` image scan should now pass, and the netty contract tests exercise the upgraded version.

## By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
