### PR TITLE
Drop service.name from span-metric datapoint attributes; emit calls with {call} unit

### DIFF
--- a/cloudwatch-plugin-otel/CHANGELOG.md
+++ b/cloudwatch-plugin-otel/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* `service.name` is no longer emitted as a metric datapoint attribute; it is carried by the
+  metric's resource (the host SDK's resource). Consumers reading `service.name` from datapoint
+  dimensions must read it from the resource instead.
+* The `traces.span.metrics.calls` counter now uses the `{call}` unit (UCUM annotation) instead of
+  an unset unit.
+
 ### v0.1.0 / 2026-08-14
 
 * Initial release of the CloudWatch Plugin for OpenTelemetry (Java).

--- a/cloudwatch-plugin-otel/README.md
+++ b/cloudwatch-plugin-otel/README.md
@@ -18,15 +18,16 @@ Two metrics, matching the OpenTelemetry SpanMetrics naming:
 
 | Metric | Instrument | Unit |
 | --- | --- | --- |
-| `traces.span.metrics.calls` | Counter (monotonic sum) | unset |
+| `traces.span.metrics.calls` | Counter (monotonic sum) | `{call}` |
 | `traces.span.metrics.duration` | Histogram | `s` (seconds) |
 
-Each datapoint carries low-cardinality dimensions: `service.name`, `span.name`, `span.kind`,
+Each datapoint carries low-cardinality dimensions: `span.name`, `span.kind`,
 `status.code`, plus any allowlisted semantic-convention attributes present on the span
 (e.g. `http.request.method`, `http.route`, `http.response.status_code`, `rpc.system.name`/`rpc.service`/`rpc.method`,
 `db.system.name`/`db.operation.name`/`db.collection.name`, `messaging.system`/`messaging.operation.name`/`messaging.destination.name`).
 Current semantic-convention keys are used, with recognized legacy keys passed through under their own
