### PR TITLE
add concurrency block to suggested files by github admin team

### DIFF
--- a/.github/workflows/di-contract-tests.yml
+++ b/.github/workflows/di-contract-tests.yml
@@ -13,6 +13,12 @@ on:
       - "release/v*"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+
 jobs:
   di-contract-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -10,6 +10,13 @@ on:
     branches:
       - main
       - "release/v*"
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+
 env:
   TEST_TAG: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:test-v2
   USER: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/serviceevents-contract-tests.yml
+++ b/.github/workflows/serviceevents-contract-tests.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+  
 jobs:
   serviceevents-contract-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github admin team suggested adding this block to reduce jobs that get queued. Will help with reducing queue times on github actions.

These 3 files were specifically named.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