-key/value when the current key is absent.
+key/value when the current key is absent. `service.name` is carried by the metric's **resource**
+(the host SDK's resource), not duplicated on each datapoint.
 
 Both metrics also carry two identity attributes:
 

--- a/cloudwatch-plugin-otel/contract-tests/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/e2e/family/BaseAttributesFamilyTest.java
+++ b/cloudwatch-plugin-otel/contract-tests/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/e2e/family/BaseAttributesFamilyTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.opentelemetry.cloudwatch.spanmetrics.e2e.utils.ResourceScopeMetric;
 
 /** Base attributes present on every datapoint, plus the error-status path. */
 @Testcontainers(disabledWithoutDocker = true)
@@ -28,13 +29,31 @@ class BaseAttributesFamilyTest extends FamilyTestBase {
   @Test
   void baseAttributesUseShortForms() {
     Map<String, String> attrs = metricAttributesFor("/ping", "GET /ping");
-    assertThat(attrs).containsKey("service.name");
+    // service.name lives on the metric RESOURCE, not the datapoint (asserted separately below).
+    assertThat(attrs).doesNotContainKey("service.name");
     assertThat(attrs).containsKey("span.name");
     assertThat(attrs.get("span.kind")).isEqualTo("SERVER").doesNotStartWith("SPAN_KIND_");
     assertThat(attrs.get("status.code")).isEqualTo("UNSET").doesNotStartWith("STATUS_CODE_");
-    // Schema + lib-version markers on every metric datapoint (spec §6).
+    // Schema + lib-version markers on every metric datapoint.
     assertThat(attrs.get("aws.otel.span.metrics.schema")).isEqualTo("v1");
     assertThat(attrs).containsKey("aws.otel.extension.lib.version");
+  }
+
+  @Test
+  void serviceNameOnResourceAndCallsUnitIsCallAnnotation() {
+    ResourceScopeMetric calls = callsMetricFor("/ping", "GET /ping");
+    // service.name is carried by the metric resource with the app's CONFIGURED value. Asserting the
+    // value (not just key presence) matters: the SDK unconditionally defaults service.name to
+    // unknown_service:java, so a key-presence check could never fail.
+    String resourceServiceName =
+        calls.getResource().getResource().getAttributesList().stream()
+            .filter(kv -> kv.getKey().equals("service.name"))
+            .findFirst()
+            .map(kv -> kv.getValue().getStringValue())
+            .orElse(null);
+    assertThat(resourceServiceName).isEqualTo(getApplicationOtelServiceName());
+    // calls unit is the {call} UCUM annotation.
+    assertThat(calls.getMetric().getUnit()).isEqualTo("{call}");
   }
 
   @Test

--- a/cloudwatch-plugin-otel/contract-tests/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/e2e/family/FamilyTestBase.java
+++ b/cloudwatch-plugin-otel/contract-tests/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/e2e/family/FamilyTestBase.java
@@ -113,6 +113,20 @@ abstract class FamilyTestBase extends SpanMetricsContractTestBase {
   }
 
   /**
+   * Drives {@code path} then returns the calls metric with its resource/scope context, so tests can
+   * assert resource-level attributes (service.name lives on the resource, not the datapoint) and
+   * instrument metadata like the unit.
+   */
+  protected ResourceScopeMetric callsMetricFor(String path, String spanName) {
+    drive(path);
+    List<ResourceScopeMetric> metrics = awaitCalls(spanName);
+    return metrics.stream()
+        .filter(m -> m.getMetric().getName().equals(CALLS_METRIC))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no calls metric for " + spanName));
+  }
+
+  /**
    * Drives {@code path} then returns the string attributes of the first calls datapoint matching all
    * of the given {@code key=value} predicates. For families whose span name isn't fixed (gRPC,
    * Kafka), match on stable family attributes instead of the span name. Multiple predicates are

--- a/cloudwatch-plugin-otel/src/main/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsAttributesBuilder.java
+++ b/cloudwatch-plugin-otel/src/main/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsAttributesBuilder.java
@@ -23,14 +23,14 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Builds the metric attribute set for a span: four base dimensions, any allowlisted
- * semantic-convention attribute present on the span, and the identity/schema attributes. The
- * allowlist is the low-cardinality subset OTel semconv defines on the corresponding request
- * metrics. It is flat: copy any listed key that is present, regardless of span family.
+ * Builds the metric attribute set for a span: three base dimensions (span.name, span.kind,
+ * status.code), any allowlisted semantic-convention attribute present on the span, and the
+ * identity/schema attributes. The allowlist is the low-cardinality subset OTel semconv defines on
+ * the corresponding request metrics. It is flat: copy any listed key that is present, regardless of
+ * span family.
  */
 final class SpanMetricsAttributesBuilder {
 
-  static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
   static final AttributeKey<String> SPAN_NAME = AttributeKey.stringKey("span.name");
   static final AttributeKey<String> SPAN_KIND = AttributeKey.stringKey("span.kind");
   static final AttributeKey<String> STATUS_CODE = AttributeKey.stringKey("status.code");
@@ -89,12 +89,11 @@ final class SpanMetricsAttributesBuilder {
             .put(SpanMetricsProcessor.SCHEMA_ATTR, SpanMetricsProcessor.SCHEMA_VERSION)
             .put(SpanMetricsProcessor.LIB_VERSION_ATTR, SpanMetricsProcessor.LIB_VERSION);
 
-    // service.name: copied verbatim from the resource, no fallback (spec Q2 — the SDK already
-    // defaults it to unknown_service:<language>). Omitted only if genuinely absent.
-    String serviceName = span.getResource().getAttribute(SERVICE_NAME);
-    if (serviceName != null) {
-      builder.put(SERVICE_NAME, serviceName);
-    }
+    // service.name is deliberately NOT a datapoint attribute: the metrics are recorded into the
+    // host SDK's MeterProvider, whose resource already carries service.name, so duplicating it on
+    // every datapoint would add a redundant dimension. Consumers read it from the metric resource.
+    // (Intentional divergence from the collector spanmetrics connector, which flattens it into
+    // datapoint attributes because collector-side consumers may drop the resource.)
 
     Attributes spanAttributes = span.getAttributes();
     for (AttributeKey<?> key : ALLOWLIST) {

--- a/cloudwatch-plugin-otel/src/main/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsProcessor.java
+++ b/cloudwatch-plugin-otel/src/main/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsProcessor.java
@@ -161,7 +161,10 @@ public final class SpanMetricsProcessor implements SpanProcessor {
               .setUnit("s")
               .setExplicitBucketBoundariesAdvice(DURATION_BUCKETS_SECONDS)
               .build();
-      calls = meter.counterBuilder(CALLS_METRIC).build();
+      // {call} is the UCUM annotation for counted things, matching OTel semconv counter
+      // conventions (cf. {request}, {operation}). The collector spanmetrics connector leaves the
+      // unit unset; the annotation is preferred because it states what is being counted.
+      calls = meter.counterBuilder(CALLS_METRIC).setUnit("{call}").build();
     }
     return true;
   }

--- a/cloudwatch-plugin-otel/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsAttributesBuilderTest.java
+++ b/cloudwatch-plugin-otel/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsAttributesBuilderTest.java
@@ -56,28 +56,22 @@ class SpanMetricsAttributesBuilderTest {
             span(SpanKind.SERVER, Attributes.empty())
                 .setStatus(StatusData.create(StatusCode.ERROR, ""))
                 .build());
-    assertThat(attrs.get(AttributeKey.stringKey("service.name"))).isEqualTo("svc");
     assertThat(attrs.get(AttributeKey.stringKey("span.name"))).isEqualTo("op");
     assertThat(attrs.get(AttributeKey.stringKey("span.kind"))).isEqualTo("SERVER");
     assertThat(attrs.get(AttributeKey.stringKey("status.code"))).isEqualTo("ERROR");
   }
 
   @Test
-  void serviceNameCopiedVerbatimWhenPresent() {
-    // span(...) sets the resource service.name to "svc"; it must be copied as-is, no fallback text.
-    Attributes attrs =
+  void serviceNameNeverEmittedAsDatapointAttribute() {
+    // service.name lives on the metric's resource (the host MeterProvider's resource), so the
+    // datapoint must not duplicate it — even when the span's resource carries it.
+    Attributes withResource =
         SpanMetricsAttributesBuilder.build(span(SpanKind.SERVER, Attributes.empty()).build());
-    assertThat(attrs.get(AttributeKey.stringKey("service.name"))).isEqualTo("svc");
-  }
-
-  @Test
-  void serviceNameOmittedWhenAbsent() {
-    // No fallback: if the resource genuinely lacks service.name, the metric omits it entirely
-    // (the SDK guarantees a default in practice, so this is the defensive edge only).
-    Attributes attrs =
+    assertThat(withResource.get(AttributeKey.stringKey("service.name"))).isNull();
+    Attributes withoutResource =
         SpanMetricsAttributesBuilder.build(
             span(SpanKind.INTERNAL, Attributes.empty()).setResource(Resource.empty()).build());
-    assertThat(attrs.get(AttributeKey.stringKey("service.name"))).isNull();
+    assertThat(withoutResource.get(AttributeKey.stringKey("service.name"))).isNull();
   }
 
   @Test

--- a/cloudwatch-plugin-otel/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsProcessorTest.java
+++ b/cloudwatch-plugin-otel/src/test/java/software/amazon/opentelemetry/cloudwatch/spanmetrics/SpanMetricsProcessorTest.java
@@ -105,8 +105,8 @@ class SpanMetricsProcessorTest {
                       5.0, 10.0, 15.0);
             });
 
-    // calls is a monotonic Sum with no unit (connector parity).
-    assertThat(calls.getUnit()).isEmpty();
+    // calls is a monotonic Sum with the {call} UCUM annotation unit.
+    assertThat(calls.getUnit()).isEqualTo("{call}");
     assertThat(calls.getLongSumData().isMonotonic()).isTrue();
     assertThat(calls.getLongSumData().getPoints())
         .anySatisfy(


### PR DESCRIPTION
## Description

Two changes to the span-metrics schema emitted by the CloudWatch plugin:

1. **`service.name` is no longer a datapoint attribute.** The metrics are recorded into the host SDK's `MeterProvider`, whose resource already carries `service.name`, so duplicating it on every datapoint adds a redundant dimension with no extra information. Consumers read it from the metric resource. This intentionally diverges from the collector spanmetrics connector, which flattens `service.name` into datapoint attributes because collector-side consumers may drop the resource; here the resource is preserved end to end.

2. **`traces.span.metrics.calls` now uses the `{call}` unit** (UCUM annotation) instead of an unset unit, matching OTel semantic-convention counter conventions (cf. `{request}`, `{operation}`).

## Testing

- Unit tests updated: the attributes builder asserts `service.name` is never emitted as a datapoint attribute (with and without a span resource); the processor test asserts the `{call}` unit.
- Contract tests (testcontainers, all 4 wiring modes): `BaseAttributesFamilyTest` now asserts the metric **resource** carries the app's configured `service.name` **value** (key presence alone can never fail — the SDK defaults `service.name` unconditionally) and the `{call}` unit, end-to-end through the javaagent.
- Full module build + unit suite and the family contract suite pass locally.

CHANGELOG and README updated accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.